### PR TITLE
DOCSP-9585 builders sort criteria

### DIFF
--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -25,10 +25,9 @@ examples of sort criteria are:
 * Earliest time of day to latest time of day
 * Alphabetical order by first name 
 
-:doc:`Builders </fundamentals/builders/>` are classes provided by the MongoDB
-Java driver that help you construct complex 
+Builders are classes provided by the MongoDB Java driver that help you construct 
 :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects. 
-Builders can improve the readability of your code.
+To learn more, see our :doc:`guide on builders </fundamentals/builders/>`.
 
 You should read this guide if you would like to:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -296,7 +296,7 @@ and use ``Sorts.metaTextScore()``.
   If your MongoDB instance is running MongoDB 4.2 and earlier, in order
   to use ``Sorts.metaTextScore()`` as sort criteria in the ``sort()``
   method of a ``FindIterable`` instance, you must also include
-  ``Sorts.metaTextScore()`` in in the ``projection()`` method of that
+  ``Projections.metaTextScore()`` in the ``projection()`` method of that
   ``FindIterable`` instance. This is demonstrated in the code example below.
 
 .. example::
@@ -310,15 +310,15 @@ and use ``Sorts.metaTextScore()``.
       :ref:`sort_example collection <sorts-builders-sort-example>`
       on the ``food`` field.
    #. Run a text search for the phrase "maple donut".
-   #. Project ``Sorts.metaTextScore()`` into your query results as the
+   #. Project ``Projections.metaTextScore()`` into your query results as the
       ``score`` field. This step is optional if your MongoDB instance is
       running MongoDB 4.4 or later. 
    #. Sort using ``Sorts.metaTextScore()`` as your sort criteria.
 
    .. code-block:: java
    
-      import static com.mongodb.client.model.Sorts.metaTextScore;
-      import static com.mongodb.client.model.Sorts.ascending;
+      import static com.mongodb.client.model.Sorts;
+      import static com.mongodb.client.model.Projections;
       import com.mongodb.client.model.Filters;
       import com.mongodb.client.model.Indexes;
 
@@ -327,13 +327,14 @@ and use ``Sorts.metaTextScore()``.
       // create a text index on the food field using the Indexes.text() builder
       collection.createIndex(Indexes.text("food"));
       // create the text score sort criteria
-      Bson metaTextScoreSort = metaTextScore("score");
+      Bson metaTextScoreSort = Sorts.metaTextScore("score");
+      Bson metaTextScoreProj = Projections.metaTextScore("score");
       String searchTerm = "maple donut";
       // build a $text query operator using the Filters.text() builder
       Bson searchQuery = Filters.text(searchTerm);
       collection.find(searchQuery)
               // project the text score into your results on the "score" field (optional in MongoDB 4.4 or later)
-              .projection(metaTextScoreSort)
+              .projection(metaTextScoreProj)
               // sort the results on the "score" field
               .sort(metaTextScoreSort)
               .into(results);

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -61,7 +61,7 @@ method of a ``FindIterable`` instance.
 
 The following examples show you how to use the methods
 provided by the ``Sorts`` class to sort your queries. The examples use a
-sample collection ``sort_example`` that contains the following documents:
+sample collection, ``sort_example``, that contains the following documents:
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -51,7 +51,7 @@ The Sorts Class
 The :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
 class is the sort criteria builder provided by the MongoDB Java driver.
 ``Sorts`` provides static factory methods for all sort criteria
-operators supported by MongoDB. All methods return a
+operators supported by MongoDB. All methods of ``Sorts`` return a
 :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
 object that you can pass to the 
 :java-docs:`sort() </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#sort(org.bson.conversions.Bson)>`

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -144,7 +144,7 @@ of the following documents:
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
 
-If you need to have a guaranteed sort order for documents that
+If you need guaranteed sort order for documents that
 have fields with identical values you can specify additional fields to sort
 on in the event of a tie.
 
@@ -214,7 +214,7 @@ the following documents:
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 6, "letter": "c", "food": "maple donut"}
 
