### PR TITLE
DOCSP-9558: Fundamentals > CRUD Operations > Read Operations > Limit the Number of Returned Results

### DIFF
--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -9,4 +9,4 @@ CRUD
    :titlesonly:
    :maxdepth: 1
 
- /fundamentals/crud/read
+   /fundamentals/crud/read

--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -10,3 +10,5 @@ CRUD
    :maxdepth: 1
 
    /fundamentals/crud/read
+   /fundamentals/crud/sort
+   

--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -10,5 +10,4 @@ CRUD
    :maxdepth: 1
 
    /fundamentals/crud/read
-   /fundamentals/crud/sort
    

--- a/source/fundamentals/crud.txt
+++ b/source/fundamentals/crud.txt
@@ -1,0 +1,12 @@
+
+====
+CRUD
+====
+
+.. default-domain:: mongodb
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+ /fundamentals/crud/read

--- a/source/fundamentals/crud/read.txt
+++ b/source/fundamentals/crud/read.txt
@@ -1,0 +1,11 @@
+====
+Read
+====
+
+.. default-domain:: mongodb
+
+.. toctree::
+   :titlesonly:
+   :maxdepth: 1
+
+/fundamentals/crud/read/limit

--- a/source/fundamentals/crud/read.txt
+++ b/source/fundamentals/crud/read.txt
@@ -8,4 +8,4 @@ Read
    :titlesonly:
    :maxdepth: 1
 
-   /fundamentals/crud/read/limit.txt
+   /fundamentals/crud/read/limit

--- a/source/fundamentals/crud/read.txt
+++ b/source/fundamentals/crud/read.txt
@@ -8,4 +8,4 @@ Read
    :titlesonly:
    :maxdepth: 1
 
-/fundamentals/crud/read/limit
+   /fundamentals/crud/read/limit.txt

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -110,6 +110,29 @@ longest books:
 You can combine ``skip()`` and ``limit()`` in this way to implement paging for your
 collection, returning only small subsets of the collection at one time.
 
+.. note::
+
+  In order to ensure stable sorts across multiple queries, you must sort
+  using a unique key (such as ``_id``). Otherwise, a call to ``skip()``
+  and ``limit()`` may produce unpredictable results when combined with
+  ``sort()``.
+
+  For example, consider the following data:
+
+  .. code_block:: java
+      
+      { type: "computer", data: "1", serial_no: 235235 }
+      { type: "computer", data: "2", serial_no: 235237 }
+      { type: "computer", data: "3", serial_no: 235239 }
+      { type: "computer", data: "4", serial_no: 235241 }
+
+  If you sorted by ``type`` alone, ``sort()`` does not guarantee the same order
+  upon return. Appending ``skip()`` and ``limit()`` to the ``sort()``
+  could return different documents for different queries. In this case, sorting
+  by ``data`` or ``serial_no`` would guarantee a stable sort, as both are unique keys.
+
+
+
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -14,7 +14,7 @@ the skip.
 
 The examples below demonstrate, respectively, how to insert data into
 a collection, how to use ``limit()`` to restrict the number of returned documents,
-and how to combine ``limit()`` with ``skip()`` to further narrow the results returned from that query. 
+and how to combine ``limit()`` with ``skip()`` to further narrow the results returned from a query. 
 
 The following operation inserts documents representing books into a collection:
 

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -89,23 +89,13 @@ To see the next three longest books, append the ``skip()`` method to your
 how many documents the find operation returns:
 
 .. code-block:: java
-  :emphasize-lines: 5, 6
-
-    import com.mongodb.client.model.Sorts;
+  :emphasize-lines: 3, 4
 
     MongoCursor<Document> cursor = collection.find()
         .sort(ascending("length"))
         .limit(3)
         .skip(3)
         .iterator();
-    try {
-        while(cursor.hasNext()) {
-            System.out.println(cursor.next());
-        }
-    } 
-    finally {
-        cursor.close();
-    }
 
 This operation returns the documents that describe the fourth through sixth
 longest books:

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -43,7 +43,7 @@ a ``sort`` on the ``length`` field to return books with longer lengths before
 books with shorter lengths, and applies a ``limit`` to return only ``3`` results:
 
 .. code-block:: java
