### PR TITLE
DOCSP-15135 crud read sort update

### DIFF
--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -47,7 +47,7 @@ driver, consider reading our
 The Sorts Class
 ---------------
 
-``Sorts`` class is a builder that provides static factory methods for all sort
+The ``Sorts`` class is a builder that provides static factory methods for all sort
 criteria operators supported by MongoDB. These methods return a ``Bson`` object
 that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to 
 ``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
@@ -170,7 +170,7 @@ Text Score
 
 To specify a sort by the text score of a text search, use the
 ``Sorts.metaTextScore()`` static factory method. For a detailed usage example
-showing how to specify a sort using ``Sorts.metaTextScore()``, see 
+showing how to specify sort criteria using ``Sorts.metaTextScore()``, see 
 :ref:`the text search section of our sorting fundamentals guide <sorts-crud-text-search>`.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -39,9 +39,9 @@ driver, consider reading our
 
 .. warning::
 
-   MongoDB does not provide guaranteed sort order in the event of ties, or
-   documents with identical values in the field used for sorting. For a detailed
-   discussion of ties see the
+   MongoDB does not provide guaranteed sort order in the event of **ties**. A
+   tie occurs when two or more documents contain identical values in the
+   field being used for a sort. For a detailed discussion of ties see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`
 
 The Sorts Class

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -198,9 +198,11 @@ The output of the example above should look something like this:
 Text Score
 ----------
 
-To specify a sort by the text score of a text search, use the
-``Sorts.metaTextScore()`` static factory method. For a detailed usage example
-showing how to specify sort criteria using ``Sorts.metaTextScore()``, see 
+You can sort text search results by their text score, a value that indicates how
+closely a search result matches your search string. To specify a sort by the
+text score of a text search, use the ``Sorts.metaTextScore()`` static factory
+method. For a detailed example showing how to specify sort criteria using
+the ``Sorts.metaTextScore()`` method, see 
 :ref:`the text search section of our sorting fundamentals guide <sorts-crud-text-search>`.
 
 For more information, see the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -86,7 +86,7 @@ The following two code snippets are equivalent. However, we recommend you use th
    // Not Recommended
    collection.find().sort(new Document("_id", 1));
 
-The code snippets above both sort the documents in the
+Both code snippets above sort the documents in the
 :ref:`sort_example collection <sorts-crud-sort-example>`  
 in the following order: 
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -132,8 +132,8 @@ The output of the example above should look something like this:
    {"_id": 4, "letter": "b", "food": "coffee with sugar"}
    ...
 
-Combining Criteria
-------------------
+Combining Sort Criteria
+-----------------------
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
 method. The ``orderBy()`` method builds sort criteria that apply passed 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -123,10 +123,7 @@ on the ``_id`` field:
    
    collection.find().sort(descending("_id"));
 
-
-The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-builders-sort-example>`  
-in the following order: 
+The output of the example above should look something like this: 
 
 .. code-block:: json
 
@@ -142,9 +139,9 @@ To combine sort criteria, use the ``Sorts.orderBy()`` static factory
 method. The ``orderBy()`` method builds sort criteria that apply passed 
 in sort criteria from left to right in the event of ties.
 
-In the following code snippet, we use the ``orderBy()`` method to combine a
-descending sort on the ``letter`` field with an ascending sort on the
-``_id`` field.
+The following example sorts the documents in the 
+:ref:`sort_example collection <sorts-builders-sort-example>` in descending order
+on the ``letter`` field and ascending order on the ``_id`` field:
 
 .. code-block:: java
 
@@ -157,9 +154,7 @@ descending sort on the ``letter`` field with an ascending sort on the
    Bson orderBySort = orderBy(descending("letter"), ascending("_id"));
    collection.find().sort(orderBySort);
 
-The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-builders-sort-example>`
-in the following order: 
+The output of the example above should look something like this: 
 
 .. code-block:: json
 
@@ -170,13 +165,13 @@ in the following order:
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
 
-Meta Text Score
----------------
+Text Score
+----------
 
 To specify a sort by the text score of a text search, use the
-``Sorts.metaTextScore()`` static factory method. For a detailed example of
-specifying a sort using ``Sorts.metaTextScore()``, see 
-:ref:`the text search section of our sorting fundamentals guide <sorts-crud-text-search>`
+``Sorts.metaTextScore()`` static factory method. For a detailed usage example
+showing how to specify a sort using ``Sorts.metaTextScore()``, see 
+:ref:`the text search section of our sorting fundamentals guide <sorts-crud-text-search>`.
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -171,7 +171,8 @@ in sort criteria from left to right in the event of ties.
 
 The following example sorts the documents in the 
 :ref:`sort_example collection <sorts-builders-sort-example>` in descending order
-on the ``letter`` field and ascending order on the ``_id`` field:
+on the ``letter`` field, and in the event of a tie, ascending order on the
+``_id`` field:
 
 .. code-block:: java
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -84,7 +84,7 @@ The following two code snippets are equivalent, however we recommend you use the
    // <MongoCollection setup code here>
    
    //Not Recommended
-   collection.find().sort(new Document("_id", 1)));
+   collection.find().sort(new Document("_id", 1));
 
 The code snippets above both sort the documents in the
 :ref:`sort_example collection <sorts-crud-sort-example>`  

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -76,7 +76,7 @@ The following two code snippets are equivalent, however we recommend you use the
 
    // <MongoCollection setup code here>
    
-   //Recommended
+   // Recommended
    collection.find().sort(ascending("_id"));
 
 .. code-block:: java

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -60,36 +60,6 @@ that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to
 class, see our 
 :doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
 
-The following two code snippets are equivalent. However, we recommend you use the
-``Sorts`` builder to specify your sort criteria:
-
-.. code-block:: java
-
-   import static com.mongodb.client.model.Sorts.ascending;
-
-   // <MongoCollection setup code here>
-   
-   // Recommended
-   collection.find().sort(ascending("_id"));
-
-.. code-block:: java
-
-   // <MongoCollection setup code here>
-   
-   // Not Recommended
-   collection.find().sort(new Document("_id", 1));
-
-Both code snippets above sort the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>`  
-in the following order: 
-   
-.. code-block:: json
-
-   {"_id": 1, "letter": "c", "food": "coffee with milk"}
-   {"_id": 2, "letter": "a", "food": "donuts and coffee"}
-   {"_id": 3, "letter": "a", "food": "maple syrup"}
-   ...
-
 For more information about the classes and interfaces in this section, see the
 following API documentation:
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -65,7 +65,8 @@ The Sorts Class
 The ``Sorts`` class is a builder that provides static factory methods for all sort
 criteria operators supported by MongoDB. These methods return a ``Bson`` object
 that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to 
