### PR TITLE
DOCSP-9596 replace one

### DIFF
--- a/source/includes/usage-examples/code-snippets/Find.java
+++ b/source/includes/usage-examples/code-snippets/Find.java
@@ -14,32 +14,31 @@ import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
 
 public class Find {
-    public static void main( String[] args )
-    {
+    public static void main( String[] args ) {
+
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
 
-        MongoClient mongoClient = MongoClients.create(uri);
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-        MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-        MongoCollection<Document> collection = database.getCollection("movies");
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
 
-        Bson projectionFields = Projections.fields(
-                Projections.include("title", "imdb"),
-                Projections.excludeId());
+            Bson projectionFields = Projections.fields(
+                    Projections.include("title", "imdb"),
+                    Projections.excludeId());
 
-        MongoCursor<Document> cursor = collection.find(lt("runtime", 15))
-                .projection(projectionFields)
-                .sort(Sorts.descending("title")).iterator();
+            MongoCursor<Document> cursor = collection.find(lt("runtime", 15))
+                    .projection(projectionFields)
+                    .sort(Sorts.descending("title")).iterator();
 
-        try {
-            while(cursor.hasNext()) {
-                System.out.println(cursor.next().toJson());
+            try {
+                while(cursor.hasNext()) {
+                    System.out.println(cursor.next().toJson());
+                }
+            } finally {
+                cursor.close();
             }
-        } finally {
-            cursor.close();
         }
-
-        mongoClient.close();
     }
 }

--- a/source/includes/usage-examples/code-snippets/FindOne.java
+++ b/source/includes/usage-examples/code-snippets/FindOne.java
@@ -13,33 +13,32 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Sorts;
 
-public class FindOne
-{
-  public static void main( String[] args )
-  {
-    // Replace the uri string with your MongoDB deployment's connection string
-    String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
-    MongoClient mongoClient = MongoClients.create(uri);
+public class FindOne {
 
-    MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-    MongoCollection<Document> collection = database.getCollection("movies");
+    public static void main( String[] args ) {
 
-    Bson projectionFields = Projections.fields(
-        Projections.include("title", "imdb"),
-        Projections.excludeId());
+        // Replace the uri string with your MongoDB deployment's connection string
+        String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
 
-    Document doc = collection.find(eq("title", "The Room"))
-        .projection(projectionFields)
-        .sort(Sorts.descending("rating"))
-        .first();
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-    if (doc == null) {
-      System.out.println("No results found.");
-    } else {
-      System.out.println(doc.toJson());
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
+
+            Bson projectionFields = Projections.fields(
+                    Projections.include("title", "imdb"),
+                    Projections.excludeId());
+
+            Document doc = collection.find(eq("title", "The Room"))
+                    .projection(projectionFields)
+                    .sort(Sorts.descending("rating"))
+                    .first();
+
+            if (doc == null) {
+                System.out.println("No results found.");
+            } else {
+                System.out.println(doc.toJson());
+            }
+        }
     }
-
-    mongoClient.close();
-  }
 }
-

--- a/source/includes/usage-examples/code-snippets/InsertMany.java
+++ b/source/includes/usage-examples/code-snippets/InsertMany.java
@@ -18,22 +18,23 @@ public class InsertMany {
     public static void main(String[] args) {
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
-        MongoClient mongoClient = MongoClients.create(uri);
 
-        MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-        MongoCollection<Document> collection = database.getCollection("movies2");
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-        List<Document> movieList = Arrays.asList(
-                new Document().append("title", "Short Circuit 3"),
-                new Document().append("title", "The Lego Frozen Movie"));
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
 
-        try {
-            InsertManyResult result = collection.insertMany(movieList);
+            List<Document> movieList = Arrays.asList(
+                    new Document().append("title", "Short Circuit 3"),
+                    new Document().append("title", "The Lego Frozen Movie"));
 
-            System.out.println("Inserted document ids: " + result.getInsertedIds());
-        } catch (MongoException me) {
-            System.err.println("Unable to insert due to an error: " + me);
+            try {
+                InsertManyResult result = collection.insertMany(movieList);
+
+                System.out.println("Inserted document ids: " + result.getInsertedIds());
+            } catch (MongoException me) {
+                System.err.println("Unable to insert due to an error: " + me);
+            }
         }
-        mongoClient.close();
     }
 }

--- a/source/includes/usage-examples/code-snippets/InsertOne.java
+++ b/source/includes/usage-examples/code-snippets/InsertOne.java
@@ -30,11 +30,6 @@ public class InsertOne {
                         .append("genres", Arrays.asList("Documentary", "Comedy")));
 
                 System.out.println("Success! Inserted document id: " + result.getInsertedId());
-
-                // Retrieve the inserted document
-                //            Document insertedDoc = collection.find(eq("_id", result.getInsertedId())).first();
-                //            System.out.println("insertedDoc: " + insertedDoc);
-
             } catch (MongoException me) {
                 System.err.println("Unable to insert due to an error: " + me);
             }

--- a/source/includes/usage-examples/code-snippets/InsertOne.java
+++ b/source/includes/usage-examples/code-snippets/InsertOne.java
@@ -4,6 +4,7 @@ package usage.examples;
 import java.util.Arrays;
 
 import org.bson.Document;
+import org.bson.types.ObjectId;
 
 import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
@@ -16,21 +17,27 @@ public class InsertOne {
     public static void main(String[] args) {
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
-        MongoClient mongoClient = MongoClients.create(uri);
 
-        MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-        MongoCollection<Document> collection = database.getCollection("movies");
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-        try {
-            InsertOneResult result = collection.insertOne(new Document()
-                    .append("title", "Ski Bloopers")
-                    .append("genres", Arrays.asList("Documentary", "Comedy")));
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
 
-            System.out.println("Inserted document id: " + result.getInsertedId());
+            try {
+                InsertOneResult result = collection.insertOne(new Document()
+                        .append("_id", new ObjectId())
+                        .append("title", "Ski Bloopers")
+                        .append("genres", Arrays.asList("Documentary", "Comedy")));
 
-        } catch (MongoException me) {
-            System.err.println("Unable to insert due to an error: " + me);
+                System.out.println("Success! Inserted document id: " + result.getInsertedId());
+
+                // Retrieve the inserted document
+                //            Document insertedDoc = collection.find(eq("_id", result.getInsertedId())).first();
+                //            System.out.println("insertedDoc: " + insertedDoc);
+
+            } catch (MongoException me) {
+                System.err.println("Unable to insert due to an error: " + me);
+            }
         }
-        mongoClient.close();
     }
 }

--- a/source/includes/usage-examples/code-snippets/ReplaceOne.java
+++ b/source/includes/usage-examples/code-snippets/ReplaceOne.java
@@ -10,7 +10,6 @@ import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.result.UpdateResult;
@@ -21,12 +20,11 @@ public class ReplaceOne {
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
 
-        MongoClient mongoClient = MongoClients.create(uri);
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-        MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-        MongoCollection<Document> collection = database.getCollection("movies");
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
 
-        try {
             Bson query = eq("title", "Music of the Heart");
 
             Document replaceDocument = new Document().
@@ -38,10 +36,10 @@ public class ReplaceOne {
             UpdateResult result = collection.replaceOne(query, replaceDocument, opts);
 
             System.out.println("Modified document count: " + result.getModifiedCount());
+            System.out.println("Upserted id: " + result.getUpsertedId()); // only contains a value when an upsert is performed
 
         } catch (MongoException me) {
             System.err.println("Unable to replace due to an error: " + me);
         }
-        mongoClient.close();
     }
 }

--- a/source/includes/usage-examples/code-snippets/ReplaceOne.java
+++ b/source/includes/usage-examples/code-snippets/ReplaceOne.java
@@ -10,39 +10,38 @@ import com.mongodb.MongoException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.UpdateOptions;
-import com.mongodb.client.model.Updates;
+import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.result.UpdateResult;
 
-public class UpdateOne {
+public class ReplaceOne {
 
     public static void main(String[] args) {
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
+
         MongoClient mongoClient = MongoClients.create(uri);
 
         MongoDatabase database = mongoClient.getDatabase("sample_mflix");
         MongoCollection<Document> collection = database.getCollection("movies");
 
         try {
-            Bson query = eq("title", "Cool Runnings");
+            Bson query = eq("title", "Music of the Heart");
 
-            Bson updates = Updates.combine(
-                    Updates.set("runtime", 99),
-                    Updates.addToSet("genres", "Sports"),
-                    Updates.currentTimestamp("lastUpdated"));
+            Document replaceDocument = new Document().
+                    append("title", "50 Violins").
+                    append("fullplot", " A dramatization of the true story of Roberta Guaspari who co-founded the Opus 118 Harlem School of Music");
 
-            UpdateOptions options = new UpdateOptions().upsert(true);
+            ReplaceOptions opts = new ReplaceOptions().upsert(true);
 
-            UpdateResult result = collection.updateOne(query, updates, options);
+            UpdateResult result = collection.replaceOne(query, replaceDocument, opts);
 
             System.out.println("Modified document count: " + result.getModifiedCount());
 
         } catch (MongoException me) {
-            System.err.println("Unable to update due to an error: " + me);
+            System.err.println("Unable to replace due to an error: " + me);
         }
         mongoClient.close();
     }
 }
-

--- a/source/includes/usage-examples/code-snippets/UpdateOne.java
+++ b/source/includes/usage-examples/code-snippets/UpdateOne.java
@@ -1,8 +1,6 @@
 // ignored first line
 package usage.examples;
 
-import static com.mongodb.client.model.Filters.eq;
-
 import org.bson.Document;
 import org.bson.conversions.Bson;
 
@@ -20,13 +18,13 @@ public class UpdateOne {
     public static void main(String[] args) {
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
-        MongoClient mongoClient = MongoClients.create(uri);
 
-        MongoDatabase database = mongoClient.getDatabase("sample_mflix");
-        MongoCollection<Document> collection = database.getCollection("movies");
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-        try {
-            Bson query = eq("title", "Cool Runnings");
+            MongoDatabase database = mongoClient.getDatabase("sample_mflix");
+            MongoCollection<Document> collection = database.getCollection("movies");
+
+            Document query = new Document().append("title",  "Cool Runnings 2");
 
             Bson updates = Updates.combine(
                     Updates.set("runtime", 99),
@@ -35,14 +33,15 @@ public class UpdateOne {
 
             UpdateOptions options = new UpdateOptions().upsert(true);
 
-            UpdateResult result = collection.updateOne(query, updates, options);
+            try {
+                UpdateResult result = collection.updateOne(query, updates, options);
 
-            System.out.println("Modified document count: " + result.getModifiedCount());
+                System.out.println("Modified document count: " + result.getModifiedCount());
 
-        } catch (MongoException me) {
-            System.err.println("Unable to update due to an error: " + me);
+                System.out.println("Upserted id: " + result.getUpsertedId()); // only contains a value when an upsert is performed
+            } catch (MongoException me) {
+                System.err.println("Unable to update due to an error: " + me);
+            }
         }
-        mongoClient.close();
     }
 }
-

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -5,7 +5,7 @@ Find Multiple Documents
 .. default-domain:: mongodb
 
 You can query for multiple documents in a collection by calling the ``find()``
-method on a ``MongoCollection`` object. Pass a query(TODO: link to filter builder) filter to the
+method on a ``MongoCollection`` object. Pass a query filter to the
 ``find()`` method to query for and return documents that match the filter in
 the collection. If you do not include a filter, MongoDB returns all the
 documents in the collection.

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -10,10 +10,6 @@ object. To insert them, add your ``Document`` objects to a ``List`` and pass
 it to your call to ``insertMany()``. If you call the ``insertMany()`` method
 on a collection that does not exist yet, the server creates it for you.
 
-For more information on inserting data using MongoDB with the Java driver,
-see our guide (TODO: Fundamentals > CRUD Operations > Write Operations)
-on inserting documents.
-
 Upon successful insert, ``insertMany()`` returns an instance of
 ``InsertManyResult``. You can retrieve information such as the ``_id``
 fields of the documents you inserted by calling the ``getInsertedIds()``
@@ -35,7 +31,7 @@ collection.
 .. literalinclude:: /includes/usage-examples/code-snippets/InsertMany.java
    :language: java
 
-If you are using the **legacy API**, see (TODO: FAQ ?) to determine what
+If you are using the **legacy API**, see (TODO: link to FAQ) to determine what
 changes you need to make to this code example.
 
 When you run the example, you should see output that resembles the following

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -10,10 +10,6 @@ method on a ``MongoCollection`` object. To insert a document, construct a
 store. If you call the ``insertOne()`` method on a collection that does
 not exist yet, the server automatically creates it for you.
 
-For more information on inserting data using MongoDB with the Java driver,
-see our guide (TODO: Fundamentals > CRUD Operations > Write Operations)
-on inserting documents.
-
 Upon successful insert, ``insertOne()`` returns an instance of
 ``InsertOneResult``. You can retrieve information such as the ``_id``
 field of the document you inserted by calling the ``getInsertedId()``
@@ -35,7 +31,7 @@ collection.
 .. literalinclude:: /includes/usage-examples/code-snippets/InsertOne.java
    :language: java
 
-If you are using the **legacy API**, see (TODO: FAQ ?) to determine what
+If you are using the **legacy API**, see (TODO: link to FAQ) to determine what
 changes you need to make to this code example.
 
 When you run the example, you should see output that resembles the following

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -1,0 +1,108 @@
+==================
+Replace a Document
+==================
+
+.. default-domain:: mongodb
+
+You can replace a single document using the ``replaceOne()`` method on
+a ``MongoCollection`` object. This method removes all the existing fields
+and values from a document (except the ``_id`` field) and substitutes it
+with your replacement document.
+
+The ``replaceOne()`` method accepts a query filter that matches the
+document you want to replace and a replacement document that contains the
+data you want to save in place of the matched document. The ``replaceOne()``
+method only updates the first document that matches the filter.
+
+You can optionally pass an instance of ``ReplaceOptions`` to the method in
+order to specify the method behavior. For example, if you set the ``upsert``
+field of the ``ReplaceOptions`` object to ``true``, the operation inserts
+a new document from the fields in the replacement document if no documents
+match the query filter. See the link to the ``ReplaceOptions`` API
+documentation at the bottom of this page for more information.
+
+Upon successful execution, the ``replaceOne()`` method returns an instance
+of ``UpdateResult``.  You can retrieve information such as the number of
+documents modified calling the ``getModifiedCount()`` method. You can also
+retrieve the value of the document's ``_id`` field by calling the
+``getUpsertedId()`` method if you set ``upsert(true)`` in the
+``UpdateOptions`` instance and the operation resulted in an upsert.
+
+If your replacement operation fails, the driver raises an exception.
+For example, if you try to specify a value for the immutable field
+``_id`` in your replacement document that differs from the original
+document, the method throws a ``MongoWriteException`` with the message:
+
+.. code-block:: none
+
+   After applying the update, the (immutable) field '_id' was found to have been altered to _id: ObjectId('...)
+
+If your replacement document contains a change that violates unique index
+rules, the method throws a ``MongoWriteException`` with the error
+message that resembles the following:
+
+.. code-block:: none
+
+   E11000 duplicate key error collection: ...
+
+For more information on the types of exceptions raised under specific
+conditions, see the API documentation for ``replaceOne()``, linked at the
+bottom of this page.
+
+Example
+-------
+
+In this example, we replace the first match of our query filter in the
+``movies`` collection of the ``sample_mflix`` database with a replacement
+document. All the fields except for the ``_id`` field are deleted from the
+original document and are substituted by the replacement document.
+
+Before the ``replaceOne()`` operation runs, the original document contains
+several fields describing the movie. After the operation runs, the resulting
+document contains only the fields specified by the replacement document
+(``title`` and ``fullplot``) and the ``_id`` field.
+
+The following snippet uses the following objects and methods:
+
+- A **query filter** that is passed in the ``replaceOne()`` method. The ``eq``
+  filter matches only movies with the title exactly matching the text
+  ``'Music of the Heart'``.
+
+- A **replacement document** that contains the document that replaces the
+  matching document if it exists.
+
+- A **ReplaceOptions** object with the ``upsert`` option set to ``true``.
+
+.. include:: /includes/connect-guide-note.rst
+
+.. literalinclude:: /includes/usage-examples/code-snippets/ReplaceOne.java
+   :language: java
+
+If you are using the **legacy API**, see (TODO: FAQ ?) to determine what
+changes you need to make to this code example.
+
+After you run the example, you should see output that resembles the
+following:
+
+.. code-block:: none
+
+   Modified document count: 1
+
+If you query the replaced document, it should resemble the following:
+
+.. code-block:: none
+
+   Document {
+     { _id=...,
+       title=50 Violins,
+       fullplot=A dramatization of the true story of Roberta Guaspari who co-founded the Opus 118 Harlem School of Music
+     }
+   }
+
+For additional information on the classes and methods mentioned on this
+page, see the following API documentation:
+
+- :java-sync-api:`ReplaceOne <com/mongodb/client/MongoCollection.html#replaceOne(org.bson.conversions.Bson,TDocument)>`
+- :java-sync-api:`ReplaceOptions <com/mongodb/client/model/ReplaceOptions.html>`
+- :java-sync-api:`UpdateResult <com/mongodb/client/result/UpdateResult.html>`
+- :java-sync-api:`Filters.eq <com/mongodb/client/model/Filters.html#eq(TItem)>`

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -89,6 +89,14 @@ following:
 .. code-block:: none
 
    Modified document count: 1
+   Upserted id: null
+
+Or if the example resulted in an upsert:
+
+.. code-block:: none
+
+   Modified document count: 0
+   Upserted id: BsonObjectId{value=...}
 
 If you query the replaced document, it should resemble the following:
 

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -72,6 +72,8 @@ The following snippet uses the following objects and methods:
   matching document if it exists.
 
 - A **ReplaceOptions** object with the ``upsert`` option set to ``true``.
+  This option specifies that the method should insert the data contained in
+  the replacement document if the query filter does not match any documents.
 
 .. include:: /includes/connect-guide-note.rst
 

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -80,7 +80,7 @@ The following snippet uses the following objects and methods:
 .. literalinclude:: /includes/usage-examples/code-snippets/ReplaceOne.java
    :language: java
 
-If you are using the **legacy API**, see (TODO: FAQ ?) to determine what
+If you are using the **legacy API**, see (TODO: link to FAQ) to determine what
 changes you need to make to this code example.
 
 After you run the example, you should see output that resembles the

--- a/source/usage-examples/update-operations.txt
+++ b/source/usage-examples/update-operations.txt
@@ -10,4 +10,4 @@ Update & Replace Operations
    :caption: Examples
 
    /usage-examples/updateOne
-   /usage-examples/ReplaceOne
+   /usage-examples/replaceOne

--- a/source/usage-examples/update-operations.txt
+++ b/source/usage-examples/update-operations.txt
@@ -10,3 +10,4 @@ Update & Replace Operations
    :caption: Examples
 
    /usage-examples/updateOne
+   /usage-examples/ReplaceOne

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -49,10 +49,6 @@ For more information on the types of exceptions raised under specific
 conditions, see the API documentation for ``updateOne()``, linked at the
 bottom of this page.
 
-For more information on updating documents using the MongoDB Java driver,
-see our guide (TODO: Fundamentals > CRUD Operations > Write Operations)
-on updating documents.
-
 Example
 -------
 

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -85,6 +85,15 @@ following:
 .. code-block:: none
 
    Modified document count: 1
+   Upserted id: null
+
+Or if the example resulted in an upsert:
+
+.. code-block:: none
+
+   Modified document count: 0
+   Upserted id: BsonObjectId{value=...}
+
 
 If you query the updated document, it should resemble the following:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-9596

### Docs staging link (requires sign-in on MongoDB Corp SSO):
[replaceOne page](https://docs-mongodbcom-staging.corp.mongodb.com/e0d5956/java/docsworker-xlarge/DOCSP-9596-replace-one/usage-examples/replaceOne)

[updateOne update](https://docs-mongodbcom-staging.corp.mongodb.com/e0d5956/java/docsworker-xlarge/DOCSP-9596-replace-one/usage-examples/updateOne)

Note: the API links are currently broken as the 4.x docs appear to have been moved. Need to update the snooty toml once I confirm.