### PR TITLE
DOCSP-13806: add note about $uuid parsing in extended json

### DIFF
--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -73,8 +73,8 @@ See the table below to see a description of each format:
 .. note::
 
    The ``$uuid`` Extended JSON type is parsed from a string to a
-   :java-docs:`BsonObject </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
-   of binary subtype 4. For a further discussion of ``$uuid`` field
+   :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
+   object of binary subtype 4. For a further discussion of ``$uuid`` field
    parsing, see the
    :spec:`Special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`
    section in the extended JSON specification.

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -76,7 +76,7 @@ See the table below to see a description of each format:
    :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
    object of binary subtype 4. For a further discussion of ``$uuid`` field
    parsing, see the
-   :spec:`Special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`
+   :spec:`special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`
    section in the extended JSON specification.
    
 

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -72,9 +72,9 @@ See the table below to see a description of each format:
 
 .. note::
 
-   The ``$uuid`` Extended JSON type is parsed from a string to a
+   The ``$uuid`` Extended JSON type is parsed from a String to a
    :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
-   object of binary subtype 4. For a further discussion of ``$uuid`` field
+   object of binary subtype 4. For more information about ``$uuid`` field
    parsing, see the
    :spec:`special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`
    section in the extended JSON specification.

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -70,6 +70,16 @@ See the table below to see a description of each format:
 
 .. _extended_json_example_section:
 
+.. note::
+
+   The ``$uuid`` Extended JSON type is parsed from a string to a
+   :java-docs:`BsonObject </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
+   of binary subtype 4. For a further discussion of ``$uuid`` field
+   parsing, see the
+   :spec:`Special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`
+   section in the extended JSON specification.
+   
+
 For more detailed information on these formats, see the
 `Extended JSON specification <https://github.com/mongodb/specifications/blob/master/source/extended-json.rst>`__.
 


### PR DESCRIPTION
## Pull Request Info
Adds note about `$uuid` extended json type parsing.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13806

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/a0e24f5/java/docsworker-xlarge/DOCSP-13806/fundamentals/data-formats/document-data-format-extended-json/#extended-json-formats

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