-If you need to have a guaranteed sort order for documents that
+If you need guaranteed sort order for documents that
 have fields with identical values you can specify additional fields to sort
 on in the event of a tie. 
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -285,11 +285,14 @@ If you perform a text search on your collection with the
 can sort your results by how well they match your ``$search`` string using
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`. 
 To sort your search results by the text scores associated with your text
-search, use the ``Sorts.metaTextScore()`` static factory method. Note
-that the ``$text`` query operator performs a text search on the content indexed 
-by the :manual:`text index </core/index-text/>`of your collection. You must
-create a text index on your collection before you can run a text search
-and use ``Sorts.metaTextScore()``.
+search, use the ``Sorts.metaTextScore()`` static factory method. 
+
+.. .. warning:: Make Sure to Create a Text Index
+
+   The ``$text`` query operator performs a text search on the content indexed 
+   by the :manual:`text index </core/index-text/>` of your collection.
+   Therefore, you must create a text index on your collection before you
+   can run a text search and use ``Sorts.metaTextScore()``.
 
 .. _sorts-builders-mongo-server-note:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -36,8 +36,8 @@ readability of your code.
 You should read this guide if you would like to:
 
 * Use the builder pattern to specify sort criteria for your queries.
-* Learn how to perform ascending sorts and descending sorts.
-* Learn how to combine sort criteria.
+* Perform ascending sorts and descending sorts.
+* Combine sort criteria.
 * Sort on the text score of a
   :manual:`text search </core/text-search-operators/>`.
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -92,7 +92,7 @@ order:
 * Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1900-07-22 
 * Words (Alphabetical): pear, mango, grapes, apple
 
-The following two subsections provide examples showing how to perform these
+The following subsections provide examples showing how to specify these
 sorts.
 
 Ascending

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -84,13 +84,13 @@ Here are some examples of data sorted in ascending order:
 
 * Numbers: 1, 2, 3, 43, 43, 55, 120
 * Dates: 1990-03-10, 1995-01-01, 2005-10-30, 2005-12-21 
-* Words (Alphabetical): carrot, cheese, cucumber, hummus
+* Words (alphabetical): carrot, cheese, cucumber, hummus
 
 Here are some examples of data sorted in descending order:
 
 * Numbers: 100, 30, 12, 12, 9, 3, 1
 * Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1975-07-22 
-* Words (Alphabetical): pear, mango, grapes, apple
+* Words (reverse alphabetical): pear, mango, grapes, apple
 
 The following subsections show how to specify these sorts using
 the ``Sorts`` class.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -325,7 +325,7 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
   into your ``FindIterable`` instance is not necessary to sort on
   ``Sorts.metaTextScore()``. In addition, the field name of a ``$meta``
   text score aggregation operation used in a sort is disregarded by the
-  query system. This means that the String field name argument passed to
+  query system. This means that the field name argument passed to
   ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -109,7 +109,7 @@ to largest on the specified field name.
 
    In this code example, we use the ``ascending()`` method to sort the
    :ref:`sort_example collection <sorts-builders-sort-example>`  
-   by ``_id``:
+   by the ``_id`` field:
 
    .. code-block:: java
    
@@ -148,8 +148,8 @@ If you need guaranteed sort order for documents that
 have fields with identical values you can specify additional fields to sort
 on in the event of a tie.
 
-We can specify an ascending sort on ``letter`` followed
-by ``_id`` as follows:
+We can specify an ascending sort on the ``letter`` field followed by the
+``_id`` field as follows:
 
 .. code-block:: java
 
@@ -251,7 +251,8 @@ method. The ``orderBy()`` method builds sort criteria that apply passed
 in sort criteria from left to right in the event of ties. 
 
 In the following code snippet, we use the ``orderBy()`` method to combine a
-descending sort on ``letter`` with an ascending sort on ``_id``.
+descending sort on the ``letter`` field with an ascending sort on the
+``_id`` field.
 
 .. code-block:: java
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -76,7 +76,7 @@ Sorting Direction
 -----------------
 
 The ``Sorts`` class provides methods for specifying the direction of your sort.
-The direction of your sort can either be **ascending**, or **descending**.
+The direction of your sort can either be **ascending** or **descending**.
 An ascending sort orders your results from smallest to largest. A
 descending sort orders your results from largest to smallest.
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -117,32 +117,30 @@ The above ``sort()`` method returns a
 object containing the documents in your collection, sorted from smallest
 to largest on the specified field name. 
 
-.. example::
+In this code example, we use the ``ascending()`` method to sort the
+:ref:`sort_example collection <sorts-builders-sort-example>`  
+by the ``_id`` field:
 
-   In this code example, we use the ``ascending()`` method to sort the
-   :ref:`sort_example collection <sorts-builders-sort-example>`  
-   by the ``_id`` field:
+.. code-block:: java
 
-   .. code-block:: java
-   
-      import static com.mongodb.client.model.Sorts.ascending;
-   
-      // <MongoCollection setup code here>
-      
-      Bson idSort = ascending("_id");
-      List<Document> results = new ArrayList<>();
-      collection.find().sort(idSort).into(results);
-      for (Document result : results) {
-          System.out.println(result.toJson());
-      }
+   import static com.mongodb.client.model.Sorts.ascending;
 
-   The output of the code snippet above should look something like this: 
+   // <MongoCollection setup code here>
    
-   .. code-block:: json
-   
-      {"_id": 1, "letter": "c", "food": "coffee with milk"}
-      {"_id": 2, "letter": "a", "food": "donuts and coffee"}
-      {"_id": 3, "letter": "a", "food": "maple syrup"}
+   Bson idSort = ascending("_id");
+   List<Document> results = new ArrayList<>();
+   collection.find().sort(idSort).into(results);
+   for (Document result : results) {
+         System.out.println(result.toJson());
+   }
+
+The output of the code snippet above should look something like this: 
+
+.. code-block:: json
+
+   {"_id": 1, "letter": "c", "food": "coffee with milk"}
+   {"_id": 2, "letter": "a", "food": "donuts and coffee"}
+   {"_id": 3, "letter": "a", "food": "maple syrup"}
       ...
 
 Descending
@@ -280,54 +278,52 @@ criteria to sort by the text score.
    information on how to
    :manual:`create a text index </core/index-text/#create-text-index>`.
 
-.. example::
+In the following code example, we show how you can use the
+``Sorts.metaTextScore()`` method to sort the results of a text
+search on the :ref:`sort_example collection <sorts-builders-sort-example>`.
+The code example uses the :doc:`Filters </fundamentals/builders/filters>`,
+:doc:`Indexes </fundamentals/builders/indexes>`, and
+:doc:`Projections </fundamentals/builders/projections>` builders.
+The code example performs the following actions:
 
-   In the following code example, we show how you can use the
-   ``Sorts.metaTextScore()`` method to sort the results of a text
-   search on the :ref:`sort_example collection <sorts-builders-sort-example>`.
-   The code example uses the :doc:`Filters </fundamentals/builders/filters>`,
-   :doc:`Indexes </fundamentals/builders/indexes>`, and
-   :doc:`Projections </fundamentals/builders/projections>` builders.
-   The code example performs the following actions:
+#. Creates a text index for your
+   :ref:`sort_example collection <sorts-builders-sort-example>`
+   on the ``food`` field.
+#. Runs your text search for the phrase "maple donut".
+#. Projects text scores into your query results as the
+   ``score`` field. This projection is optional if your MongoDB instance is
+   running MongoDB 4.4 or later. 
+#. Sorts your results by text score (best match first).
 
-   #. Creates a text index for your
-      :ref:`sort_example collection <sorts-builders-sort-example>`
-      on the ``food`` field.
-   #. Runs your text search for the phrase "maple donut".
-   #. Projects text scores into your query results as the
-      ``score`` field. This projection is optional if your MongoDB instance is
-      running MongoDB 4.4 or later. 
-   #. Sorts your results by text score (best match first).
+.. code-block:: java
 
-   .. code-block:: java
+   import com.mongodb.client.model.Sorts;
+   import com.mongodb.client.model.Projections;
+   import com.mongodb.client.model.Filters;
+   import com.mongodb.client.model.Indexes;
+
+   // <MongoCollection setup code here>
    
-      import com.mongodb.client.model.Sorts;
-      import com.mongodb.client.model.Projections;
-      import com.mongodb.client.model.Filters;
-      import com.mongodb.client.model.Indexes;
+   collection.createIndex(Indexes.text("food"));
+   Bson metaTextScoreSort = Sorts.metaTextScore("score");
+   Bson metaTextScoreProj = Projections.metaTextScore("score");
+   String searchTerm = "maple donut";
+   Bson searchQuery = Filters.text(searchTerm);
+   collection.find(searchQuery)
+            .projection(metaTextScoreProj)
+            .sort(metaTextScoreSort)
+            .into(results);
+   for (Document result : results) {
+         System.out.println(result.toJson());
+   }
 