-``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
+``Aggregates.sort()``. If you want to learn more about the ``Aggregates``
+class, see our 
 :doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
 
 The following two code snippets are equivalent. However, we recommend you use the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -36,14 +36,6 @@ If you want to learn the fundamentals of sorting in the MongoDB Java
 driver, consider reading our
 :doc:`guide on sorting </fundamentals/crud/read-operations/sort/>`.
 
-.. warning::
-
-   MongoDB does not guarantee sort order in the event of **ties**. A
-   tie occurs when two or more documents contain identical values in the
-   field being used to order your results. For a detailed discussion of ties, 
-   see the
-   :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`.
-
 .. _sorts-builders-sort-example:
 
 The examples on this page use a sample collection, ``sort_example``, that

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -128,8 +128,9 @@ Combining Sort Criteria
 -----------------------
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
-method. The ``orderBy()`` method builds sort criteria that apply passed 
-in sort criteria from left to right in the event of ties.
+method. This method constructs an object containing an ordered list of sort
+criteria. When performing the sort, if the leftmost sort criteria results in a
+tie, the sort uses the next sort criteria in the list to determine the order.
 
 The following example sorts the documents in the 
 :ref:`sample collection <sorts-builders-sort-sample>` in descending order

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -36,9 +36,9 @@ If you want to learn the fundamentals of sorting in the MongoDB Java
 driver, consider reading our
 :doc:`guide on sorting </fundamentals/crud/read-operations/sort/>`.
 
-.. _sorts-builders-sort-example:
+.. _sorts-builders-sort-sample:
 
-The examples on this page use a sample collection, ``sort_example``, that
+The examples on this page use a sample collection that
 contains the following documents:
 
 .. code-block:: json
@@ -77,7 +77,7 @@ factory method. Pass ``Sorts.ascending()``
 the name of the field you need to sort on.
 
 The following example sorts the documents in the 
-:ref:`sort_example collection <sorts-builders-sort-example>` by ascending order
+:ref:`sample collection <sorts-builders-sort-sample>` by ascending order
 on the ``_id`` field:
 
 .. code-block:: java
@@ -104,7 +104,7 @@ To specify a descending sort, use the ``Sorts.descending()`` static factory
 method. Pass ``Sorts.descending()`` the name of the field you need to sort on.
 
 The following example sorts the documents in the 
-:ref:`sort_example collection <sorts-builders-sort-example>` in descending order
+:ref:`sample collection <sorts-builders-sort-sample>` in descending order
 on the ``_id`` field:
 
 .. code-block:: java
@@ -132,7 +132,7 @@ method. The ``orderBy()`` method builds sort criteria that apply passed
 in sort criteria from left to right in the event of ties.
 
 The following example sorts the documents in the 
-:ref:`sort_example collection <sorts-builders-sort-example>` in descending order
+:ref:`sample collection <sorts-builders-sort-sample>` in descending order
 on the ``letter`` field, and in the event of a tie, ascending order on the
 ``_id`` field:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -39,7 +39,7 @@ driver, consider reading our
 
 .. warning::
 
-   MongoDB does not provide guaranteed sort order in the event of **ties**. A
+   MongoDB does not guarantee sort order in the event of **ties**. A
    tie occurs when two or more documents contain identical values in the
    field being used for a sort. For a detailed discussion of ties see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -67,7 +67,7 @@ that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to
 ``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
 :doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
 
-The following two code snippets are equivalent, however we recommend you use the
+The following two code snippets are equivalent. However, we recommend you use the
 ``Sorts`` builder to specify your sort criteria:
 
 .. code-block:: java

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -41,7 +41,7 @@ driver, consider reading our
 
    MongoDB does not guarantee sort order in the event of **ties**. A
    tie occurs when two or more documents contain identical values in the
-   field being used for a sort. For a detailed discussion of ties see the
+   field being used for a sort. For a detailed discussion of ties, see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`.
 
 .. _sorts-builders-sort-example:

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -44,20 +44,10 @@ driver, consider reading our
    field being used for a sort. For a detailed discussion of ties see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`
 
-The Sorts Class
----------------
-
-The ``Sorts`` class is a builder that provides static factory methods for all sort
-criteria operators supported by MongoDB. These methods return a ``Bson`` object
-that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to 
-``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
-:doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
-
 .. _sorts-builders-sort-example:
 
-The following examples show you how to use the methods
-provided by the ``Sorts`` class to sort your queries. The examples use a
-sample collection, ``sort_example``, that contains the following documents:
+The examples on this page use a sample collection, ``sort_example``, that
+contains the following documents:
 
 .. code-block:: json
 
@@ -67,6 +57,15 @@ sample collection, ``sort_example``, that contains the following documents:
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
    {"_id": 6, "letter": "c", "food": "maple donut"}
+
+The Sorts Class
+---------------
+
+The ``Sorts`` class is a builder that provides static factory methods for all sort
+criteria operators supported by MongoDB. These methods return a ``Bson`` object
+that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to 
+``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
+:doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
 
 For more information about the classes and interfaces in this section, see the
 following API documentation:

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -67,6 +67,36 @@ that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to
 ``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
 :doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
 
+The following two code snippets are equivalent, however we recommend you use the
+``Sorts`` builder to specify your sort criteria:
+
+.. code-block:: java
+
+   import static com.mongodb.client.model.Sorts.ascending;
+
+   // <MongoCollection setup code here>
+   
+   //Recommended
+   collection.find().sort(ascending("_id"));
+
+.. code-block:: java
+
+   // <MongoCollection setup code here>
+   
+   //Not Recommended
+   collection.find().sort(new Document("_id", 1)));
+
+The code snippets above both sort the documents in the
+:ref:`sort_example collection <sorts-crud-sort-example>`  
+in the following order: 
+   
+.. code-block:: json
+
+   {"_id": 1, "letter": "c", "food": "coffee with milk"}
+   {"_id": 2, "letter": "a", "food": "donuts and coffee"}
+   {"_id": 3, "letter": "a", "food": "maple syrup"}
+   ...
+
 For more information about the classes and interfaces in this section, see the
 following API documentation:
    

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -83,7 +83,7 @@ The following two code snippets are equivalent, however we recommend you use the
 
    // <MongoCollection setup code here>
    
-   //Not Recommended
+   // Not Recommended
    collection.find().sort(new Document("_id", 1));
 
 The code snippets above both sort the documents in the

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -152,7 +152,7 @@ on the ``_id`` field:
    
    collection.find().sort(descending("_id"));
 
-The output of the example above should look something like this: 
+The above example should output something like this: 
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -42,7 +42,7 @@ driver, consider reading our
    MongoDB does not provide guaranteed sort order in the event of **ties**. A
    tie occurs when two or more documents contain identical values in the
    field being used for a sort. For a detailed discussion of ties see the
-   :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`
+   :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`.
 
 .. _sorts-builders-sort-example:
 

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -40,24 +40,18 @@ driver, consider reading our
 .. warning::
 
    MongoDB does not provide guaranteed sort order in the event of ties, or
-   documents with identical values on the field being sorted. For a detailed
+   documents with identical values in the field used for sorting. For a detailed
    discussion of ties see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`
 
 The Sorts Class
 ---------------
 
