### PR TITLE
needs to sort on imdb.rating rather than rating

### DIFF
--- a/source/includes/usage-examples/code-snippets/FindOne.java
+++ b/source/includes/usage-examples/code-snippets/FindOne.java
@@ -30,7 +30,7 @@ public class FindOne {
 
             Document doc = collection.find(eq("title", "The Room"))
                     .projection(projectionFields)
-                    .sort(Sorts.descending("rating"))
+                    .sort(Sorts.descending("imdb.rating"))
                     .first();
 
             if (doc == null) {


### PR DESCRIPTION
## Pull Request Info

The find a document code example is sorting on an invalid field. Needs to sort on "imdb.rating" rather than "rating". 

### Issue JIRA link:
NA

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/fd85f1a/java/docsworker-xlarge/FindOne-Incorrect-Sort/usage-examples/findOne/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