-      // <MongoCollection setup code here>
-      
-      collection.createIndex(Indexes.text("food"));
-      Bson metaTextScoreSort = Sorts.metaTextScore("score");
-      Bson metaTextScoreProj = Projections.metaTextScore("score");
-      String searchTerm = "maple donut";
-      Bson searchQuery = Filters.text(searchTerm);
-      collection.find(searchQuery)
-              .projection(metaTextScoreProj)
-              .sort(metaTextScoreSort)
-              .into(results);
-      for (Document result : results) {
-          System.out.println(result.toJson());
-      }
-   
-   The output of the code snippet above should look something like this: 
-   
-   .. code-block:: json
+The output of the code snippet above should look something like this: 
 
-      {"_id": 6, "letter": "c", "food": "maple donut", "score": 1.5}
-      {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
-      {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
+.. code-block:: json
+
+   {"_id": 6, "letter": "c", "food": "maple donut", "score": 1.5}
+   {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
+   {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
 .. note:: MongoDB 4.4 or later ``$meta`` Behavior
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -359,9 +359,11 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
   aggregation operation used in a sort is disregarded by the query system. 
   In MongoDB 4.2 and earlier however, the field name of a ``$meta`` text score
   used in a sort must match the field name of a ``$meta`` text score used
-  in the proceeding projection. This means that the String field name
-  argument passed to ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4
-  and later, but must match the String field name argument passed to
+  in the proceeding projection
+  (:ref:`see the above note on projections and text score <_sorts-builders-mongo-server-note>`). 
+  This means that the String field name argument passed to
+  ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later, but
+  must match the String field name argument passed to
   ``Projections.metaTextScore()``in MongoDB 4.2 and earlier.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -285,7 +285,7 @@ Text Search
 
 If you perform a text search on your collection with the
 :manual:`$text </reference/operator/query/text/>` query operator, you 
-can sort your results by how well they match your ``$search`` string using
+can sort your results by how well they match your ``$search`` String using
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`. 
 To sort your search results by the text scores associated with your text
 search, use the ``Sorts.metaTextScore()`` static factory method. 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -247,8 +247,8 @@ Combining Sort Criteria
 -----------------------
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
-method. The ``orderBy()`` method applies additional sort criteria from
-left to right in the event of ties. 
+method. The ``orderBy()`` method builds sort criteria that apply passed 
+in sort criteria from left to right in the event of ties. 
 
 In the following code snippet, we use the ``orderBy()`` method to combine a
 descending sort on ``letter`` with an ascending sort on ``_id``.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -54,7 +54,11 @@ operators supported by MongoDB. These methods return a
 :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
 object that you can pass to the 
 :java-docs:`sort() </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#sort(org.bson.conversions.Bson)>`
-method of a ``FindIterable`` instance. 
+method of a ``FindIterable`` instance or to 
+:java-docs:`Aggregates.sort() </apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#sort(org.bson.conversions.Bson)>`.
+If you want to learn more about ``Aggregates``, see our 
+:doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
+
 
 .. _sorts-builders-sort-example:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -84,13 +84,13 @@ Here are some examples of data sorted in ascending order:
 
 * Numbers: 1, 2, 3, 43, 43, 55, 120
 * Dates: 1990-03-10, 1995-01-01, 2005-10-30, 2005-12-21 
-* Words (alphabetical): carrot, cheese, cucumber, hummus
+* Words (alphabetical): Banana, Dill, carrot, cucumber, hummus
 
 Here are some examples of data sorted in descending order:
 
 * Numbers: 100, 30, 12, 12, 9, 3, 1
 * Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1975-07-22 
-* Words (reverse alphabetical): pear, mango, grapes, apple
+* Words (reverse alphabetical): pear, grapes, apple, Cheese
 
 The following subsections show how to specify these sorts using
 the ``Sorts`` class.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -49,8 +49,7 @@ The Sorts Class
 ---------------
 
 The :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
-class is the sort criteria builder provided by the MongoDB Java driver.
-``Sorts`` provides static factory methods for all sort criteria
+class is a builder that provides static factory methods for all sort criteria
 operators supported by MongoDB. All methods of ``Sorts`` return a
 :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
 object that you can pass to the 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -43,8 +43,7 @@ You should read this guide if you would like to:
 
 If you want to learn the fundamentals of sorting in the MongoDB Java
 driver, consider reading our
-:doc:`guide on sorting </fundamentals/crud/read-operations/sort/>`
-for a general introduction.
+:doc:`guide on sorting </fundamentals/crud/read-operations/sort/>`.
 
 The Sorts Class
 ---------------

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -333,11 +333,11 @@ criteria to sort by the text score.
 .. note:: MongoDB 4.4 ``$meta`` Behavior
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
-  into your ``FindIterable`` instance is not necessary to sort on
-  ``Sorts.metaTextScore()``. In addition, the field name you specify in a
-  ``$meta`` text score aggregation operation used in a sort is disregarded by
-  the query system. This means that the field name argument you pass to
-  ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later.
+  into your ``FindIterable`` instance is not necessary to sort on the text
+  score. In addition, the field name you specify in a ``$meta`` text score
+  aggregation operation used in a sort is disregarded by the query system. This
+  means that the field name argument you pass to ``Sorts.metaTextScore()`` is
+  ignored in MongoDB 4.4 and later.
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -321,8 +321,8 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 
 .. note:: MongoDB 4.4 ``$meta`` Behavior
 
-  As of MongoDB 4.4, projecting ``Projections.metaTextScore()`` into
-  your ``FindIterable`` instance is not necessary to sort on
+  When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
+  into your ``FindIterable`` instance is not necessary to sort on
   ``Sorts.metaTextScore()``. In addition, the field name of a ``$meta``
   text score aggregation operation used in a sort is disregarded by the
   query system. This means that the String field name argument passed to

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -50,7 +50,7 @@ The Sorts Class
 
 The :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
 class is a builder that provides static factory methods for all sort criteria
-operators supported by MongoDB. All methods of ``Sorts`` return a
+operators supported by MongoDB. These methods return a
 :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
 object that you can pass to the 
 :java-docs:`sort() </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#sort(org.bson.conversions.Bson)>`

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -25,17 +25,15 @@ examples of sort criteria are:
 * Earliest time of day to latest time of day
 * Alphabetical order by first name 
 
-The builder pattern allows you to create complex immutable objects
-separately from their representation. :doc:`Builders </fundamentals/builders/>` 
-are classes provided by the MongoDB Java driver that allow you to use
-the builder pattern to construct
-:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects.
-The builders provided by the MongoDB Java driver can improve the
-readability of your code.
+:doc:`Builders </fundamentals/builders/>` are classes provided by the MongoDB
+Java driver that help you construct complex 
+:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects. The
+builders provided by the MongoDB Java driver can improve the readability of your
+code.
 
 You should read this guide if you would like to:
 
-* Use the builder pattern to specify sort criteria for your queries.
+* Use builders to specify sort criteria for your queries.
 * Perform ascending sorts and descending sorts.
 * Combine sort criteria.
 * Sort on the text score of a

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -59,7 +59,7 @@ method of a ``FindIterable`` instance.
 
 .. _sorts-builders-sort-example:
 
-The following examples show you how to use the static factory methods
+The following examples show you how to use the methods
 provided by the ``Sorts`` class to sort your queries. The examples use a
 sample collection ``sort_example`` that contains the following documents:
 
@@ -303,7 +303,7 @@ and use ``Sorts.metaTextScore()``.
 .. example::
 
    In the following code example, we show how to use the
-   ``Sorts.metaTextScore()`` static factory method to sort the results of a text
+   ``Sorts.metaTextScore()`` method to sort the results of a text
    search on the :ref:`sort_example collection <sorts-builders-sort-example>`.
    The following code snippet works as follows:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -287,7 +287,7 @@ can sort your results by how well they match your ``$search`` string using
 To sort your search results by the text scores associated with your text
 search, use the ``Sorts.metaTextScore()`` static factory method. 
 
-.. .. warning:: Make Sure to Create a Text Index
+.. warning:: Make Sure to Create a Text Index
 
    The ``$text`` query operator performs a text search on the content indexed 
    by the :manual:`text index </core/index-text/>` of your collection.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -75,18 +75,31 @@ sample collection, ``sort_example``, that contains the following documents:
 Sorting Direction
 -----------------
 
-The ``Sorts`` class provides two methods for specifying sort direction.
-You can sort your data from smallest to largest with
-``Sorts.ascending()``, and you can sort your data from
-largest to smallest with ``Sorts.descending()``. The following two
-subsections provide examples on how to use these two methods. 
+The ``Sorts`` class provides two methods for specify sort direction.
+You can sort your data in **ascending** order, from smallest to largest, with
+``Sorts.ascending()``. Here are some examples of data sorted in ascending
+order:
+
+* Numbers: 1, 2, 3, 43, 43, 55, 120
+* Dates: 1990-03-10, 1995-01-01, 2005-10-30, 2005-12-21 
+* Words (Alphabetical): carrot, cheese, cucumber, hummus
+
+You can sort your data in **descending** order, from largest to smallest, with
+``Sorts.descending()``. Here are some examples of data sorted in descending
+order:
+
+* Numbers: 100, 30, 12, 12, 9, 3, 1
+* Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1900-07-22 
+* Words (Alphabetical): pear, mango, grapes, apple
+
+The following two subsections provide examples showing how to perform these
+sorts.
 
 Ascending
 ~~~~~~~~~
 
-An ascending sort returns your documents from smallest to largest based
-on the value of a specified field. To specify an ascending sort, use the
-``Sorts.ascending()`` static factory method. Pass ``Sorts.ascending()``
+To specify an ascending sort, use the ``Sorts.ascending()`` static
+factory method. Pass ``Sorts.ascending()``
 the name of the field you need to sort on.
 
 The ``ascending()`` method can be used as follows:
@@ -135,10 +148,8 @@ to largest on the specified field name.
 Descending
 ~~~~~~~~~~
 
-A descending sort returns your documents from largest to smallest based
-on the value of a specified field. To specify a descending sort, use the
-``Sorts.descending()`` static factory method. Pass
-``Sorts.descending()`` the name of the field you need to sort on.
+To specify a descending sort, use the ``Sorts.descending()`` static factory
+method. Pass ``Sorts.descending()`` the name of the field you need to sort on.
 
 The following code snippet shows how to specify a descending sort on the
 ``_id`` field: 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -77,8 +77,8 @@ Sorting Direction
 
 The ``Sorts`` class provides methods for specifying the direction of your sort.
 The direction of your sort can either be **ascending**, or **descending**.
-An ascending sort orders your data from smallest to largest. A
-descending sort orders your data from largest to smallest.
+An ascending sort orders your results from smallest to largest. A
+descending sort orders your results from largest to smallest.
 
 Here are some examples of data sorted in ascending order:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -49,7 +49,7 @@ The Sorts Class
 ---------------
 
 The :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
-class is the sort criteria builder provided by the MongoDB Java Driver.
+class is the sort criteria builder provided by the MongoDB Java driver.
 ``Sorts`` provides static factory methods for all sort criteria
 operators supported by MongoDB. All methods return a
 :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -284,10 +284,10 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
       :ref:`sort_example collection <sorts-builders-sort-example>`
       on the ``food`` field.
    #. Runs your text search for the phrase "maple donut".
-   #. Projects ``Projections.metaTextScore()`` into your query results as the
+   #. Projects text scores into your query results as the
       ``score`` field. This projection is optional if your MongoDB instance is
       running MongoDB 4.4 or later. 
-   #. Sorts using ``Sorts.metaTextScore()`` as your sort criteria.
+   #. Sorts your results by text score (best match first).
 
    .. code-block:: java
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -305,7 +305,9 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
   to use ``Sorts.metaTextScore()`` as sort criteria in the ``sort()``
   method of a ``FindIterable`` instance, you must also include
   ``Projections.metaTextScore()`` in the ``projection()`` method of that
-  ``FindIterable`` instance. This is demonstrated in the code example below.
+  ``FindIterable`` instance. In addition, the String field names passed to 
+  ``Projections.metaTextScore()`` and ``Sorts.metaTextScore()`` must be
+  identical. This is demonstrated in the code example below.
 
 .. example::
 
@@ -359,15 +361,9 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 .. note::
 
   As of MongoDB 4.4, the field name of a ``$meta`` text score
-  aggregation operation used in a sort is disregarded by the query system. 
-  In MongoDB 4.2 and earlier however, the field name of a ``$meta`` text score
-  used in a sort must match the field name of a ``$meta`` text score used
-  in the proceeding projection
-  (:ref:`see the above note on projections and text score <_sorts-builders-mongo-server-note>`). 
+  aggregation operation used in a sort is disregarded by the query system.
   This means that the String field name argument passed to
-  ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later, but
-  must match the String field name argument passed to
-  ``Projections.metaTextScore()``in MongoDB 4.2 and earlier.
+  ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later.
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -277,8 +277,8 @@ in the following order:
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
 
-Text Score
-----------
+Text Search
+-----------
 
 If you perform a text search on your collection with the
 :manual:`$text </reference/operator/query/text/>` query operator, you 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -131,8 +131,42 @@ to largest on the specified field name.
       {"_id": 2, "letter": "a", "food": "donuts and coffee"}
       {"_id": 3, "letter": "a", "food": "maple syrup"}
       ...
+
+Descending
+~~~~~~~~~~
+
+A descending sort returns your documents from largest to smallest based
+on the value of a specified field. To specify a descending sort, use the
+``Sorts.descending()`` static factory method. Pass
+``Sorts.descending()`` the name of the field you need to sort on.
+
+The following code snippet shows how to specify a descending sort on the
+``_id`` field: 
+
+.. code-block:: java
    
-Note that MongoDB does not guarantee sort order for documents that have
+   import static com.mongodb.client.model.Sorts.descending;
+
+   // <MongoCollection setup code here>
+   
+   collection.find().sort(descending("_id"));
+
+
+The code snippet above returns the documents in the
+:ref:`sort_example collection <sorts-builders-sort-example>`  
+in the following order: 
+
+.. code-block:: json
+
+   {"_id": 6, "letter": "c", "food": "maple donut"}
+   {"_id": 5, "letter": "a", "food": "milk and cookies"}
+   {"_id": 4, "letter": "b", "food": "coffee with sugar"}
+   ...
+
+Handling Ties
+~~~~~~~~~~~~~
+
+MongoDB does not guarantee sort order for documents that have
 fields with identical values. This means that if you pass "letter" to
 the ``ascending()`` method and use the returned sort criteria to sort
 the documents in the
@@ -172,77 +206,6 @@ in the following order:
    {"_id": 4, "letter": "b", "food": "coffee with sugar"}
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 6, "letter": "c", "food": "maple donut"}
-
-
-Descending
-~~~~~~~~~~
-
-A descending sort returns your documents from largest to smallest based
-on the value of a specified field. To specify a descending sort, use the
-``Sorts.descending()`` static factory method. Pass
-``Sorts.descending()`` the name of the field you need to sort on.
-
-The following code snippet shows how to specify a descending sort on the
-``_id`` field: 
-
-.. code-block:: java
-   
-   import static com.mongodb.client.model.Sorts.descending;
-
-   // <MongoCollection setup code here>
-   
-   collection.find().sort(descending("_id"));
-
-
-The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-builders-sort-example>`  
-in the following order: 
-
-.. code-block:: json
-
-   {"_id": 6, "letter": "c", "food": "maple donut"}
-   {"_id": 5, "letter": "a", "food": "milk and cookies"}
-   {"_id": 4, "letter": "b", "food": "coffee with sugar"}
-   ...
-
-Note that MongoDB does not guarantee sort order for documents that have
-fields with identical values. This means that if you pass "letter" to
-the ``descending()`` method, the first document returned could be any of
-the following documents:
-
-.. code-block:: json
-
-   {"_id": 1, "letter": "c", "food": "coffee with milk"}
-   {"_id": 6, "letter": "c", "food": "maple donut"}
-
-If you need guaranteed sort order for documents that
-have fields with identical values you can specify additional fields to sort
-on in the event of a tie. 
-
-The following code snippet shows how to specify a descending
-sort on the ``letter`` field followed by the ``_id`` field: 
-
-.. code-block:: java
-
-   import static com.mongodb.client.model.Sorts.descending;
-
-   // <MongoCollection setup code here>
-   
-   collection.find().sort(descending("letter", "_id"));
-
-
-The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-builders-sort-example>`  
-in the following order: 
-
-.. code-block:: json
-
-   {"_id": 6, "letter": "c", "food": "maple donut"}
-   {"_id": 1, "letter": "c", "food": "coffee with milk"}
-   {"_id": 4, "letter": "b", "food": "coffee with sugar"}
-   {"_id": 5, "letter": "a", "food": "milk and cookies"}
-   {"_id": 3, "letter": "a", "food": "maple syrup"}
-   {"_id": 2, "letter": "a", "food": "donuts and coffee"}
 
 Combining Sort Criteria
 -----------------------

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -100,7 +100,7 @@ The ``ascending()`` method can be used as follows:
 
    collection.find().sort(ascending("<field name>"));
 
-This returns a 
+The above ``sort()`` method returns a 
 :java-docs:`FindIterable </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>`
 object containing the documents in your collection, sorted from smallest
 to largest on the specified field name. 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -324,18 +324,16 @@ and use ``Sorts.metaTextScore()``.
 
       // <MongoCollection setup code here>
       
-      // create a text index on the food field using the Indexes.text() builder
+      // create your text index on the food field
       collection.createIndex(Indexes.text("food"));
-      // create the text score sort criteria
       Bson metaTextScoreSort = Sorts.metaTextScore("score");
       Bson metaTextScoreProj = Projections.metaTextScore("score");
       String searchTerm = "maple donut";
-      // build a $text query operator using the Filters.text() builder
+      // build your $text query operator
       Bson searchQuery = Filters.text(searchTerm);
+      // projection optional in MongoDB 4.4 or later
       collection.find(searchQuery)
-              // project the text score into your results on the "score" field (optional in MongoDB 4.4 or later)
               .projection(metaTextScoreProj)
-              // sort the results on the "score" field
               .sort(metaTextScoreSort)
               .into(results);
       for (Document result : results) {

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -177,11 +177,21 @@ in the following order:
 Handling Ties
 ~~~~~~~~~~~~~
 
-MongoDB does not guarantee sort order for documents that have
-fields with identical values. This means that if you pass "letter" to
-the ``ascending()`` method and use the returned sort criteria to sort
-the documents in the
-:ref:`sort_example collection <sorts-builders-sort-example>`, the first
+A tie occurs when two or more documents have a field with identical values.
+MongoDB does not guarantee sort order in the event of ties. For example, suppose
+we encounter a tie when applying a sort to the
+:ref:`sort_example collection <sorts-builders-sort-example>` using the following
+code:
+
+.. code-block:: java
+
+   import static com.mongodb.client.model.Sorts.ascending;
+
+   // <MongoCollection setup code here>
+   
+   collection.find().sort(ascending("letter"));
+
+Since multiple documents contain "a" on the field we are sorting on, the first
 document returned could be any of the following documents:
 
 .. code-block:: json

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -76,9 +76,9 @@ sample collection, ``sort_example``, that contains the following documents:
 Sorting Direction
 -----------------
 
-The ``Sorts`` class provides two methods for specifying the sort direction
-of your collection of data. You can sort your data from smallest to
-largest with ``Sorts.ascending()``, and you can sort your data from
+The ``Sorts`` class provides two methods for specifying sort direction.
+You can sort your data from smallest to largest with
+``Sorts.ascending()``, and you can sort your data from
 largest to smallest with ``Sorts.descending()``. The following two
 subsections provide examples on how to use these two methods. 
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -323,9 +323,9 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
   into your ``FindIterable`` instance is not necessary to sort on
-  ``Sorts.metaTextScore()``. In addition, the field name of a ``$meta``
-  text score aggregation operation used in a sort is disregarded by the
-  query system. This means that the field name argument passed to
+  ``Sorts.metaTextScore()``. In addition, the field name you specify in a
+  ``$meta`` text score aggregation operation used in a sort is disregarded by
+  the query system. This means that the field name argument you pass to
   ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -271,8 +271,8 @@ You can specify the order of the results of a text search performed with the
 by how closely they match your search string. Each of your search results has a
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`, a
 numerical value indicating how well that result matches your search. 
-Use the ``Sorts.metaTextScore()`` method to build your sort criteria to sort by
-the text score.
+Use the ``Sorts.metaTextScore()`` static factory method to build your sort
+criteria to sort by the text score.
 
 .. warning:: Make Sure to Create a Text Index
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -117,7 +117,7 @@ The above ``sort()`` method returns a
 object containing the documents in your collection, sorted from smallest
 to largest on the specified field name. 
 
-In this code example, we use the ``ascending()`` method to sort the
+In the following code example, we use the ``ascending()`` method to sort the
 :ref:`sort_example collection <sorts-builders-sort-example>`  
 by the ``_id`` field:
 
@@ -265,7 +265,7 @@ Text Search
 -----------
 
 You can specify the order of the results of a 
-:manual:`text search </manual/text-search/>` by how closely they match your
+:manual:`text search </text-search/>` by how closely they match your
 search string. Each of your search results has a
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`, a
 numerical value indicating how well that result matches your search. 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -77,8 +77,8 @@ Sorting Direction
 -----------------
 
 The ``Sorts`` class provides two methods for specifying the sort direction
-of your collection of data. Your data can be sorted from smallest to
-largest with ``Sorts.ascending()``, and your data can be sorted from
+of your collection of data. You can sort your data from smallest to
+largest with ``Sorts.ascending()``, and you can sort your data from
 largest to smallest with ``Sorts.descending()``. The following two
 subsections provide examples on how to use these two methods. 
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -330,7 +330,7 @@ criteria to sort by the text score.
       {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
       {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
-.. note:: MongoDB 4.4 ``$meta`` Behavior
+.. note:: MongoDB 4.4 or later ``$meta`` Behavior
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
   into your ``FindIterable`` instance is not necessary to sort on the text

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -84,13 +84,13 @@ Here are some examples of data sorted in ascending order:
 
 * Numbers: 1, 2, 3, 43, 43, 55, 120
 * Dates: 1990-03-10, 1995-01-01, 2005-10-30, 2005-12-21 
-* Words (alphabetical): Banana, Dill, carrot, cucumber, hummus
+* Words (ASCII): Banana, Dill, carrot, cucumber, hummus
 
 Here are some examples of data sorted in descending order:
 
 * Numbers: 100, 30, 12, 12, 9, 3, 1
 * Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1975-07-22 
-* Words (reverse alphabetical): pear, grapes, apple, Cheese
+* Words (reverse ASCII): pear, grapes, apple, Cheese
 
 The following subsections show how to specify these sorts using
 the ``Sorts`` class.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -266,9 +266,9 @@ in the following order:
 Text Search
 -----------
 
-You can specify the order of the results of a text search performed with the
-:manual:`$text </reference/operator/query/text/>` query operator
-by how closely they match your search string. Each of your search results has a
+You can specify the order of the results of a 
+:manual:`text search </manual/text-search/>` by how closely they match your
+search string. Each of your search results has a
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`, a
 numerical value indicating how well that result matches your search. 
 Use the ``Sorts.metaTextScore()`` static factory method to build your sort

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -89,7 +89,7 @@ Here are some examples of data sorted in ascending order:
 Here are some examples of data sorted in descending order:
 
 * Numbers: 100, 30, 12, 12, 9, 3, 1
-* Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1900-07-22 
+* Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1975-07-22 
 * Words (Alphabetical): pear, mango, grapes, apple
 
 The following subsections show how to specify these sorts using

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -302,6 +302,9 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
    In the following code example, we show how you can use the
    ``Sorts.metaTextScore()`` method to sort the results of a text
    search on the :ref:`sort_example collection <sorts-builders-sort-example>`.
+   The code example uses the :doc:`Filters </fundamentals/builders/filters>`,
+   :doc:`Indexes </fundamentals/builders/indexes>`, and
+   :doc:`Projections </fundamentals/builders/projections>` builders.
    The code example performs the following actions:
 
    #. Creates a text index for your
@@ -315,21 +318,18 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 
    .. code-block:: java
    
-      import static com.mongodb.client.model.Sorts;
-      import static com.mongodb.client.model.Projections;
+      import com.mongodb.client.model.Sorts;
+      import com.mongodb.client.model.Projections;
       import com.mongodb.client.model.Filters;
       import com.mongodb.client.model.Indexes;
 
       // <MongoCollection setup code here>
       
-      // create your text index on the food field
       collection.createIndex(Indexes.text("food"));
       Bson metaTextScoreSort = Sorts.metaTextScore("score");
       Bson metaTextScoreProj = Projections.metaTextScore("score");
       String searchTerm = "maple donut";
-      // build your $text query operator
       Bson searchQuery = Filters.text(searchTerm);
-      // projection optional in MongoDB 4.4 or later
       collection.find(searchQuery)
               .projection(metaTextScoreProj)
               .sort(metaTextScoreSort)

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -310,10 +310,10 @@ and use ``Sorts.metaTextScore()``.
       :ref:`sort_example collection <sorts-builders-sort-example>`
       on the ``food`` field.
    #. Run a text search for the phrase "maple donut".
-   #. Project ``Projections.metaTextScore()`` into your query results as the
+   #. Project ``Projections.metaTextScore()`` into the query results as the
       ``score`` field. This step is optional if your MongoDB instance is
       running MongoDB 4.4 or later. 
-   #. Sort using ``Sorts.metaTextScore()`` as your sort criteria.
+   #. Sort using ``Sorts.metaTextScore()`` as the sort criteria.
 
    .. code-block:: java
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -25,11 +25,13 @@ examples of sort criteria are:
 * Earliest time of day to latest time of day
 * Alphabetical order by first name 
 
-Builders are classes provided by the MongoDB Java driver that allow you to use
-the builder pattern to interact with your MongoDB instance. The builder
-pattern allows you to create complex immutable objects separately from
-their representation. The :doc:`builders </fundamentals/builders/>`
-provided by the MongoDB Java driver can improve the readability of your code.
+The builder pattern allows you to create complex immutable objects
+separately from their representation. :doc:`Builders </fundamentals/builders/>` 
+are classes provided by the MongoDB Java driver that allow you to use
+the builder pattern to construct
+:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects.
+The builders provided by the MongoDB Java driver can improve the
+readability of your code.
 
 You should read this guide if you would like to:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -301,19 +301,19 @@ and use ``Sorts.metaTextScore()``.
 
 .. example::
 
-   In the following code example, we show how to use the
+   In the following code example, we show how you can use the
    ``Sorts.metaTextScore()`` method to sort the results of a text
    search on the :ref:`sort_example collection <sorts-builders-sort-example>`.
-   The following code snippet works as follows:
+   The code example performs the following actions:
 
-   #. Create a text index for the
+   #. Creates a text index for your
       :ref:`sort_example collection <sorts-builders-sort-example>`
       on the ``food`` field.
-   #. Run a text search for the phrase "maple donut".
-   #. Project ``Projections.metaTextScore()`` into the query results as the
-      ``score`` field. This step is optional if your MongoDB instance is
+   #. Runs your text search for the phrase "maple donut".
+   #. Projects ``Projections.metaTextScore()`` into your query results as the
+      ``score`` field. This projection is optional if your MongoDB instance is
       running MongoDB 4.4 or later. 
-   #. Sort using ``Sorts.metaTextScore()`` as the sort criteria.
+   #. Sorts using ``Sorts.metaTextScore()`` as your sort criteria.
 
    .. code-block:: java
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -256,12 +256,13 @@ in the following order:
 Text Search
 -----------
 
-If you perform a text search on your collection with the
-:manual:`$text </reference/operator/query/text/>` query operator, you 
-can sort your results by how well they match your ``$search`` String using
-:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`. 
-To sort your search results by the text scores associated with your text
-search, use the ``Sorts.metaTextScore()`` static factory method. 
+You can specify the order of the results of a text search performed with the
+:manual:`$text </reference/operator/query/text/>` query operator
+by how closely they match your search string. Each of your search results has a
+:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`, a
+numerical value indicating how well that result matches your search. 
+Use the ``Sorts.metaTextScore()`` method to build your sort criteria to sort by
+the text score.
 
 .. warning:: Make Sure to Create a Text Index
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -265,10 +265,10 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 
 .. warning:: Make Sure to Create a Text Index
 
-   The ``$text`` query operator performs a text search on the content indexed 
-   by the :manual:`text index </core/index-text/>` of your collection.
-   Therefore, you must create a text index on your collection before you
-   can run a text search and use ``Sorts.metaTextScore()``.
+   Text searches require a :manual:`text index </core/index-text/>` to locate
+   and score your results. See the server manual documentation for more
+   information on how to
+   :manual:`create a text index </core/index-text/#create-text-index>`.
 
 .. example::
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -330,7 +330,7 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.
-For more information on the :manual:`$text </reference/operator/query/text/>`
+See the server manual documentation for more information on the :manual:`$text </reference/operator/query/text/>`
 query operator and the
 :manual:`$meta </reference/operator/aggregation/meta/>`
-aggregation pipeline operator, see the related server manual documentation.
+aggregation pipeline operator.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -191,7 +191,7 @@ document returned could be any of the following documents:
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
 
 If you need guaranteed sort order for documents that
-have fields with identical values you can specify additional fields to sort
+have fields with identical values, you can specify additional fields to sort
 on in the event of a tie.
 
 We can specify an ascending sort on the ``letter`` field followed by the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -75,25 +75,25 @@ sample collection, ``sort_example``, that contains the following documents:
 Sorting Direction
 -----------------
 
-The ``Sorts`` class provides two methods for specify sort direction.
-You can sort your data in **ascending** order, from smallest to largest, with
-``Sorts.ascending()``. Here are some examples of data sorted in ascending
-order:
+The ``Sorts`` class provides methods for specifying the direction of your sort.
+The direction of your sort can either be **ascending**, or **descending**.
+An ascending sort orders your data from smallest to largest. A
+descending sort orders your data from largest to smallest.
+
+Here are some examples of data sorted in ascending order:
 
 * Numbers: 1, 2, 3, 43, 43, 55, 120
 * Dates: 1990-03-10, 1995-01-01, 2005-10-30, 2005-12-21 
 * Words (Alphabetical): carrot, cheese, cucumber, hummus
 
-You can sort your data in **descending** order, from largest to smallest, with
-``Sorts.descending()``. Here are some examples of data sorted in descending
-order:
+Here are some examples of data sorted in descending order:
 
 * Numbers: 100, 30, 12, 12, 9, 3, 1
 * Dates: 2020-01-01, 1998-12-11, 1998-12-10, 1900-07-22 
 * Words (Alphabetical): pear, mango, grapes, apple
 
-The following subsections provide examples showing how to specify these
-sorts.
+The following subsections show how to specify these sorts using
+the ``Sorts`` class.
 
 Ascending
 ~~~~~~~~~

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -134,7 +134,7 @@ by the ``_id`` field:
          System.out.println(result.toJson());
    }
 
-The output of the code snippet above should look something like this: 
+The output of the code example above should look something like this: 
 
 .. code-block:: json
 
@@ -317,7 +317,7 @@ The code example performs the following actions:
          System.out.println(result.toJson());
    }
 
-The output of the code snippet above should look something like this: 
+The output of the code example above should look something like this: 
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -280,15 +280,14 @@ in the following order:
 Text Score
 ----------
 
-If you are using the :manual:`$text </reference/operator/query/text/>`
-query operator to perform text searches on your collections of data you
-can sort the results of those text searches by
-:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`
-(how well your search matched each returned document). To sort your search
-results by the text score associated with your text search so the best match
-is returned first, use the ``Sorts.metaTextScore()`` static factory method. Note
-that the ``$text`` query operator performs a text search on the content indexed
-by the :manual:`text index </core/index-text/>` of your collection. You must
+If you perform a text search on your collection with the
+:manual:`$text </reference/operator/query/text/>` query operator, you 
+can sort your results by how well they match your ``$search`` string using
+:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`. 
+To sort your search results by the text scores associated with your text
+search, use the ``Sorts.metaTextScore()`` static factory method. Note
+that the ``$text`` query operator performs a text search on the content indexed 
+by the :manual:`text index </core/index-text/>`of your collection. You must
 create a text index on your collection before you can run a text search
 and use ``Sorts.metaTextScore()``.
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -291,6 +291,8 @@ by the :manual:`text index </core/index-text/>`of your collection. You must
 create a text index on your collection before you can run a text search
 and use ``Sorts.metaTextScore()``.
 
+.. _sorts-builders-mongo-server-note:
+
 .. note::
 
   If your MongoDB instance is running MongoDB 4.2 and earlier, in order

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -135,8 +135,10 @@ to largest on the specified field name.
    
 Note that MongoDB does not guarantee sort order for documents that have
 fields with identical values. This means that if you pass "letter" to
-the ``ascending()`` method, the first document returned could be any
-of the following documents:
+the ``ascending()`` method and use the returned sort criteria to sort
+the documents in the
+:ref:`sort_example collection <sorts-builders-sort-example>`, the first
+document returned could be any of the following documents:
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -297,18 +297,6 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
    Therefore, you must create a text index on your collection before you
    can run a text search and use ``Sorts.metaTextScore()``.
 
-.. _sorts-builders-mongo-server-note:
-
-.. note::
-
-  If your MongoDB instance is running MongoDB 4.2 and earlier, in order
-  to use ``Sorts.metaTextScore()`` as sort criteria in the ``sort()``
-  method of a ``FindIterable`` instance, you must also include
-  ``Projections.metaTextScore()`` in the ``projection()`` method of that
-  ``FindIterable`` instance. In addition, the String field names passed to 
-  ``Projections.metaTextScore()`` and ``Sorts.metaTextScore()`` must be
-  identical. This is demonstrated in the code example below.
-
 .. example::
 
    In the following code example, we show how you can use the
@@ -358,11 +346,13 @@ search, use the ``Sorts.metaTextScore()`` static factory method.
       {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
       {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
-.. note::
+.. note:: MongoDB 4.4 ``$meta`` Behavior
 
-  As of MongoDB 4.4, the field name of a ``$meta`` text score
-  aggregation operation used in a sort is disregarded by the query system.
-  This means that the String field name argument passed to
+  As of MongoDB 4.4, projecting ``Projections.metaTextScore()`` into
+  your ``FindIterable`` instance is not necessary to sort on
+  ``Sorts.metaTextScore()``. In addition, the field name of a ``$meta``
+  text score aggregation operation used in a sort is disregarded by the
+  query system. This means that the String field name argument passed to
   ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4 and later.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -333,10 +333,10 @@ criteria to sort by the text score.
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
   into your ``FindIterable`` instance is not necessary to sort on the text
-  score. In addition, the field name you specify in a ``$meta`` text score
-  aggregation operation used in a sort is disregarded by the query system. This
-  means that the field name argument you pass to ``Sorts.metaTextScore()`` is
-  ignored in MongoDB 4.4 and later.
+  score. In addition, MongoDB 4.4 or later disregards the field name you specify
+  in a ``$meta`` text score aggregation operation used in a sort. This means
+  that the field name argument you pass to ``Sorts.metaTextScore()`` is ignored
+  in MongoDB 4.4 or later.
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -350,9 +350,9 @@ and use ``Sorts.metaTextScore()``.
       {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
       {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
-For additional information on the ``Sorts`` class, see the 
+For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.
-For additional information on the ``$text`` query operator and the
-``$meta`` aggregation pipeline operator, see the server manual
-documentation for :manual:`$text </reference/operator/query/text/>` and
-:manual:`$meta </reference/operator/aggregation/meta/>`.
+For more information on the :manual:`$text </reference/operator/query/text/>`
+query operator and the
+:manual:`$meta </reference/operator/aggregation/meta/>`
+aggregation pipeline operator, see the related server manual documentation.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -27,9 +27,8 @@ examples of sort criteria are:
 
 :doc:`Builders </fundamentals/builders/>` are classes provided by the MongoDB
 Java driver that help you construct complex 
-:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects. The
-builders provided by the MongoDB Java driver can improve the readability of your
-code.
+:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects. 
+Builders can improve the readability of your code.
 
 You should read this guide if you would like to:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -348,6 +348,17 @@ and use ``Sorts.metaTextScore()``.
       {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
       {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
+.. note::
+
+  As of MongoDB 4.4, the field name of a ``$meta`` text score
+  aggregation operation used in a sort is disregarded by the query system. 
+  In MongoDB 4.2 and earlier however, the field name of a ``$meta`` text score
+  used in a sort must match the field name of a ``$meta`` text score used
+  in the proceeding projection. This means that the String field name
+  argument passed to ``Sorts.metaTextScore()`` is ignored in MongoDB 4.4
+  and later, but must match the String field name argument passed to
+  ``Projections.metaTextScore()``in MongoDB 4.2 and earlier.
+
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.
 For more information on the :manual:`$text </reference/operator/query/text/>`


### PR DESCRIPTION
## Pull Request Info
Create the Fundamentals > Builders > Sorts Page

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-9585

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/91154a2/java/docsworker-xlarge/DOCSP-9585-Fundamentals-Builders-Sort-Criteria/fundamentals/builders/sort/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?

Snooty Log Contains following Error which seems to be present on other branches as well. Possibly misreading build log but documenting here to check to discuss:
`ERROR(fundamentals/aggregation.txt:94ish): Target not found: "label:builders"
Closing connection...`

- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