-  :emphasize-lines: 5
+  :emphasize-lines: 6
 
     import com.mongodb.client.model.Sorts;
 
@@ -89,7 +89,6 @@ the number of documents to skip over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: java
-
   :emphasize-lines: 5
 
     import com.mongodb.client.model.Sorts;

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -5,9 +5,9 @@ Limit the Number of Returned Results
 .. default-domain:: mongodb
 
 Use ``limit`` to cap the number of documents that can be returned from a
-read operation. ``limit`` functions as a cap on the maximum number of
-documents that the operation can return, but the operation can return
-a smaller number of documents if there are not enough documents present
+read operation. The ``limit`` operation functions as a cap on the maximum number of
+documents that the operation can return, but it can return
+a smaller number of documents if there are not enough present
 to reach the limit. If ``limit`` is used with the
 :doc:`skip </fundamentals/crud/read-operations/skip>` method, the skip applies
 first and the limit only applies to the documents left over after
@@ -15,27 +15,34 @@ the skip.
 
 Follow the instructions in the examples below to insert data into
 a collection and return only certain results from a query using a sort,
-a skip, and a limit. Consider the following collection of documents that
-describe books:
+a skip, and a limit. Perform the following operation to insert these documents
+representing books into a collection:
 
-.. code-block:: javascript
+.. code-block:: java
 
-   [
-     { "_id": 1, "name": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 },
-     { "_id": 2, "name": "Les Misérables", "author": "Hugo", "length": 1462 },
-     { "_id": 3, "name": "Atlas Shrugged", "author": "Rand", "length": 1088 },
-     { "_id": 4, "name": "Infinite Jest", "author": "Wallace", "length": 1104 },
-     { "_id": 5, "name": "Cryptonomicon", "author": "Stephenson", "length": 918 },
-     { "_id": 6, "name": "A Dance With Dragons", "author": "Tolkein", "length": 1104 },
-   ]
+    collection.insertMany(Arrays.asList(
+        new Document().append("_id", 1)
+            .append("title", "The Brothers Karamazov").append("length", 824)
+            .append("author", "Dostoyevksy"),
+        new Document().append("_id", 2)
+            .append("title", "Les Misérables").append("length", 1462).append("author", "Hugo"),
+        new Document().append("_id", 3)
+            .append("title", "Atlas Shrugged").append("length", 1088).append("author", "Rand"),
+        new Document().append("_id", 4)
+            .append("title", "Infinite Jest").append("length", 1104).append("author", "Wallace"),
+        new Document().append("_id", 5)
+            .append("title", "Cryptonomicon").append("length", 918).append("author", "Stephenson"),
+        new Document().append("_id", 6)
+            .append("title", "A Dance with Dragons").append("length", 1104)
+            .append("author", "Martin")
+    ));
 
 The following example queries the collection to return the top three
 longest books. It matches all the documents with the query, applies
 a ``sort`` on the ``length`` field to return books with longer lengths before
 books, and applies a ``limit`` to return only ``3`` results:
 
-.. code-block:: javascript
-   :emphasize-lines: 4
+.. code-block:: java
 
     // define a cursor that will return the first 3 sorted items
     MongoCursor<Document> cursor = collection.find()
@@ -74,45 +81,23 @@ length:
       collection.find().sort(descending("title")).limit(3);
       collection.find().limit(3).sort(descending("title"));
 
-//TODO: figure out find options in Java
-FindOptions findOptions = new FindOptions();
-findOptions.limit(3);
-findOptions.sort(descending("title"));
-
-collection.find(findOptions);
-
-
-You can also apply ``sort`` and ``limit`` by specifying them in an
-``FindOptions`` object in your call to the ``find()`` method. The following two
-calls are equivalent:
-
-.. code-block:: javascript
-
-   collection.find(query).sort({ length: -1 }).limit(3);
-   collection.find(query, { sort: { length: -1 }, limit: 3 });
-
-For more information on the ``options`` settings for the ``find()``
-method, see the
-:node-api:`API documentation on find() <Collection.html#find>`.
 
 To see the next three longest books, append the ``skip()`` method, passing
 the number of documents to skim over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: java
