### PR TITLE
DOCSP-13803 Kerberos ticket caching

### DIFF
--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -63,9 +63,10 @@ mechanism:
 .. note::
    The Java driver will by default cache 
    `Kerberos Tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
-   by ``MongoClient`` instance. TODO: NEED EXACT USE CASE WHERE PROCESS KERBEROS TICKET CACHE IS HELPFUL.
-   If you would like to instead cache Kerberos Tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
-   mechanism property in the ``MongoCredential`` class.
+   by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
+   ``MongoClient`` instances, you can change the default Kerberos Ticket caching behavior
+   to cache by process. To cache Kerberos Tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
+   mechanism property in the ``MongoCredential``class.
 
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -161,7 +161,7 @@ You may need to specify one or more of the following additional
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
 
 
-By default, the Java Driver caches Kerberos tickets by ``MongoClient`` instance.
+By default, the Java driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
 you can change the default Kerberos ticket caching behavior to cache by process
 to improve performance.

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -163,8 +163,8 @@ You may need to specify one or more of the following additional
 
 By default, the Java Driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
-you can change the default Kerberos ticket caching behavior of the Java Driver
-to cache by process.
+you can change the default Kerberos ticket caching behavior to cache by process
+to improve performance.
 
 .. tabs::
    :hidden:

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -116,6 +116,7 @@ You may need to specify one or more of the following additional
 - ``CANONICALIZE_HOST_NAME``
 - ``JAVA_SUBJECT``
 - ``JAVA_SASL_CLIENT_PROPERTIES``
+- ``JAVA_SUBJECT_PROVIDER``
 
 .. tabs::
    :hidden:
@@ -130,6 +131,7 @@ You may need to specify one or more of the following additional
 
          - ``JAVA_SUBJECT``
          - ``JAVA_SASL_CLIENT_PROPERTIES``
+         - ``JAVA_SUBJECT_PROVIDER``
 
          Select the :guilabel:`MongoCredential` tab to see how to specify
          them.

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -60,17 +60,6 @@ Select the :guilabel:`Connection String` or the :guilabel:`MongoCredential`
 tab below for instructions and sample code for specifying this authentication
 mechanism:
 
-.. note::
-   The Java Driver will by default cache 
-   `Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
-   by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
-   ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior of the Java Driver
-   to cache by process. To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
-   mechanism property and provide a 
-   `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
-   in your ``MongoCredential`` instance.
-
-
 .. tabs::
 
    .. tab::
@@ -169,6 +158,32 @@ You may need to specify one or more of the following additional
       properties might resemble the following:
 
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
+
+
+The Java Driver will by default cache 
+`Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
+by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
+``MongoClient`` instances, you can change the default Kerberos ticket caching behavior of the Java Driver
+to cache by process.
+
+.. tabs::
+   :hidden:
+
+   .. tab::
+      :tabid: Connection String
+
+      To cache Kerberos tickets by process, you must use the ``MongoCredential`` authentication
+      mechanism, as the connection string authentication mechanism does not support the ``JAVA_SUBJECT_PROVIDER``
+      mechanism property. If you would like to cache Kerberos tickets by process, select the :guilabel:`MongoCredential`
+      tab to see how to accomplish this.
+
+   .. tab::
+      :tabid: MongoCredential
+
+      To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
+      mechanism property and provide a 
+      `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
+      in your ``MongoCredential`` instance.
 
 .. note::
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -94,7 +94,7 @@ mechanism:
 
 
 In order to acquire a 
-`Kerberos ticket <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__,
+`Kerberos ticket <https://docs.oracle.com/en/java/javase/11/docs/api/java.security.jgss/javax/security/auth/kerberos/KerberosTicket.html>`__,
 the GSSAPI Java libraries require you to specify the realm and Key Distribution 
 Center (KDC) system properties. See the sample settings in the example below:
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -159,6 +159,7 @@ You may need to specify one or more of the following additional
       - :java-docs:`SERVICE_NAME_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#SERVICE_NAME_KEY>`
       - :java-docs:`CANONICALIZE_HOST_NAME_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#CANONICALIZE_HOST_NAME_KEY>`
       - :java-docs:`JAVA_SUBJECT_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_KEY>`
+      - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
 
       Your code to instantiate a ``MongoClient`` using GSSAPI and additional

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -62,9 +62,9 @@ mechanism:
 
 .. note::
    The Java driver will by default cache 
