### PR TITLE
fix atlas link in quickstart

### DIFF
--- a/source/includes/quick-start/atlas-setup.rst
+++ b/source/includes/quick-start/atlas-setup.rst
@@ -3,7 +3,7 @@ Set up a Free Tier Cluster in Atlas
 
 After setting up your Java project dependencies, create a MongoDB cluster
 where you can store and manage your data. Complete the
-:atlas:`Get Started with Atlas <getting-started>` guide to set up a new
+:atlas:`Get Started with Atlas </getting-started>` guide to set up a new
 Atlas account, free tier MongoDB cluster, load datasets, and
 interact with the data.
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
None

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/0a7c3dc/java/docsworker-xlarge/113020-link-fix/quick-start

### Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Did you run a spell-check?
- [X] Did you run a grammar-check?
- [X] Does it render on staging correctly?
- [X] Are all the links working?
- [X] Are the staging links in the PR description updated?