-   :emphasize-lines: 4
 
     MongoCursor<Document> cursor = collection.find()
-    .sort(Sorts.ascending("length"))
-    .limit(3)
-    .skip(3)
-    .iterator();
+      .sort(Sorts.ascending("length")).limit(3).skip(3).iterator();
 
     try {
       while(cursor.hasNext()) {
         System.out.println(cursor.next().toJson());
       }
-    } finally {
+    } 
+    
+    finally {
       cursor.close();
     }
 
@@ -125,5 +110,11 @@ longest books:
    { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }
    { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }
 
-You can combine skip and limit in this way to implement paging for your
+.. note::
+
+   These results are in JSON format due to the ``toJson()`` method used in the example above.
+   Without ``toJson()``, they are returned in a Java string format, 
+   like this: ``Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}``.
+
+You can combine ``skip`` and ``limit`` in this way to implement paging for your
 collection, returning only small "slices" of the collection at once.

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -12,9 +12,10 @@ If you use ``limit()`` with the ``skip()`` (TODO: link) instance method, the ski
 first and the limit only applies to the documents left over after
 the skip.
 
-The examples below demonstrate how to insert data into
-a collection, sort the results of a query on that collection,
-and use ``skip()`` and ``limit()`` to narrow the results returned from that query. 
+The examples below demonstrate, respectively, how to insert data into
+a collection, how to use ``limit()`` to restrict the number of returned documents,
+and how to combine ``limit()`` with ``skip()`` to further narrow the results returned from that query. 
+
 The following operation inserts documents representing books into a collection:
 
 .. code-block:: java

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -75,6 +75,13 @@ length:
       collection.find().limit(3).sort(descending("title"));
 
 //TODO: figure out find options in Java
+FindOptions findOptions = new FindOptions();
+findOptions.limit(3);
+findOptions.sort(descending("title"));
+
+collection.find(findOptions);
+
+
 You can also apply ``sort`` and ``limit`` by specifying them in an
 ``FindOptions`` object in your call to the ``find()`` method. The following two
 calls are equivalent:

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -89,7 +89,7 @@ the number of documents to skip over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: java
-  :emphasize-lines: 5
+  :emphasize-lines: 5, 6
 
     import com.mongodb.client.model.Sorts;
 

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -5,17 +5,17 @@ Limit the Number of Returned Results
 .. default-domain:: mongodb
 
 Use ``limit()`` to cap the number of documents that a read operation returns. 
-The ``limit()`` instance method designates the maximum number of
-documents that the read operation can return. If there are not enough documents 
+This instance method designates the maximum number of
+documents that a read operation can return. If there are not enough documents
 to reach the specified limit, it can return a smaller number. 
 If you use ``limit()`` with the ``skip()`` (TODO: link) instance method, the skip applies
 first and the limit only applies to the documents left over after
 the skip.
 
 The examples below demonstrate how to insert data into
-a collection and return only certain results from a query using a sort,
-a skip, and a limit. The following operation inserts documents
-representing books into a collection:
+a collection, sort the results of a query on that collection,
+and use ``skip()`` and ``limit()`` to narrow the results returned from that query. 
+The following operation inserts documents representing books into a collection:
 
 .. code-block:: java
 
@@ -117,7 +117,7 @@ longest books:
     Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
 
 You can combine ``skip()`` and ``limit()`` in this way to implement paging for your
-collection, returning only small subsets (otherwise known as "slices") of the collection at one time.
+collection, returning only small subsets of the collection at one time.
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -9,7 +9,7 @@ read operation. The ``limit`` operation functions as a cap on the maximum number
 documents that the operation can return, but it can return
 a smaller number of documents if there are not enough present
 to reach the limit. If ``limit`` is used with the