-   `Kerberos Ticket <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__ per
-   ``MongoClient`` instance. TODO: NEED EXACT USE CASE WHERE PROCESS TGT CACHE IS HELPFUL.
-   If you would like to instead cache TGTs by process, specify the ``JAVA_SUBJECT_PROVIDER``
+   `Kerberos Tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
+   by ``MongoClient`` instance. TODO: NEED EXACT USE CASE WHERE PROCESS KERBEROS TICKET CACHE IS HELPFUL.
+   If you would like to instead cache Kerberos Tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
    mechanism property in the ``MongoCredential`` class.
 
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -183,7 +183,11 @@ to cache by process.
       To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
       mechanism property and provide a 
       `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
-      in your ``MongoCredential`` instance.
+      in your ``MongoCredential`` instance. The code to configure the Java driver to cache Kerberos tickets
+      by process should resemble the following:
+
+      .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+
 
 .. note::
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -61,7 +61,8 @@ tab below for instructions and sample code for specifying this authentication
 mechanism:
 
 .. note::
-   The Java driver will by default cache Kerberos Ticket-Granting Tickets (TGTs) per
+   The Java driver will by default cache 
+   `Kerberos Ticket <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__ per
    ``MongoClient`` instance. TODO: NEED EXACT USE CASE WHERE PROCESS TGT CACHE IS HELPFUL.
    If you would like to instead cache TGTs by process, specify the ``JAVA_SUBJECT_PROVIDER``
    mechanism property in the ``MongoCredential`` class.

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -62,11 +62,11 @@ mechanism:
 
 .. note::
    The Java driver will by default cache 
-   `Kerberos Tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
+   `Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
    by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
-   ``MongoClient`` instances, you can change the default Kerberos Ticket caching behavior
-   to cache by process. To cache Kerberos Tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
-   mechanism property in the ``MongoCredential``class.
+   ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior
+   to cache by process. To cache Kerberos tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
+   mechanism property in the ``MongoCredential`` class.
 
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -161,7 +161,7 @@ You may need to specify one or more of the following additional
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
 
 
-The Java Driver will by default cache Kerberos tickets by ``MongoClient`` instance.
+By default, the Java Driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
 you can change the default Kerberos ticket caching behavior of the Java Driver
 to cache by process.

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -175,7 +175,7 @@ to cache by process.
       To cache Kerberos tickets by process, you must use the ``MongoCredential`` authentication
       mechanism, as the connection string authentication mechanism does not support the ``JAVA_SUBJECT_PROVIDER``
       mechanism property. If you would like to cache Kerberos tickets by process, select the :guilabel:`MongoCredential`
-      tab to see how to accomplish this.
+      tab to learn how to accomplish this.
 
    .. tab::
       :tabid: MongoCredential

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -159,8 +159,8 @@ You may need to specify one or more of the following additional
       - :java-docs:`SERVICE_NAME_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#SERVICE_NAME_KEY>`
       - :java-docs:`CANONICALIZE_HOST_NAME_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#CANONICALIZE_HOST_NAME_KEY>`
       - :java-docs:`JAVA_SUBJECT_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_KEY>`
-      - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
+      - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
       Your code to instantiate a ``MongoClient`` using GSSAPI and additional
       properties might resemble the following:

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -65,8 +65,9 @@ mechanism:
    `Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
    by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
    ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior
-   to cache by process. To cache Kerberos tickets by process, specify the ``JAVA_SUBJECT_PROVIDER``
-   mechanism property in the ``MongoCredential`` class.
+   to cache by process. To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
+   mechanism property in the ``MongoCredential`` and a 
+   ```KerberosSubjectProvider <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__``.
 
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -61,13 +61,14 @@ tab below for instructions and sample code for specifying this authentication
 mechanism:
 
 .. note::
-   The Java driver will by default cache 
+   The Java Driver will by default cache 
    `Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
    by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
-   ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior
+   ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior of the Java Driver
    to cache by process. To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
-   mechanism property in the ``MongoCredential`` and a 
-   `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__.
+   mechanism property and provide a 
+   `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
+   in your ``MongoCredential`` instance.
 
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -67,7 +67,7 @@ mechanism:
    ``MongoClient`` instances, you can change the default Kerberos ticket caching behavior
    to cache by process. To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
    mechanism property in the ``MongoCredential`` and a 
-   ```KerberosSubjectProvider <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__``.
+   `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__.
 
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -93,9 +93,10 @@ mechanism:
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi.rst
 
 
-In order to acquire a Kerberos ticket, the GSSAPI Java libraries require
-you to specify the realm and Key Distribution Center (KDC) system
-properties. See the sample settings in the example below:
+In order to acquire a 
+`Kerberos ticket <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__,
+the GSSAPI Java libraries require you to specify the realm and Key Distribution 
+Center (KDC) system properties. See the sample settings in the example below:
 
 .. code-block:: none
 