-The :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
-class is a builder that provides static factory methods for all sort criteria
-operators supported by MongoDB. These methods return a
-:java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
-object that you can pass to the 
-:java-docs:`sort() </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#sort(org.bson.conversions.Bson)>`
-method of a ``FindIterable`` instance or to 
-:java-docs:`Aggregates.sort() </apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#sort(org.bson.conversions.Bson)>`.
-If you want to learn more about ``Aggregates``, see our 
+``Sorts`` class is a builder that provides static factory methods for all sort
+criteria operators supported by MongoDB. These methods return a ``Bson`` object
+that you can pass to the  ``sort()`` method of a ``FindIterable`` instance or to 
+``Aggregates.sort()``. If you want to learn more about ``Aggregates``, see our 
 :doc:`guide on the Aggregates builder </fundamentals/builders/aggregates>`.
-
 
 .. _sorts-builders-sort-example:
 
@@ -73,6 +67,15 @@ sample collection, ``sort_example``, that contains the following documents:
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
    {"_id": 6, "letter": "c", "food": "maple donut"}
+
+For more information about the classes and interfaces in this section, see the
+following API documentation:
+   
+- :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>` 
+- :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
+- :java-docs:`FindIterable </apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>`
+- :java-docs:`Aggregates </apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`.
+
 
 Ascending
 ---------

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -37,6 +37,13 @@ If you want to learn the fundamentals of sorting in the MongoDB Java
 driver, consider reading our
 :doc:`guide on sorting </fundamentals/crud/read-operations/sort/>`.
 
+.. warning::
+
+   MongoDB does not provide guaranteed sort order in the event of ties, or
+   documents with identical values on the field being sorted. For a detailed
+   discussion of ties see the
+   :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`
+
 The Sorts Class
 ---------------
 
@@ -130,7 +137,7 @@ Combining Criteria
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
 method. The ``orderBy()`` method builds sort criteria that apply passed 
-in sort criteria from left to right in the event of ties. 
+in sort criteria from left to right in the event of ties.
 
 In the following code snippet, we use the ``orderBy()`` method to combine a
 descending sort on the ``letter`` field with an ascending sort on the
@@ -165,8 +172,8 @@ Meta Text Score
 
 To specify a sort by the text score of a text search, use the
 ``Sorts.metaTextScore()`` static factory method. For a detailed example of
-specifying a sort using ``Sorts.metaTextScore()``, see our 
-:doc:`sorting fundamentals guide </fundamentals/crud/read-operations/sort/#text-search>`.
+specifying a sort using ``Sorts.metaTextScore()``, see 
+:ref:`the text search section of our sorting fundamentals guide <sorts-crud-text-search>`
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -41,7 +41,8 @@ driver, consider reading our
 
    MongoDB does not guarantee sort order in the event of **ties**. A
    tie occurs when two or more documents contain identical values in the
