### PR TITLE
update versions, separate into files, and clarify dependency import process

### DIFF
--- a/source/includes/quick-start/gradle-versioned.rst
+++ b/source/includes/quick-start/gradle-versioned.rst
@@ -1,0 +1,6 @@
+.. code-block:: groovy
+
+   dependencies {
+     compile 'org.mongodb:mongodb-driver-sync:4.1.0'
+   }
+

--- a/source/includes/quick-start/maven-versioned.rst
+++ b/source/includes/quick-start/maven-versioned.rst
@@ -1,0 +1,10 @@
+.. code-block:: xml
+
+   <dependencies>
+       <dependency>
+           <groupId>org.mongodb</groupId>
+           <artifactId>mongodb-driver-sync</artifactId>
+           <version>4.1.0</version>
+       </dependency>
+   </dependencies>
+

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -30,27 +30,19 @@ Create the Project
 Add MongoDB as a Dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are using `Maven <https://maven.apache.org/>`__, add the following to 
+If you are using `Maven <https://maven.apache.org/>`__, add the following to
 your ``pom.xml`` dependencies list:
 
-.. code-block:: xml
-
-   <dependencies>
-       <dependency>
-           <groupId>org.mongodb</groupId>
-           <artifactId>mongodb-driver-sync</artifactId>
-           <version>4.0.1</version>
-       </dependency>
-   </dependencies>
+.. include:: /includes/quick-start/maven-versioned.rst
 
 If you are using `Gradle <https://gradle.org/>`__, add the following to your
 ``build.gradle`` dependencies list:
 
-.. code-block:: groovy
+.. include:: /includes/quick-start/gradle-versioned.rst
 
-   dependencies {
-     compile 'org.mongodb:mongodb-driver-sync:4.0.1'
-   }
+Once you configure your dependencies, make sure they are available to your
+project which involves running your dependency manager and/or refreshing
+the project in your IDE.
 
 .. note::
    You may need to configure the JDK version in your IDE and/or dependency


### PR DESCRIPTION
## Pull Request Info

Reason for change:
- separate versioned snippets using the -versioned file suffix
- clarify a step that was a point of confusion

### Issue JIRA link:
None

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/91db077/java/docsworker-xlarge/113020-clarify-dependencies/quick-start

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
_- [ ] Are the staging links in the PR description updated?_