@@ -160,10 +161,9 @@ You may need to specify one or more of the following additional
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
 
 
-The Java Driver will by default cache 
-`Kerberos tickets <https://docs.oracle.com/javase/7/docs/api/javax/security/auth/kerberos/KerberosTicket.html>`__
-by ``MongoClient`` instance. If your deployment needs to frequently create and destroy
-``MongoClient`` instances, you can change the default Kerberos ticket caching behavior of the Java Driver
+The Java Driver will by default cache Kerberos tickets by ``MongoClient`` instance.
+If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
+you can change the default Kerberos ticket caching behavior of the Java Driver
 to cache by process.
 
 .. tabs::

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -60,6 +60,13 @@ Select the :guilabel:`Connection String` or the :guilabel:`MongoCredential`
 tab below for instructions and sample code for specifying this authentication
 mechanism:
 
+.. note::
+   The Java driver will by default cache Kerberos Ticket-Granting Tickets (TGTs) per
+   ``MongoClient`` instance. TODO: NEED EXACT USE CASE WHERE PROCESS TGT CACHE IS HELPFUL.
+   If you would like to instead cache TGTs by process, specify the ``JAVA_SUBJECT_PROVIDER``
+   mechanism property in the ``MongoCredential`` class.
+
+
 .. tabs::
 
    .. tab::

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
@@ -1,11 +1,10 @@
 .. code-block:: java
 
-   /*
-   All MongoClient instances sharing this instance of KerberosSubjectProvider
-   will share a Kerberos ticket cache 
-   */
+   /* All MongoClient instances sharing this instance of KerberosSubjectProvider
+   will share a Kerberos ticket cache */
    String myLoginContext = "MyContext";
    MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
-   //login context defaults to "com.sun.security.jgss.krb5.initiate" if unspecified in KerberosSubjectProvider
+   /* login context defaults to "com.sun.security.jgss.krb5.initiate"
+   if unspecified in KerberosSubjectProvider */
    credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_PROVIDER_KEY,
                                                  new KerberosSubjectProvider(myLoginContext));

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
@@ -8,4 +8,4 @@
    MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
    //login context defaults to "com.sun.security.jgss.krb5.initiate" if unspecified in KerberosSubjectProvider
    credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_PROVIDER_KEY,
-                                                             new KerberosSubjectProvider(myLoginContext));
+                                                 new KerberosSubjectProvider(myLoginContext));

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
@@ -1,0 +1,11 @@
+.. code-block:: java
+
+   /*
+   All MongoClient instances sharing this instance of KerberosSubjectProvider
+   will share a Kerberos ticket cache 
+   */
+   String myLoginContext = "MyContext";
+   MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
+   //login context defaults to "com.sun.security.jgss.krb5.initiate" if unspecified in KerberosSubjectProvider
+   credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_PROVIDER_KEY,
+                                                             new KerberosSubjectProvider(myLoginContext));

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
@@ -2,7 +2,7 @@
 
    /* All MongoClient instances sharing this instance of KerberosSubjectProvider
    will share a Kerberos ticket cache */
-   String myLoginContext = "MyContext";
+   String myLoginContext = "myContext";
    MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
    /* login context defaults to "com.sun.security.jgss.krb5.initiate"
    if unspecified in KerberosSubjectProvider */

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-ticket-cache.rst
@@ -1,6 +1,6 @@
 .. code-block:: java
 
-   /* All MongoClient instances sharing this instance of KerberosSubjectProvider
+   /* all MongoClient instances sharing this instance of KerberosSubjectProvider
    will share a Kerberos ticket cache */
    String myLoginContext = "myContext";
    MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);


### PR DESCRIPTION
## Pull Request Info

Document Kerberos default ticket caching behavior and how to configure Kerberos ticket caching by process. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13803

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/2afd327/java/docsworker-xlarge/DOCSP-13803-kerberos-ticket-caching/fundamentals/enterprise-auth/#std-label-gssapi-auth-mechanism

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?

* There is a warning that was present on master before making edits. Warning is:

`INFO:snooty.main:Snooty 0.9.2 starting
/usr/lib/python3.8/getpass.py:91: GetPassWarning: Can not control echo on the terminal.
  passwd = fallback_getpass(prompt, stream)
Warning: Password input may be echoed.`

[From commit log from empty branch off of master](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=602d4284ab23346c2001f70d)

- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [X] Does it render on staging correctly?
- [X] Are all the links working?
- [x] Are the staging links in the PR description updated?