-   field being used for a sort. For a detailed discussion of ties, see the
+   field being used to order your results. For a detailed discussion of ties, 
+   see the
    :ref:`handling ties section of our guide on sorting <sorts-crud-handling-ties>`.
 
 .. _sorts-builders-sort-example:

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -29,9 +29,8 @@ Builders are classes provided by the MongoDB Java driver that help you construct
 :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` objects. 
 To learn more, see our :doc:`guide on builders </fundamentals/builders/>`.
 
-You should read this guide if you would like to:
-
-* Use builders to specify sort criteria for your queries.
+You should read this guide if you would like to use builders to specify sort
+criteria for your queries.
 
 If you want to learn the fundamentals of sorting in the MongoDB Java
 driver, consider reading our

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -220,8 +220,9 @@ code:
    
    collection.find().sort(ascending("letter"));
 
-Since multiple documents contain the value "a" for the field on which we perform the sort,
-the following documents could be returned in any order:
+Since multiple documents that matched our query contain the value "a" for the
+field on which we perform the sort, the following documents could be returned
+in any order:
 
 .. code-block:: json
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -230,9 +230,9 @@ document returned could be any of the following documents:
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
 
-If you need guaranteed sort order for documents that
-have fields with identical values, you can specify additional fields to sort
-on in the event of a tie.
+If you need to guarantee a specific sort order for documents that have fields
+with identical values, you can specify additional fields to sort on in the event
+of a tie.
 
 We can specify an ascending sort on the ``letter`` field followed by the
 ``_id`` field as follows:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -262,8 +262,9 @@ Combining Sort Criteria
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
-method. The ``orderBy()`` method builds sort criteria that apply passed 
-in sort criteria from left to right in the event of ties. 
+method. This method constructs an object containing an ordered list of sort criteria. 
+When performing the sort, if the leftmost sort criteria results in a tie, the sort uses the
+next sort criteria in the list to determine the order.
 
 In the following code snippet, we use the ``orderBy()`` method to combine a
 descending sort on the ``letter`` field with an ascending sort on the

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -302,7 +302,7 @@ Text Search
 You can specify the order of the results of a 
 :manual:`text search </text-search/>` by how closely they match your
 search string. Each of your search results has a
-:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>`, a
+:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` which is a
 numerical value indicating how well that result matches your search. 
 Use the ``Sorts.metaTextScore()`` static factory method to build your sort
 criteria to sort by the text score.

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -31,10 +31,10 @@ You should read this guide if you would like to:
 * Sort on the text score of a
   :manual:`text search </core/text-search-operators/>`.
 
-.. _sorts-crud-sort-example:
+.. _sorts-crud-sort-sample:
 
-The examples in this guide use a sample collection, ``sort_example``, that
-contains the following documents:
+The examples in this guide use a sample collection that contains the following
+documents:
   
 .. code-block:: json
   
@@ -79,7 +79,7 @@ as follows:
    collection.aggregate(Arrays.asList(Aggregates.sort(ascending("_id"))));
 
 The code snippets above both sort the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>` from smallest to
+:ref:`sample collection <sorts-crud-sort-sample>` from smallest to
 largest value of the ``_id`` field: 
 
 .. code-block:: json
@@ -148,7 +148,7 @@ documents in your collection, sorted from smallest to largest on the specified
 field name. 
 
 In the following code example, we use the ``ascending()`` method to sort the
-:ref:`sort_example collection <sorts-crud-sort-example>`  
+:ref:`sample collection <sorts-crud-sort-sample>`  
 by the ``_id`` field:
 
 .. code-block:: java
@@ -191,7 +191,7 @@ The following code snippet shows how to specify a descending sort on the
 
 
 The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>`  
+:ref:`sample collection <sorts-crud-sort-sample>`  
 in descending order: 
 
 .. code-block:: json
@@ -209,7 +209,7 @@ Handling Ties
 A tie occurs when two or more documents have a field with identical values.
 MongoDB does not guarantee sort order in the event of ties. For example, suppose
 we encounter a tie when applying a sort to the
-:ref:`sort_example collection <sorts-crud-sort-example>` using the following
+:ref:`sample collection <sorts-crud-sort-sample>` using the following
 code:
 
 .. code-block:: java
@@ -245,7 +245,7 @@ We can specify an ascending sort on the ``letter`` field followed by the
    collection.find().sort(ascending("letter", "_id"));
 
 The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>`  
+:ref:`sample collection <sorts-crud-sort-sample>`  
 in the following order: 
 
 .. code-block:: json
@@ -281,7 +281,7 @@ descending sort on the ``letter`` field with an ascending sort on the
    collection.find().sort(orderBySort);
 
 The code snippet above returns the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>`
+:ref:`sample collection <sorts-crud-sort-sample>`
 in the following order: 
 
 .. code-block:: json
@@ -315,14 +315,14 @@ criteria to sort by the text score.
 
 In the following code example, we show how you can use the
 ``Sorts.metaTextScore()`` method to sort the results of a text
-search on the :ref:`sort_example collection <sorts-crud-sort-example>`.
+search on the :ref:`sample collection <sorts-crud-sort-sample>`.
 The code example uses the :doc:`Filters </fundamentals/builders/filters>`,
 :doc:`Indexes </fundamentals/builders/indexes>`, and
 :doc:`Projections </fundamentals/builders/projections>` builders.
 The code example performs the following actions:
 
 #. Creates a text index for your
-   :ref:`sort_example collection <sorts-crud-sort-example>`
+   :ref:`sample collection <sorts-crud-sort-sample>`
    on the ``food`` field. If you call ``createIndex()`` specifying an index that
    already exists on the collection, the operation does not create a new index.
 #. Runs your text search for the phrase "maple donut".

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -364,13 +364,12 @@ The output of the code example above should look something like this:
 
 .. note:: ``$meta`` Behavior in MongoDB 4.4 or Later
 
-  When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
-  into your ``FindIterable`` instance is not necessary to sort on the text
-  score. 
-  
-  In addition, MongoDB 4.4 or later disregards the field name you specify
-  in a ``$meta`` text score aggregation operation used in a sort. This means
-  that the field name argument you pass to ``Sorts.metaTextScore()`` is ignored.
+  If you are using MongoDB 4.4 or later, projecting
+  ``Projections.metaTextScore()`` into your ``FindIterable`` instance is not
+  necessary to sort on the text score. In addition, MongoDB 4.4 or later
+  disregards the field name you specify in a ``$meta`` text score aggregation
+  operation used in a sort. This means that the field name argument you pass to
+  ``Sorts.metaTextScore()`` is ignored.
 
 For more information about the classes in this section, see the
 following API documentation:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -144,9 +144,9 @@ method to specify an ascending sort on a field as follows:
 
    collection.find().sort(ascending("<field name>"));
 
-The above ``sort()`` method returns a ``FindIterable`` object containing the
-documents in your collection, sorted from smallest to largest on the specified
-field name. 
+The above ``sort()`` method returns a ``FindIterable`` object that can iterate
+over the documents in your collection, sorted from smallest to largest on the
+specified field name. 
 
 In the following code example, we use the ``ascending()`` method to sort the
 :ref:`sample collection <sorts-crud-sort-sample>`  

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -86,9 +86,9 @@ in the following order:
    ...
 
 In the above code snippets, we specify our sort criteria by passing a
-``Document`` object to our sort method. While this will run without errors, we
-recommend that you instead specify sort criteria through the ``Sorts`` builder
-class. 
+``Document`` object (which implements the ``Bson`` interface) to our sort
+method. While this will run without errors, we recommend that you instead
+specify sort criteria through the ``Sorts`` builder class. 
 
 The following code snippet is equivalent to the
 :ref:`FindIterable example above <sorts-crud-find-iterable-example>`. 
@@ -115,6 +115,7 @@ following API documentation:
 - :java-docs:`Aggregates </apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`
 - :java-docs:`Sorts </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
 - :java-docs:`Bson </apidocs/bson/org/bson/conversions/Bson.html>`