-:doc:`skip </fundamentals/crud/read-operations/skip>` method, the skip applies
+``skip`` (TODO: link) method, the skip applies
 first and the limit only applies to the documents left over after
 the skip.
 
@@ -40,7 +40,7 @@ representing books into a collection:
 The following example queries the collection to return the top three
 longest books. It matches all the documents with the query, applies
 a ``sort`` on the ``length`` field to return books with longer lengths before
-books, and applies a ``limit`` to return only ``3`` results:
+books with shorter lengths, and applies a ``limit`` to return only ``3`` results:
 
 .. code-block:: java
 
@@ -49,7 +49,6 @@ books, and applies a ``limit`` to return only ``3`` results:
         .sort(Sorts.descending("length"))
         .limit(3)
         .iterator();
-
     // print out items
     try {
       while (cursor.hasNext()) {
@@ -78,25 +77,23 @@ length:
 
    .. code-block:: java
 
-      collection.find().sort(descending("title")).limit(3);
-      collection.find().limit(3).sort(descending("title"));
+      collection.find().sort(descending("length")).limit(3);
+      collection.find().limit(3).sort(descending("length"));
 
 
 To see the next three longest books, append the ``skip()`` method, passing
-the number of documents to skim over to the previous code snippet's call to
+the number of documents to skip over to the previous code snippet's call to
 ``find()``:
 
 .. code-block:: java
 
     MongoCursor<Document> cursor = collection.find()
       .sort(Sorts.ascending("length")).limit(3).skip(3).iterator();
-
     try {
       while(cursor.hasNext()) {
         System.out.println(cursor.next().toJson());
       }
     } 
-    
     finally {
       cursor.close();
     }

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -1,0 +1,122 @@
+====================================
+Limit the Number of Returned Results
+====================================
+
+.. default-domain:: mongodb
+
+Use ``limit`` to cap the number of documents that can be returned from a
+read operation. ``limit`` functions as a cap on the maximum number of
+documents that the operation can return, but the operation can return
+a smaller number of documents if there are not enough documents present
+to reach the limit. If ``limit`` is used with the
+:doc:`skip </fundamentals/crud/read-operations/skip>` method, the skip applies
+first and the limit only applies to the documents left over after
+the skip.
+
+Follow the instructions in the examples below to insert data into
+a collection and return only certain results from a query using a sort,
+a skip, and a limit. Consider the following collection of documents that
+describe books:
+
+.. code-block:: javascript
+
+   [
+     { "_id": 1, "name": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 },
+     { "_id": 2, "name": "Les Misérables", "author": "Hugo", "length": 1462 },
+     { "_id": 3, "name": "Atlas Shrugged", "author": "Rand", "length": 1088 },
+     { "_id": 4, "name": "Infinite Jest", "author": "Wallace", "length": 1104 },
+     { "_id": 5, "name": "Cryptonomicon", "author": "Stephenson", "length": 918 },
+     { "_id": 6, "name": "A Dance With Dragons", "author": "Tolkein", "length": 1104 },
+   ]
+
+The following example queries the collection to return the top three
+longest books. It matches all the documents with the query, applies
+a ``sort`` on the ``length`` field to return books with longer lengths before
+books, and applies a ``limit`` to return only ``3`` results:
+
+.. code-block:: javascript
+   :emphasize-lines: 4
+
+    // define a cursor that will return the first 3 sorted items
+    MongoCursor<Document> cursor = collection.find()
+        .sort(Sorts.descending("length"))
+        .limit(3)
+        .iterator();
+
+    // print out items
+    try {
+      while (cursor.hasNext()) {
+        System.out.println(cursor.next().toJson());
+      }
+    // close the cursor
+    } finally {
+      cursor.close();
+    }
+
+
+The code example above outputs the following three documents, sorted by
+length:
+
+.. code-block:: javascript
+
+   { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
+   { "_id": 6, "title": "A Dance With Dragons", "author": "Martin", "length": 1104 }
+   { "_id": 4, "title": "Infinite Jest", "author": "Wallace", "length": 1104 }
+
+.. note::
+
+   The order in which you call ``limit`` and ``sort`` does not matter
+   because the driver reorders the calls to apply the sort first and the
+   limit after it. The following two calls are equivalent:
+
+   .. code-block:: java
+
+      collection.find().sort(descending("title")).limit(3);
+      collection.find().limit(3).sort(descending("title"));
+
+//TODO: figure out find options in Java
+You can also apply ``sort`` and ``limit`` by specifying them in an
+``FindOptions`` object in your call to the ``find()`` method. The following two
+calls are equivalent:
+
+.. code-block:: javascript
+
+   collection.find(query).sort({ length: -1 }).limit(3);
+   collection.find(query, { sort: { length: -1 }, limit: 3 });
+
+For more information on the ``options`` settings for the ``find()``
+method, see the
+:node-api:`API documentation on find() <Collection.html#find>`.
+
+To see the next three longest books, append the ``skip()`` method, passing
+the number of documents to skim over to the previous code snippet's call to
+``find()``:
+
+.. code-block:: java
+   :emphasize-lines: 4
+
+    MongoCursor<Document> cursor = collection.find()
+    .sort(Sorts.ascending("length"))
+    .limit(3)
+    .skip(3)
+    .iterator();
+
+    try {
+      while(cursor.hasNext()) {
+        System.out.println(cursor.next().toJson());
+      }
+    } finally {
+      cursor.close();
+    }
+
+This operation returns the documents that describe the fourth through sixth
+longest books:
+
+.. code-block:: javascript
+
+   { "_id": 3, "title": "Atlas Shrugged", "author": "Rand", "length": 1088 }
+   { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }
+   { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }
+
+You can combine skip and limit in this way to implement paging for your
+collection, returning only small "slices" of the collection at once.

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -46,7 +46,7 @@ books with shorter lengths, and applies a ``limit`` to return only ``3`` results
 
     // define a cursor that will return the first 3 sorted items
     MongoCursor<Document> cursor = collection.find()
-        .sort(Sorts.descending("length"))
+        .sort(descending("length"))
         .limit(3)
         .iterator();
     // print out items
@@ -88,7 +88,7 @@ the number of documents to skip over to the previous code snippet's call to
 .. code-block:: java
 
     MongoCursor<Document> cursor = collection.find()
-      .sort(Sorts.ascending("length")).limit(3).skip(3).iterator();
+      .sort(ascending("length")).limit(3).skip(3).iterator();
     try {
       while(cursor.hasNext()) {
         System.out.println(cursor.next().toJson());

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -43,7 +43,7 @@ a ``sort`` on the ``length`` field to return books with longer lengths before
 books with shorter lengths, and applies a ``limit`` to return only ``3`` results:
 
 .. code-block:: java
-  :emphasize-lines: 4
+  :emphasize-lines: 5
 
     import com.mongodb.client.model.Sorts;
 
@@ -90,10 +90,15 @@ the number of documents to skip over to the previous code snippet's call to
 
 .. code-block:: java
 
+  :emphasize-lines: 5
+
     import com.mongodb.client.model.Sorts;
 
     MongoCursor<Document> cursor = collection.find()
-      .sort(ascending("length")).limit(3).skip(3).iterator();
+      .sort(ascending("length"))
+      .limit(3)
+      .skip(3)
+      .iterator();
     try {
       while(cursor.hasNext()) {
         System.out.println(cursor.next());

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -4,18 +4,17 @@ Limit the Number of Returned Results
 
 .. default-domain:: mongodb
 
-Use ``limit`` to cap the number of documents that can be returned from a
-read operation. The ``limit`` operation functions as a cap on the maximum number of
-documents that the operation can return, but it can return
-a smaller number of documents if there are not enough present
-to reach the limit. If ``limit`` is used with the
-``skip`` (TODO: link) method, the skip applies
+Use ``limit()`` to cap the number of documents that a read operation returns. 
+The ``limit()`` instance method designates the maximum number of
+documents that the read operation can return. If there are not enough documents 
+to reach the specified limit, it can return a smaller number. 
+If you use ``limit()`` with the ``skip()`` (TODO: link) instance method, the skip applies
 first and the limit only applies to the documents left over after
 the skip.
 
-Follow the instructions in the examples below to insert data into
+The examples below demonstrate how to insert data into
 a collection and return only certain results from a query using a sort,
-a skip, and a limit. Perform the following operation to insert these documents
+a skip, and a limit. The following operation inserts documents
 representing books into a collection:
 
 .. code-block:: java
@@ -23,7 +22,7 @@ representing books into a collection:
     collection.insertMany(Arrays.asList(
         new Document().append("_id", 1)
             .append("title", "The Brothers Karamazov").append("length", 824)
-            .append("author", "Dostoyevksy"),
+            .append("author", "Dostoyevsky"),
         new Document().append("_id", 2)
             .append("title", "Les Misérables").append("length", 1462).append("author", "Hugo"),
         new Document().append("_id", 3)
@@ -37,10 +36,10 @@ representing books into a collection:
             .append("author", "Martin")
     ));
 
-The following example queries the collection to return the top three
-longest books. It matches all the documents with the query, applies
-a ``sort`` on the ``length`` field to return books with longer lengths before
-books with shorter lengths, and applies a ``limit`` to return only ``3`` results:
+The next example queries the collection to return the top three
+longest books. It first matches all the documents with the query, then sorts on the
+``length`` field to return books with longer lengths before
+books with shorter lengths. Lastly, it limits the return value to ``3`` documents:
 
 .. code-block:: java
   :emphasize-lines: 6
@@ -54,12 +53,13 @@ books with shorter lengths, and applies a ``limit`` to return only ``3`` results
         .iterator();
     // print out items
     try {
-      while (cursor.hasNext()) {
-        System.out.println(cursor.next());
-      }
+        while (cursor.hasNext()) {
+            System.out.println(cursor.next());
+        }
+    } 
     // close the cursor
-    } finally {
-      cursor.close();
+    finally {
+        cursor.close();
     }
 
 
@@ -68,13 +68,13 @@ length:
 
 .. code-block:: java
 
-   Document{{_id=2, title=Les Misérables, author=Hugo, length=1462}}
-   Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}
-   Document{{_id=4, title=Infinite Jest, author=Wallace, length=1104}}
+    Document{{_id=2, title=Les Misérables, author=Hugo, length=1462}}
+    Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}
+    Document{{_id=4, title=Infinite Jest, author=Wallace, length=1104}}
 
 .. note::
 
-   The order in which you call ``limit`` and ``sort`` does not matter
+   The order in which you call ``limit()`` and ``sort()`` does not matter
    because the driver reorders the calls to apply the sort first and the
    limit after it. The following two calls are equivalent:
 
@@ -84,9 +84,9 @@ length:
       collection.find().limit(3).sort(descending("length"));
 
 
-To see the next three longest books, append the ``skip()`` method, passing
-the number of documents to skip over to the previous code snippet's call to
-``find()``:
+To see the next three longest books, append the ``skip()`` method to your 
+``find()`` call. The integer argument passed to ``skip()`` will determine
+how many documents the find operation returns:
 
 .. code-block:: java
   :emphasize-lines: 5, 6
@@ -94,27 +94,35 @@ the number of documents to skip over to the previous code snippet's call to
     import com.mongodb.client.model.Sorts;
 
     MongoCursor<Document> cursor = collection.find()
-      .sort(ascending("length"))
-      .limit(3)
-      .skip(3)
-      .iterator();
+        .sort(ascending("length"))
+        .limit(3)
+        .skip(3)
+        .iterator();
     try {
-      while(cursor.hasNext()) {
-        System.out.println(cursor.next());
-      }
+        while(cursor.hasNext()) {
+            System.out.println(cursor.next());
+        }
     } 
     finally {
-      cursor.close();
+        cursor.close();
     }
 
 This operation returns the documents that describe the fourth through sixth
 longest books:
 
-.. code-block:: javascript
+.. code-block:: java
 
-   Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
-   Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
-   Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
+    Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
+    Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
+    Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
 
-You can combine ``skip`` and ``limit`` in this way to implement paging for your
-collection, returning only small "slices" of the collection at once.
+You can combine ``skip()`` and ``limit()`` in this way to implement paging for your
+collection, returning only small subsets (otherwise known as "slices") of the collection at one time.
+
+For additional information on the classes and methods mentioned on this
+page, see the following API documentation:
+
+- :java-sync-api:`FindIterable <com/mongodb/client/FindIterable.html>`
+- :java-sync-api:`MongoIterable <com/mongodb/client/MongoIterable.html>`
+- :java-sync-api:`MongoCursor <com/mongodb/client/MongoCursor.html>`
+- :java-sync-api:`find() <com/mongodb/client/MongoCollection.html#find()>`

--- a/source/fundamentals/crud/read/limit.txt
+++ b/source/fundamentals/crud/read/limit.txt
@@ -43,6 +43,9 @@ a ``sort`` on the ``length`` field to return books with longer lengths before
 books with shorter lengths, and applies a ``limit`` to return only ``3`` results:
 
 .. code-block:: java
+  :emphasize-lines: 4
+
+    import com.mongodb.client.model.Sorts;
 
     // define a cursor that will return the first 3 sorted items
     MongoCursor<Document> cursor = collection.find()
@@ -52,7 +55,7 @@ books with shorter lengths, and applies a ``limit`` to return only ``3`` results
     // print out items
     try {
       while (cursor.hasNext()) {
-        System.out.println(cursor.next().toJson());
+        System.out.println(cursor.next());
       }
     // close the cursor
     } finally {
@@ -60,14 +63,14 @@ books with shorter lengths, and applies a ``limit`` to return only ``3`` results
     }
 
 
-The code example above outputs the following three documents, sorted by
+The code example above prints out the following three documents, sorted by
 length:
 
-.. code-block:: javascript
+.. code-block:: java
 
-   { "_id": 2, "title": "Les Misérables", "author": "Hugo", "length": 1462 }
-   { "_id": 6, "title": "A Dance With Dragons", "author": "Martin", "length": 1104 }
-   { "_id": 4, "title": "Infinite Jest", "author": "Wallace", "length": 1104 }
+   Document{{_id=2, title=Les Misérables, author=Hugo, length=1462}}
+   Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}
+   Document{{_id=4, title=Infinite Jest, author=Wallace, length=1104}}
 
 .. note::
 
@@ -87,11 +90,13 @@ the number of documents to skip over to the previous code snippet's call to
 
 .. code-block:: java
 
+    import com.mongodb.client.model.Sorts;
+
     MongoCursor<Document> cursor = collection.find()
       .sort(ascending("length")).limit(3).skip(3).iterator();
     try {
       while(cursor.hasNext()) {
-        System.out.println(cursor.next().toJson());
+        System.out.println(cursor.next());
       }
     } 
     finally {
@@ -103,15 +108,9 @@ longest books:
 
 .. code-block:: javascript
 
-   { "_id": 3, "title": "Atlas Shrugged", "author": "Rand", "length": 1088 }
-   { "_id": 5, "title": "Cryptonomicon", "author": "Stephenson", "length": 918 }
-   { "_id": 1, "title": "The Brothers Karamazov", "author": "Dostoyevsky", "length": 824 }
-
-.. note::
-
-   These results are in JSON format due to the ``toJson()`` method used in the example above.
-   Without ``toJson()``, they are returned in a Java string format, 
-   like this: ``Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}``.
+   Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
+   Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
+   Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
 
 You can combine ``skip`` and ``limit`` in this way to implement paging for your
 collection, returning only small "slices" of the collection at once.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-9558

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/d2fdb0a/java/docsworker-xlarge/DOCSP-9558/fundamentals/crud/read/limit

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

