### PR TITLE
DOCSP-16254 Fix Build Error

### DIFF
--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -104,7 +104,7 @@ For more information on the ``Projections`` class, see our
 :doc:`guide on the Projections builder </fundamentals/builders/projections/>`.
 
 For more information on the upsert operation, see our 
-:doc:`guide on upserts </fundamentals/crud/write-operations/upsert/#insert-or-update-in-a-single-operation/>`.
+:doc:`guide on upserts </fundamentals/crud/write-operations/upsert/>`.
 
 For more information on the methods and classes in this section, see the
 following API documentation pages:


### PR DESCRIPTION
## Pull Request Info
I accidentally merged in a build error with the compound operations page. This PR is to fix the build error. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16254

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/2cad7af/java/docsworker-xlarge/DOCSP-16254-Fix-Build-Error/fundamentals/crud/compound-operations/

Build Log: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=60acf4b9f1f69374507ab158

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