+- :java-docs:`Document </apidocs/bson/org/bson/Document.html>`
 
 Sorting Direction
 -----------------

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -16,7 +16,7 @@ Overview
 In this guide, we show you how to **sort** your results.
 
 Sorting orders the documents returned from your query by your specified 
-**sort criteria**. Sort criteria are the rules you give MongoDB that describe
+**sort criteria**. Sort criteria are the rules you give to MongoDB that describe
 how you would like your data ordered. Some examples of sort criteria are:
 
 * Smallest number to largest number

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -363,7 +363,7 @@ The output of the code example above should look something like this:
    {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
    {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
-.. note:: MongoDB 4.4 or later ``$meta`` Behavior
+.. note:: ``$meta`` Behavior in MongoDB 4.4 or Later
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
   into your ``FindIterable`` instance is not necessary to sort on the text

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -106,7 +106,7 @@ The remainder of this guide will specify sort criteria using the ``Sorts`` class
 For more information on the benefits of using builders, see our
 :doc:`guide on builders </fundamentals/builders/>`. For more information on the
 ``Sorts`` builder class, see our
-:doc:`guide on the Sorts builder </fundamentals/builders/>`.    
+:doc:`guide on the Sorts builder </fundamentals/builders/sort/>`.    
 
 For more information about the classes and interfaces in this section, see the
 following API documentation:
@@ -268,7 +268,7 @@ in the following order:
    {"_id": 6, "letter": "c", "food": "maple donut"}
 
 Combining Sort Criteria
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
 method. The ``orderBy()`` method builds sort criteria that apply passed 
@@ -315,7 +315,8 @@ criteria to sort by the text score.
 
 .. warning:: Make Sure to Create a Text Index
 
-   You need a :manual:`text index </core/index-text/>` on your collection to perform a text search. See the server manual documentation for more
+   You need a :manual:`text index </core/index-text/>` on your collection to
+   perform a text search. See the server manual documentation for more
    information on how to
    :manual:`create a text index </core/index-text/#create-text-index>`.
 
@@ -374,7 +375,14 @@ The output of the code example above should look something like this:
   in a ``$meta`` text score aggregation operation used in a sort. This means
   that the field name argument you pass to ``Sorts.metaTextScore()`` is ignored
   in MongoDB 4.4 or later.
-  
+
+For more information about the classes in this section, see the
+following API documentation:
+
+- :java-docs:`Filters </apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`
+- :java-docs:`Indexes </apidocs/mongodb-driver-core/com/mongodb/client/model/Indexes.html>`
+- :java-docs:`Projections </apidocs/mongodb-driver-core/com/mongodb/client/model/Projections.html>`
+
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.
 See the server manual documentation for more information on the :manual:`$text </reference/operator/query/text/>`

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -133,7 +133,8 @@ To specify an ascending sort, use the ``Sorts.ascending()`` static
 factory method. Pass the ``Sorts.ascending()`` method
 the name of the field you need to sort in ascending order.
 
-The ``ascending()`` method can be used as follows:
+You can use pass the ``sort()`` method the output of the ``Sorts.ascending()``
+method to specify an ascending sort on a field as follows:
 
 .. code-block:: java
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -48,11 +48,11 @@ contains the following documents:
 Methods For Sorting
 -------------------
 
-You can sort your results using the  ``sort()`` method of a ``FindIterable``
+You can sort your results using the ``sort()`` method of a ``FindIterable``
 instance or by using the  ``Aggregates.sort()`` static factory method in an
-aggregation pipeline. Both of these methods take objects that implement the
-``Bson`` interface and specify sort criteria as arguments. For information
-on the ``Bson`` interface, see our 
+aggregation pipeline. Both of these methods receive objects that implement the
+``Bson`` interface as arguments. For information on the ``Bson`` interface, 
+see our 
 :doc:`guide on BSON </fundamentals/data-formats/document-data-format-bson/>`.   
 
 You can use the ``sort()`` method of a ``FindIterable`` instance as follows:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -79,8 +79,8 @@ as follows:
    collection.aggregate(Arrays.asList(Aggregates.sort(ascending("_id"))));
 
 The code snippets above both sort the documents in the
-:ref:`sort_example collection <sorts-crud-sort-example>`  
-in the following order: 
+:ref:`sort_example collection <sorts-crud-sort-example>` from smallest to
+largest value of the ``_id`` field: 
 
 .. code-block:: json
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -323,13 +323,11 @@ The code example performs the following actions:
 
 #. Creates a text index for your
    :ref:`sort_example collection <sorts-crud-sort-example>`
-   on the ``food`` field. If the index specified in your call to the
-   ``createIndex()`` method already exists, calling it will not create a new
-   index.
+   on the ``food`` field. If you call ``createIndex()`` specifying an index that
+   already exists on the collection, the operation does not create a new index.
 #. Runs your text search for the phrase "maple donut".
 #. Projects text scores into your query results as the
-   ``score`` field. This projection is optional if your MongoDB instance is
-   running MongoDB 4.4 or later. 
+   ``score`` field.
 #. Sorts your results by text score (best match first).
 
 .. code-block:: java

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -131,8 +131,8 @@ Ascending
 ~~~~~~~~~
 
 To specify an ascending sort, use the ``Sorts.ascending()`` static
-factory method. Pass ``Sorts.ascending()``
-the name of the field you need to sort on.
+factory method. Pass the ``Sorts.ascending()`` method
+the name of the field you need to sort in ascending order.
 
 The ``ascending()`` method can be used as follows:
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -52,7 +52,7 @@ instance or by using the  ``Aggregates.sort()`` static factory method in an
 aggregation pipeline. Both of these methods take objects that implement the
 ``Bson`` interface and specify sort criteria as arguments. For information
 on the ``Bson`` interface, see our 
-:doc:`guide on Bson </fundamentals/data-formats/document-data-format-bson/>`.   
+:doc:`guide on BSON </fundamentals/data-formats/document-data-format-bson/>`.   
 
 .. _sorts-crud-find-iterable-example:
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -261,9 +261,9 @@ Combining Sort Criteria
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 To combine sort criteria, use the ``Sorts.orderBy()`` static factory
-method. This method constructs an object containing an ordered list of sort criteria. 
-When performing the sort, if the leftmost sort criteria results in a tie, the sort uses the
-next sort criteria in the list to determine the order.
+method. This method constructs an object containing an ordered list of sort
+criteria. When performing the sort, if the leftmost sort criteria results in a
+tie, the sort uses the next sort criteria in the list to determine the order.
 
 In the following code snippet, we use the ``orderBy()`` method to combine a
 descending sort on the ``letter`` field with an ascending sort on the

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -54,25 +54,26 @@ aggregation pipeline. Both of these methods take objects that implement the
 on the ``Bson`` interface, see our 
 :doc:`guide on BSON </fundamentals/data-formats/document-data-format-bson/>`.   
 
-.. _sorts-crud-find-iterable-example:
-
 You can use the ``sort()`` method of a ``FindIterable`` instance as follows:
 
 .. code-block:: java
 
+   import static com.mongodb.client.model.Sorts.ascending;
+
    // <MongoCollection setup code here>
    
-   collection.find().sort(new Document("_id", 1)));
+   collection.find().sort(ascending("_id"));
  
 You can use the ``Aggregates.sort()`` method as follows:
    
 .. code-block:: java
 
    import com.mongodb.client.model.Aggregates;
+   import static com.mongodb.client.model.Sorts.ascending;
 
    // <MongoCollection setup code here>
    
-   collection.aggregate(Arrays.asList(Aggregates.sort(new Document("_id", 1))));
+   collection.aggregate(Arrays.asList(Aggregates.sort(ascending("_id"))));
 
 The code snippets above both sort the documents in the
 :ref:`sort_example collection <sorts-crud-sort-example>`  
@@ -85,27 +86,12 @@ in the following order:
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    ...
 
-In the above code snippets, we specify our sort criteria by passing a
-``Document`` object (which implements the ``Bson`` interface) to our sort
-method. While this will run without errors, we recommend that you instead
-specify sort criteria through the ``Sorts`` builder class. 
-
-The following code snippet is equivalent to the
-:ref:`FindIterable example above <sorts-crud-find-iterable-example>`. 
-
-.. code-block:: java
-
-   import static com.mongodb.client.model.Sorts.ascending;
-
-   // <MongoCollection setup code here>
-   
-   collection.find().sort(ascending("_id"));
-
-The remainder of this guide will specify sort criteria using the ``Sorts`` class.
-
-For more information on the benefits of using builders, see our
-:doc:`guide on builders </fundamentals/builders/>`. For more information on the
-``Sorts`` builder class, see our
+In the above code snippets, we specify our sort criteria using the ``Sorts``
+builder class. While it is possible to specify ``Sort`` criteria using any class
+that implements the ``Bson`` interface, we recommend that you specify sort
+criteria through the ``Sorts`` builder. For more information on the benefits of
+using builders, see our :doc:`guide on builders </fundamentals/builders/>`. For
+more information on the ``Sorts`` builder class, see our
 :doc:`guide on the Sorts builder </fundamentals/builders/sort/>`.    
 
 For more information about the classes and interfaces in this section, see the

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -13,9 +13,10 @@ Sort Results
 Overview
 --------
 
-In this guide, we show you how to **sort** your results.
+In this guide, we show you how to use the **sort** operation to order your
+results.
 
-Sorting orders the documents returned from your query by your specified 
+The sort operation orders the documents returned from your query by your specified 
 **sort criteria**. Sort criteria are the rules you give to MongoDB that describe
 how you would like your data to be ordered. Some examples of sort criteria are:
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -266,9 +266,9 @@ method. This method constructs an object containing an ordered list of sort
 criteria. When performing the sort, if the leftmost sort criteria results in a
 tie, the sort uses the next sort criteria in the list to determine the order.
 
-In the following code snippet, we use the ``orderBy()`` method to combine a
-descending sort on the ``letter`` field with an ascending sort on the
-``_id`` field.
+In the following code snippet, we use the ``orderBy()`` method to order our data
+by performing a descending sort on the ``letter`` field, and in the event of a
+tie, an ascending sort on the ``_id`` field.
 
 .. code-block:: java
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -48,11 +48,12 @@ contains the following documents:
 Methods For Sorting
 -------------------
 
-You can sort your results using the ``sort()`` method of a ``FindIterable``
-instance or by using the  ``Aggregates.sort()`` static factory method in an
-aggregation pipeline. Both of these methods receive objects that implement the
-``Bson`` interface as arguments. For information on the ``Bson`` interface, 
-see our 
+You can sort results retrieved by a query and you can sort results 
+within an aggregation pipeline. To sort your query results, use the
+``sort()`` method of a ``FindIterable`` instance. To sort your results within an 
+aggregation pipeline, use the ``Aggregates.sort()`` static factory method. Both
+of these methods receive objects that implement the ``Bson`` interface as
+arguments. For information on the ``Bson`` interface, see our 
 :doc:`guide on BSON </fundamentals/data-formats/document-data-format-bson/>`.   
 
 You can use the ``sort()`` method of a ``FindIterable`` instance as follows:
@@ -65,7 +66,8 @@ You can use the ``sort()`` method of a ``FindIterable`` instance as follows:
    
    collection.find().sort(ascending("_id"));
  
-You can use the ``Aggregates.sort()`` method as follows:
+You can use the ``Aggregates.sort()`` method within an aggregation pipeline
+as follows:
    
 .. code-block:: java
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -362,14 +362,14 @@ The output of the code example above should look something like this:
    {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}
    {"_id": 3, "letter": "a", "food": "maple syrup", "score": 0.75}
 
-.. note:: ``$meta`` Behavior in MongoDB 4.4 or Later
+.. note:: Text Search Behavior in MongoDB 4.4 or Later
 
-  If you are using MongoDB 4.4 or later, projecting
-  ``Projections.metaTextScore()`` into your ``FindIterable`` instance is not
-  necessary to sort on the text score. In addition, MongoDB 4.4 or later
-  disregards the field name you specify in a ``$meta`` text score aggregation
-  operation used in a sort. This means that the field name argument you pass to
-  ``Sorts.metaTextScore()`` is ignored.
+   The structure of text search has changed for MongoDB 4.4 or later. You no
+   longer need to project ``Projections.metaTextScore()`` into your
+   ``FindIterable`` instance in order to sort on the text score. In addition,
+   the field name you specify in a ``$meta`` text score aggregation operation
+   used in a sort is ignored. This means that the field name argument you pass
+   to ``Sorts.metaTextScore()`` is disregarded.
 
 For more information about the classes in this section, see the
 following API documentation:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -53,8 +53,8 @@ within an aggregation pipeline. To sort your query results, use the
 ``sort()`` method of a ``FindIterable`` instance. To sort your results within an 
 aggregation pipeline, use the ``Aggregates.sort()`` static factory method. Both
 of these methods receive objects that implement the ``Bson`` interface as
-arguments. For information on the ``Bson`` interface, see our 
-:doc:`guide on BSON </fundamentals/data-formats/document-data-format-bson/>`.   
+arguments. For more information, see our 
+:java-docs:`API documentation for the Bson interface <apidocs/bson/org/bson/conversions/Bson.html>`
 
 You can use the ``sort()`` method of a ``FindIterable`` instance as follows:
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -213,6 +213,8 @@ in the following order:
    {"_id": 4, "letter": "b", "food": "coffee with sugar"}
    ...
 
+.. _sorts-crud-handling-ties:
+
 Handling Ties
 ~~~~~~~~~~~~~
 
@@ -301,6 +303,8 @@ in the following order:
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
+
+.. _sorts-crud-text-search:
 
 Text Search
 -----------

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -367,10 +367,11 @@ The output of the code example above should look something like this:
 
   When using MongoDB 4.4 or later, projecting ``Projections.metaTextScore()`` 
   into your ``FindIterable`` instance is not necessary to sort on the text
-  score. In addition, MongoDB 4.4 or later disregards the field name you specify
+  score. 
+  
+  In addition, MongoDB 4.4 or later disregards the field name you specify
   in a ``$meta`` text score aggregation operation used in a sort. This means
-  that the field name argument you pass to ``Sorts.metaTextScore()`` is ignored
-  in MongoDB 4.4 or later.
+  that the field name argument you pass to ``Sorts.metaTextScore()`` is ignored.
 
 For more information about the classes in this section, see the
 following API documentation:

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -221,8 +221,8 @@ code:
    
    collection.find().sort(ascending("letter"));
 
-Since multiple documents contain "a" on the field we are sorting on, the first
-document returned could be any of the following documents:
+Since multiple documents contain the value "a" for the field on which we perform the sort,
+the following documents could be returned in any order:
 
 .. code-block:: json
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -301,12 +301,13 @@ Text Search
 -----------
 
 You can specify the order of the results of a 
-:manual:`text search </text-search/>` by how closely they match your
-search string. Each of your search results has a
-:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` which is a
-numerical value that indicates how closely that result matches your search. 
-Use the ``Sorts.metaTextScore()`` static factory method to build your sort
-criteria to sort by the text score.
+:manual:`text search </text-search/>` by how closely they match the string
+values in the fields specified by the collection's text index. The text search
+assigns a numerical
+:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` to
+indicate how closely each result matches the search string. Use the
+``Sorts.metaTextScore()`` static factory method to build your sort criteria to
+sort by the text score.
 
 .. warning:: Make Sure to Create a Text Index
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -303,7 +303,7 @@ You can specify the order of the results of a
 :manual:`text search </text-search/>` by how closely they match your
 search string. Each of your search results has a
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` which is a
-numerical value indicating how well that result matches your search. 
+numerical value that indicates how closely that result matches your search. 
 Use the ``Sorts.metaTextScore()`` static factory method to build your sort
 criteria to sort by the text score.
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -301,9 +301,9 @@ Text Search
 -----------
 
 You can specify the order of the results of a 
-:manual:`text search </text-search/>` by how closely they match the string
-values in the fields specified by the collection's text index. The text search
-assigns a numerical
+:manual:`text search </text-search/>` by how closely the string values of
+each result's fields specified by the collection's text index match your search
+string. The text search assigns a numerical
 :manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` to
 indicate how closely each result matches the search string. Use the
 ``Sorts.metaTextScore()`` static factory method to build your sort criteria to

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -17,7 +17,7 @@ In this guide, we show you how to **sort** your results.
 
 Sorting orders the documents returned from your query by your specified 
 **sort criteria**. Sort criteria are the rules you give to MongoDB that describe
-how you would like your data ordered. Some examples of sort criteria are:
+how you would like your data to be ordered. Some examples of sort criteria are:
 
 * Smallest number to largest number
 * Earliest time of day to latest time of day

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -92,9 +92,8 @@ largest value of the ``_id`` field:
 In the above code snippets, we specify our sort criteria using the ``Sorts``
 builder class. While it is possible to specify sort criteria using any class
 that implements the ``Bson`` interface, we recommend that you specify sort
-criteria through the ``Sorts`` builder. For more information on the benefits of
-using builders, see our :doc:`guide on builders </fundamentals/builders/>`. For
-more information on the ``Sorts`` builder class, see our
+criteria through the ``Sorts`` builder. For more information on the ``Sorts``
+builder class, see our
 :doc:`guide on the Sorts builder </fundamentals/builders/sort/>`.    
 
 For more information about the classes and interfaces in this section, see the

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -87,7 +87,7 @@ in the following order:
    ...
 
 In the above code snippets, we specify our sort criteria using the ``Sorts``
-builder class. While it is possible to specify ``Sort`` criteria using any class
+builder class. While it is possible to specify sort criteria using any class
 that implements the ``Bson`` interface, we recommend that you specify sort
 criteria through the ``Sorts`` builder. For more information on the benefits of
 using builders, see our :doc:`guide on builders </fundamentals/builders/>`. For

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -48,7 +48,7 @@ contains the following documents:
 Methods For Sorting
 -------------------
 
-You can sort results retrieved by a query and you can sort results 
+You can sort results retrieved by a query and you can sort data 
 within an aggregation pipeline. To sort your query results, use the
 ``sort()`` method of a ``FindIterable`` instance. To sort your results within an 
 aggregation pipeline, use the ``Aggregates.sort()`` static factory method. Both

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -158,9 +158,8 @@ by the ``_id`` field:
 
    // <MongoCollection setup code here>
    
-   Bson idSort = ascending("_id");
    List<Document> results = new ArrayList<>();
-   collection.find().sort(idSort).into(results);
+   collection.find().sort(ascending("_id")).into(results);
    for (Document result : results) {
          System.out.println(result.toJson());
    }

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -269,7 +269,7 @@ tie, the sort uses the next sort criteria in the list to determine the order.
 
 In the following code snippet, we use the ``orderBy()`` method to order our data
 by performing a descending sort on the ``letter`` field, and in the event of a
-tie, an ascending sort on the ``_id`` field.
+tie, by performing an ascending sort on the ``_id`` field.
 
 .. code-block:: java
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -183,7 +183,7 @@ The output of the code example above should look something like this:
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
    {"_id": 3, "letter": "a", "food": "maple syrup"}
-      ...
+   ...
 
 Descending
 ~~~~~~~~~~
@@ -335,7 +335,9 @@ The code example performs the following actions:
 
 #. Creates a text index for your
    :ref:`sort_example collection <sorts-crud-sort-example>`
-   on the ``food`` field.
+   on the ``food`` field. In a production application you would not
+   want to call the ``createIndex()`` method every search, but it is alright for
+   the purpose of this example.
 #. Runs your text search for the phrase "maple donut".
 #. Projects text scores into your query results as the
    ``score`` field. This projection is optional if your MongoDB instance is
@@ -387,6 +389,7 @@ following API documentation:
 - :java-docs:`Filters </apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html>`
 - :java-docs:`Indexes </apidocs/mongodb-driver-core/com/mongodb/client/model/Indexes.html>`
 - :java-docs:`Projections </apidocs/mongodb-driver-core/com/mongodb/client/model/Projections.html>`
+- :java-docs:`MongoCollection </apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html>`
 
 For more information, see the
 :java-docs:`Sorts class API documentation </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`.

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -206,10 +206,10 @@ in descending order:
 Handling Ties
 ~~~~~~~~~~~~~
 
-A tie occurs when two or more documents have a field with identical values.
-MongoDB does not guarantee sort order in the event of ties. For example, suppose
-we encounter a tie when applying a sort to the
-:ref:`sample collection <sorts-crud-sort-sample>` using the following
+A tie occurs when two or more documents have identical values in the field
+you are using to order your results. MongoDB does not guarantee sort order in
+the event of ties. For example, suppose we encounter a tie when applying a sort
+to the :ref:`sample collection <sorts-crud-sort-sample>` using the following
 code:
 
 .. code-block:: java

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -324,9 +324,9 @@ The code example performs the following actions:
 
 #. Creates a text index for your
    :ref:`sort_example collection <sorts-crud-sort-example>`
-   on the ``food`` field. In a production application you would not
-   want to call the ``createIndex()`` method every search, but it is alright for
-   the purpose of this example.
+   on the ``food`` field. If the index specified in your call to the
+   ``createIndex()`` method already exists, calling it will not create a new
+   index.
 #. Runs your text search for the phrase "maple donut".
 #. Projects text scores into your query results as the
    ``score`` field. This projection is optional if your MongoDB instance is

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -48,7 +48,7 @@ contains the following documents:
 Methods For Sorting
 -------------------
 
-You can sort results retrieved by a query and you can sort data 
+You can sort results retrieved by a query and you can sort results 
 within an aggregation pipeline. To sort your query results, use the
 ``sort()`` method of a ``FindIterable`` instance. To sort your results within an 
 aggregation pipeline, use the ``Aggregates.sort()`` static factory method. Both
@@ -192,7 +192,7 @@ The following code snippet shows how to specify a descending sort on the
 
 The code snippet above returns the documents in the
 :ref:`sort_example collection <sorts-crud-sort-example>`  
-in the following order: 
+in descending order: 
 
 .. code-block:: json
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -17,7 +17,7 @@ In this guide, we show you how to use the **sort** operation to order your
 results.
 
 The sort operation orders the documents returned from your query by your specified 
-**sort criteria**. Sort criteria are the rules you give to MongoDB that describe
+**sort criteria**. Sort criteria are the rules you pass to MongoDB that describe
 how you would like your data to be ordered. Some examples of sort criteria are:
 
 * Smallest number to largest number


### PR DESCRIPTION
## Pull Request Info
Migrate Fundamentals > Builders > Sorts page from  https://jira.mongodb.org/browse/DOCSP-9585 into Fundamentals > CRUD > Read > Sort and redo builders section to more explicitly focus on `Sorts` classs. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15135

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/d9aff57/java/docsworker-xlarge/DOCSP-15135-CRUD-Read-Sort-Update/fundamentals/crud/read-operations/sort/

https://docs-mongodbcom-staging.corp.mongodb.com/d9aff57/java/docsworker-xlarge/DOCSP-15135-CRUD-Read-Sort-Update/fundamentals/builders/sort/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

