### PR TITLE
DOCSP-15781: Versioned API

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -9,6 +9,7 @@ Fundamentals
    :maxdepth: 1
 
    /fundamentals/connection
+   /fundamentals/versioned-api
    /fundamentals/auth
    /fundamentals/enterprise-auth
    /fundamentals/databases-collections

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -14,8 +14,7 @@ Versioned API
 
    The Versioned API feature requires MongoDB Server 5.0 or later. You
    should only use the Versioned API feature if you are connecting to
-   MongoDB servers that are upgraded to a version that supports the
-   Versioned API feature.
+   MongoDB servers that are upgraded to a version that supports this feature.
 
 This guide shows you how to specify the **Versioned API** when connecting to
 a MongoDB instance or replica set. You can use the Versioned API feature to
@@ -34,8 +33,8 @@ covered by the Versioned API.
 The following sections describe how you can enable Versioned API for
 your MongoDB client and each of the options that you can specify.
 
-Specify the API Version
------------------------
+Enable Versioned API
+--------------------
 
 To enable the Versioned API, you must specify an API version in the settings
 that you use to create your MongoDB client. Once you instantiate a
@@ -45,13 +44,14 @@ run commands not covered by the Versioned API or with a different version of
 it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
-specifies version "1" of the Versioned API by performing the following
-operations:
+specifies version "1" of the Versioned API and connects to a server by 
+performing the following operations:
 
 - Construct a ``ServerApi`` instance using the ``ServerApi.Builder``
   helper class.
 - Construct a ``MongoClientSettings`` instance using the
   ``MongoClientSettings.Builder`` class.
+- Specify a server to connect to using a ``ServerAddress`` instance.
 - Instantiate a ``MongoClient`` using the ``MongoClients.create()`` method
   and pass your ``MongoClientSettings`` instance as a parameter.
 
@@ -63,11 +63,11 @@ operations:
 
 .. warning::
 
-   Make sure that you are connecting to a version of MongoDB server that
-   supports Versioned API. Otherwise, your application may throw an exception
-   when attempting to perform any operation that sends a command to
-   MongoDB. For example, a query to a server could return an exception
-   message that resembles the following:
+   Make sure that when you specify an API version that you connect to a 
+   version of MongoDB server that supports Versioned API. Otherwise, your
+   application may raise an exception when attempting to perform any operation 
+   that sends a command to MongoDB. For example, a query to a server could 
+   return an exception message that resembles the following:
 
    .. code-block:: none
 
@@ -78,6 +78,7 @@ section, see the following API documentation:
 
 - :java-docs:`ServerApi <apidocs/mongodb-driver-core/com/mongodb/ServerApi.html>`
 - :java-docs:`ServerApi.Builder <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html>`
+- :java-docs:`ServerAddress <apidocs/mongodb-driver-core/com/mongodb/ServerAddress.html>`
 - :java-docs:`MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`
 - :java-docs:`MongoClientSettings.Builder <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html>`
 - :java-docs:`MongoClients.create() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html#create(com.mongodb.MongoClientSettings)>`

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -12,26 +12,29 @@ Versioned API
 
 .. note::
 
-   The Versioned API feature requires MongoDB Server 5.0 or later. You
-   should only use the Versioned API feature if you are connecting to
-   MongoDB servers that are upgraded to a version that supports this feature.
+   The Versioned API feature requires MongoDB Server 5.0 or later.
+
+   You should only use the Versioned API feature if all the MongoDB
+   servers you are connecting to are upgraded to a version that supports
+   this feature.
 
 This guide shows you how to specify the **Versioned API** when connecting to
 a MongoDB instance or replica set. You can use the Versioned API feature to
-force the server to run operations with consistent behavior as specified by
-an **API version**. An API version defines expected behavior of operations
-such as the information expected in the request and the response.
+force the server to run operations with behavior compatible with the
+specified **API version**. An API version defines the expected behavior of the
+operations it covers and the format of server responses. If you change to
+a different API version, the operations are not guaranteed to be
+compatible and the server responses are not guaranteed to be similar.
 
-When you use the Versioned API feature, you can update your MongoDB driver or
-server without worrying about backward compatibility issues of the commands
-covered by the Versioned API.
+When you use the Versioned API feature with an official MongoDB driver, you
+can update your driver or server without worrying about backward compatibility
+issues of the commands covered by the Versioned API.
 
-..
-   TODO: See the server manual page on `Versioned API <https://docs.mongodb.com/v5.0/reference/versioned-api/>`__
-   for more information including the set the commands covered.
+See the server manual page on `Versioned API <https://docs.mongodb.com/v5.0/reference/versioned-api/>`__
+for more information including a list of commands it covers.
 
 The following sections describe how you can enable Versioned API for
-your MongoDB client and each of the options that you can specify.
+your MongoDB client and the options that you can specify.
 
 Enable Versioned API on a MongoDB Client
 ----------------------------------------
@@ -44,11 +47,13 @@ run commands not covered by the Versioned API or with a different version of
 it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
-specifies version "1" of the Versioned API and connects to a server by
-performing the following operations:
+sets the Versioned API version and connects to a server by performing the
+following operations:
 
 - Construct a ``ServerApi`` instance using the ``ServerApi.Builder``
   helper class.
+- Specify a Versioned API version using a constant from the
+  ``ServerApiVersion`` class.
 - Construct a ``MongoClientSettings`` instance using the
   ``MongoClientSettings.Builder`` class.
 - Specify a server to connect to using a ``ServerAddress`` instance.
@@ -63,11 +68,12 @@ performing the following operations:
 
 .. warning::
 
-   Make sure that when you specify an API version that you connect to a
-   version of MongoDB server that supports Versioned API. Otherwise, your
-   application may raise an exception when attempting to perform any operation
-   that sends a command to MongoDB. For example, a query to a server could
-   return an exception message that resembles the following:
+   If you specify an API version and connect to a MongoDB server that does
+   not support Versioned API, your application may raise an exception when
+   executing a command on your MongoDB server. If you use
+   a ``MongoClient`` that specifies the API version to query a server that
+   does not support it, your query could fail with the following exception
+   message:
 
    .. code-block:: none
       :copyable: false
@@ -79,17 +85,18 @@ section, see the following API documentation:
 
 - :java-docs:`ServerApi <apidocs/mongodb-driver-core/com/mongodb/ServerApi.html>`
 - :java-docs:`ServerApi.Builder <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html>`
+- :java-docs:`ServerApiVersion </apidocs/mongodb-driver-core/com/mongodb/ServerApiVersion.html>`
 - :java-docs:`ServerAddress <apidocs/mongodb-driver-core/com/mongodb/ServerAddress.html>`
 - :java-docs:`MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`
 - :java-docs:`MongoClientSettings.Builder <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html>`
 - :java-docs:`MongoClients.create() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html#create(com.mongodb.MongoClientSettings)>`
 - :java-docs:`MongoClient <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClient.html>`
 
-Additional Options
-------------------
+Versioned API Options
+---------------------
 
-You can set additional options to enable or disable behavior related to
-Versioned API as described in the following table.
+You can enable or disable optional behavior related to Versioned API as
+described in the following table.
 
 .. list-table::
    :header-rows: 1
@@ -112,8 +119,8 @@ Versioned API as described in the following table.
        | For more information, see the :java-docs:`deprecationErrors() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#>` API documentation.
 
 
-The following code example shows how you can set the two options on an
-instance of ``ServerApi`` by chaining methods on the ``ServerApi.Builder``:
+The following example shows how you can set the two options on an instance
+of ``ServerApi`` by chaining methods on the ``ServerApi.Builder``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start apiVersionOptions

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -12,31 +12,37 @@ Versioned API
 
 .. note::
 
-   The Versioned API feature requires MongoDB Server 5.0 or later.
+   The Versioned API feature requires MongoDB Server 5.0 or later. You
+   should only use the Versioned API feature if you are connecting to
+   MongoDB servers that are upgraded to a version that supports the
+   Versioned API feature.
 
-This guide shows you how to specify the *Versioned API* when connecting to
-a MongoDB instance or replica set deployment. The Versioned API feature
-enables you to force the server to run operations with consistent behavior
-as specified by the API version. You can update the version of your driver
-or server without worrying about compatibility issues of the commands covered
-by the Versioned API.
+This guide shows you how to specify the **Versioned API** when connecting to
+a MongoDB instance or replica set. You can use the Versioned API feature to
+force the server to run operations with consistent behavior as specified by
+an **API version**. An API version defines expected behavior of operations
+such as the information expected in the request and the response.
+
+When you use the Versioned API feature, you can update your MongoDB driver or
+server without worrying about backward compatibility issues of the commands
+covered by the Versioned API.
 
 ..
-   TODO: See the server manual page on Versioned API for more information
-   including the set the commands covered.
+   TODO: See the server manual page on `Versioned API <https://docs.mongodb.com/v5.0/reference/versioned-api/>`__
+   for more information including the set the commands covered.
 
-The following sections describe how you can enable Versioned API and each of
-the options that you can specify.
+The following sections describe how you can enable Versioned API for
+your MongoDB client and each of the options that you can specify.
 
 Specify the API Version
 -----------------------
 
 To enable the Versioned API, you must specify an API version in the settings
 that you use to create your MongoDB client. Once you instantiate a
-``MongoClient`` instance with a sepcified Versioned API, all commands you
+``MongoClient`` instance with a specified Versioned API, all commands you
 run with that client use that version of the Versioned API. If you need to
-run commands without the Versioned API or with a different version of it,
-instantiate a separate client.
+run commands not covered by the Versioned API or with a different version of
+it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
 specifies version "1" of the Versioned API by performing the following
@@ -104,8 +110,9 @@ Versioned API as described in the following table.
        | For more information, see the :java-docs:`deprecationErrors() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#>` API documentation.
 
 
-The following code example shows how you can set the two options on the
-``ServerApi`` by chaining the methods to the ``ServerApi.Builder``:
+The following code example shows how you can set the two options on an
+instance of ``ServerApi`` by chaining methods to specify the options to the
+``ServerApi.Builder``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start serverAPIVersion
@@ -113,4 +120,3 @@ The following code example shows how you can set the two options on the
    :language: java
    :dedent:
 
-.. _test@#:

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -113,8 +113,7 @@ Versioned API as described in the following table.
 
 
 The following code example shows how you can set the two options on an
-instance of ``ServerApi`` by chaining methods to specify the options to the
-``ServerApi.Builder``:
+instance of ``ServerApi`` by chaining methods on the ``ServerApi.Builder``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start apiVersionOptions

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -39,11 +39,10 @@ Enable Versioned API on a MongoDB Client
 ----------------------------------------
 
 To enable the Versioned API, you must specify an API version in the settings
-that you use to create your MongoDB client. Once you instantiate a
-``MongoClient`` instance with a specified Versioned API, all commands you
-run with that client use that version of the Versioned API. If you need to
-run commands not covered by the Versioned API or with a different version of
-it, instantiate a separate client.
+of your MongoDB client. Once you instantiate a ``MongoClient`` instance with
+a specified Versioned API, all commands you run with that client use that
+version of the Versioned API. If you need to run commands not covered by the
+Versioned API or with a different version of it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
 sets the Versioned API version and connects to a server by performing the

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -50,7 +50,7 @@ operations:
 - Instantiate a ``MongoClient`` using the ``MongoClients.create()`` method
   and pass your ``MongClientSettings`` instance as a parameter.
 
-.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPIExample.java
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start serverAPIVersion
    :end-before: end serverAPIVersion
    :language: java
@@ -101,7 +101,7 @@ Versioned API as described in the following table.
 The following code example shows how you can set the two options on the
 ``ServerApi`` by chaining the methods to the ``ServerApi.Builder``:
 
-.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPIExample.java
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start serverAPIVersion
    :end-before: end serverAPIVersion
    :language: java

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -41,7 +41,18 @@ Enable Versioned API on a MongoDB Client
 To enable the Versioned API, you must specify an API version in the settings
 of your MongoDB client. Once you instantiate a ``MongoClient`` instance with
 a specified Versioned API, all commands you run with that client use that
-version of the Versioned API. If you need to run commands not covered by the
+version of the Versioned API.
+
+.. tip::
+
+   If you need to run commands using a more than one version of the Versioned
+   API, instantiate a separate client with that version.
+
+   If you need to run commands not covered by the Versioned API, make sure the
+   "strict" option is disabled. See the section on
+   :ref:`Versioned API Options <versioned-api-options>` for more information.
+
+If you need to run commands not covered by the
 Versioned API or with a different version of it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
@@ -68,15 +79,15 @@ following operations:
 
    If you specify an API version and connect to a MongoDB server that does
    not support Versioned API, your application may raise an exception when
-   executing a command on your MongoDB server. If you use
-   a ``MongoClient`` that specifies the API version to query a server that
-   does not support it, your query could fail with the following exception
-   message:
+   executing a command on your MongoDB server. If you use a ``MongoClient``
+   that specifies the API version to query a server that does not support it,
+   your query could fail with an exception message that includes the
+   following text:
 
    .. code-block:: none
       :copyable: false
 
-      com.mongodb.MongoQueryException: Query failed with error code 9 and error message 'Failed to parse: {...} Unrecognized field 'apiVersion'.' on server
+      'Unrecognized field 'apiVersion' on server...
 
 For more information on the methods and classes referenced in this
 section, see the following API documentation:
@@ -89,6 +100,8 @@ section, see the following API documentation:
 - :java-docs:`MongoClientSettings.Builder <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html>`
 - :java-docs:`MongoClients.create() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html#create(com.mongodb.MongoClientSettings)>`
 - :java-docs:`MongoClient <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClient.html>`
+
+.. _versioned-api-options:
 
 Versioned API Options
 ---------------------

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -52,9 +52,6 @@ version of the Versioned API.
    "strict" option is disabled. See the section on
    :ref:`Versioned API Options <versioned-api-options>` for more information.
 
-If you need to run commands not covered by the
-Versioned API or with a different version of it, instantiate a separate client.
-
 The example below shows how you can instantiate a ``MongoClient`` that
 sets the Versioned API version and connects to a server by performing the
 following operations:

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -1,0 +1,109 @@
+=============
+Versioned API
+=============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+
+.. note::
+
+   The Versioned API feature requires MongoDB Server 5.0 or later.
+
+This guide shows you how to specify the *Versioned API* when connecting to
+a MongoDB instance or replica set deployment. The Versioned API feature
+enables you to force the server to run operations with consistent behavior
+as specified by the API version. You can update the version of your driver
+or server without worrying about compatibility issues of the commands covered
+by the Versioned API.
+
+..
+   TODO: See the server manual page on Versioned API for more information
+   including the set the commands covered.
+
+The following sections describe how you can enable Versioned API and each of
+the options that you can specify.
+
+Specify the API Version
+-----------------------
+
+To enable the Versioned API, you must specify an API version in the settings
+that you use to create your MongoDB client. Once you instantiate a
+``MongoClient`` instance with a sepcified Versioned API, all commands you
+run with that client use that version of the Versioned API. If you need to
+run commands without the Versioned API or with a different version of it,
+instantiate a separate client.
+
+The example below shows how you can instantiate a ``MongoClient`` that
+specifies version "1" of the Versioned API by performing the following
+operations:
+
+- Construct a ``ServerApi`` instance using the ``ServerApi.Builder``
+  helper class.
+- Construct a ``MongoClientSettings`` instance using the
+  ``MongoClientSettings.Builder`` class.
+- Instantiate a ``MongoClient`` using the ``MongoClients.create()`` method
+  and pass your ``MongClientSettings`` instance as a parameter.
+
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPI.java
+   :start-after: start serverAPIVersion
+   :end-before: end serverAPIVersion
+   :language: java
+   :dedent:
+
+.. warning::
+
+   Make sure that you are connecting to a version of MongoDB server that
+   supports Versioned API. Otherwise, your application may throw an exception
+   when attempting to perform any operation that sends a command to
+   MongoDB.
+
+For more information on the methods and classes referenced in this
+section, see the following API documentation:
+
+- :java-docs:`ServerApi <apidocs/mongodb-driver-core/com/mongodb/ServerApi.html>`
+- :java-docs:`ServerApi.Builder <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html>`
+- :java-docs:`MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`
+- :java-docs:`MongoClientSettings.Builder <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html>`
+- :java-docs:`MongoClients.create() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html#create(com.mongodb.MongoClientSettings)>`
+- :java-docs:`MongoClient <apidocs/mongodb-driver-sync/com/mongodb/client/MongoClient.html>`
+
+Additional Options
+------------------
+
+You can set additional options to enable or disable behavior related to
+Versioned API as described in the following table.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 25,75
+
+   * - Option Name
+     - Description
+
+   * - Strict
+     - | **Optional**. When set, if you call a command that is not part of declared API version, the driver raises an exception.
+       | Default: **false**
+       | :java-docs:`strict() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#strict(boolean)>` API documentation
+
+   * -  DeprecationErrors
+     - | **Optional**. When set, if you call a command that is deprecated in the declared API version, the driver raises an exception.
+       | Default: **false**
+       | :java-docs:`deprecationErrors() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#>` API documentation
+
+
+The following code example shows how you can set the two options on the
+``ServerApi`` by chaining the methods to the ``ServerApi.Builder``:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPI.java
+   :start-after: start serverAPIVersion
+   :end-before: end serverAPIVersion
+   :language: java
+   :dedent:
+

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -33,8 +33,8 @@ covered by the Versioned API.
 The following sections describe how you can enable Versioned API for
 your MongoDB client and each of the options that you can specify.
 
-Enable Versioned API
---------------------
+Enable Versioned API on a MongoDB Client
+----------------------------------------
 
 To enable the Versioned API, you must specify an API version in the settings
 that you use to create your MongoDB client. Once you instantiate a
@@ -44,7 +44,7 @@ run commands not covered by the Versioned API or with a different version of
 it, instantiate a separate client.
 
 The example below shows how you can instantiate a ``MongoClient`` that
-specifies version "1" of the Versioned API and connects to a server by 
+specifies version "1" of the Versioned API and connects to a server by
 performing the following operations:
 
 - Construct a ``ServerApi`` instance using the ``ServerApi.Builder``
@@ -63,10 +63,10 @@ performing the following operations:
 
 .. warning::
 
-   Make sure that when you specify an API version that you connect to a 
+   Make sure that when you specify an API version that you connect to a
    version of MongoDB server that supports Versioned API. Otherwise, your
-   application may raise an exception when attempting to perform any operation 
-   that sends a command to MongoDB. For example, a query to a server could 
+   application may raise an exception when attempting to perform any operation
+   that sends a command to MongoDB. For example, a query to a server could
    return an exception message that resembles the following:
 
    .. code-block:: none

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -117,8 +117,8 @@ instance of ``ServerApi`` by chaining methods to specify the options to the
 ``ServerApi.Builder``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
-   :start-after: start serverAPIVersion
-   :end-before: end serverAPIVersion
+   :start-after: start apiVersionOptions
+   :end-before: end apiVersionOptions
    :language: java
    :dedent:
 

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -15,8 +15,7 @@ Versioned API
    The Versioned API feature requires MongoDB Server 5.0 or later.
 
    You should only use the Versioned API feature if all the MongoDB
-   servers you are connecting to are upgraded to a version that supports
-   this feature.
+   servers you are connecting to support this feature.
 
 This guide shows you how to specify the **Versioned API** when connecting to
 a MongoDB instance or replica set. You can use the Versioned API feature to

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -50,7 +50,7 @@ operations:
 - Instantiate a ``MongoClient`` using the ``MongoClients.create()`` method
   and pass your ``MongClientSettings`` instance as a parameter.
 
-.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPI.java
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPIExample.java
    :start-after: start serverAPIVersion
    :end-before: end serverAPIVersion
    :language: java
@@ -101,7 +101,7 @@ Versioned API as described in the following table.
 The following code example shows how you can set the two options on the
 ``ServerApi`` by chaining the methods to the ``ServerApi.Builder``:
 
-.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPI.java
+.. literalinclude:: /includes/fundamentals/code-snippets/VersionedAPIExample.java
    :start-after: start serverAPIVersion
    :end-before: end serverAPIVersion
    :language: java

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -70,6 +70,7 @@ performing the following operations:
    return an exception message that resembles the following:
 
    .. code-block:: none
+      :copyable: false
 
       com.mongodb.MongoQueryException: Query failed with error code 9 and error message 'Failed to parse: {...} Unrecognized field 'apiVersion'.' on server
 

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -7,9 +7,8 @@ Versioned API
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
-
 
 .. note::
 
@@ -48,7 +47,7 @@ operations:
 - Construct a ``MongoClientSettings`` instance using the
   ``MongoClientSettings.Builder`` class.
 - Instantiate a ``MongoClient`` using the ``MongoClients.create()`` method
-  and pass your ``MongClientSettings`` instance as a parameter.
+  and pass your ``MongoClientSettings`` instance as a parameter.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/VersionedApiExample.java
    :start-after: start serverAPIVersion
@@ -61,7 +60,12 @@ operations:
    Make sure that you are connecting to a version of MongoDB server that
    supports Versioned API. Otherwise, your application may throw an exception
    when attempting to perform any operation that sends a command to
-   MongoDB.
+   MongoDB. For example, a query to a server could return an exception
+   message that resembles the following:
+
+   .. code-block:: none
+
+      com.mongodb.MongoQueryException: Query failed with error code 9 and error message 'Failed to parse: {...} Unrecognized field 'apiVersion'.' on server
 
 For more information on the methods and classes referenced in this
 section, see the following API documentation:
@@ -89,13 +93,15 @@ Versioned API as described in the following table.
 
    * - Strict
      - | **Optional**. When set, if you call a command that is not part of declared API version, the driver raises an exception.
+       |
        | Default: **false**
-       | :java-docs:`strict() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#strict(boolean)>` API documentation
+       | For more information, see the :java-docs:`strict() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#strict(boolean)>` API documentation.
 
    * -  DeprecationErrors
      - | **Optional**. When set, if you call a command that is deprecated in the declared API version, the driver raises an exception.
+       |
        | Default: **false**
-       | :java-docs:`deprecationErrors() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#>` API documentation
+       | For more information, see the :java-docs:`deprecationErrors() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#>` API documentation.
 
 
 The following code example shows how you can set the two options on the
@@ -107,3 +113,4 @@ The following code example shows how you can set the two options on the
    :language: java
    :dedent:
 
+.. _test@#:

--- a/source/includes/fundamentals/code-snippets/VersionedApiExample.java
+++ b/source/includes/fundamentals/code-snippets/VersionedApiExample.java
@@ -22,21 +22,20 @@ public class VersionedAPIExample {
     }
 
     public static void main(String[] args) {
-
-
         // start serverAPIVersion
         ServerApi serverApi = ServerApi.builder()
                 .version(ServerApiVersion.V1)
                 .build();
 
+        ServerAddress serverAddress = new ServerAddress("localhost", 27017);
+
         MongoClientSettings settings = MongoClientSettings.builder()
                 .serverApi(serverApi)
                 .applyToClusterSettings(builder ->
-                        builder.hosts(Arrays.asList(new ServerAddress("localhost", 27017))))
+                        builder.hosts(Arrays.asList(serverAddress)))
                 .build();
 
         MongoClient client = MongoClients.create(settings);
         // end serverAPIVersion
     }
 }
-

--- a/source/includes/fundamentals/code-snippets/VersionedApiExample.java
+++ b/source/includes/fundamentals/code-snippets/VersionedApiExample.java
@@ -1,0 +1,42 @@
+package fundamentals;
+
+import java.util.Arrays;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ServerAddress;
+import com.mongodb.ServerApi;
+import com.mongodb.ServerApiVersion;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+
+public class VersionedAPIExample {
+
+    private static void setApiVersionOptions(String uri) {
+        // start apiVersionOptions
+        ServerApi serverApi = ServerApi.builder()
+                .version(ServerApiVersion.V1)
+                .strict(true)
+                .deprecationErrors(true)
+                .build();
+        // end apiVersionOptions
+    }
+
+    public static void main(String[] args) {
+
+
+        // start serverAPIVersion
+        ServerApi serverApi = ServerApi.builder()
+                .version(ServerApiVersion.V1)
+                .build();
+
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .serverApi(serverApi)
+                .applyToClusterSettings(builder ->
+                        builder.hosts(Arrays.asList(new ServerAddress("localhost", 27017))))
+                .build();
+
+        MongoClient client = MongoClients.create(settings);
+        // end serverAPIVersion
+    }
+}
+

--- a/source/includes/fundamentals/code-snippets/VersionedApiExample.java
+++ b/source/includes/fundamentals/code-snippets/VersionedApiExample.java
@@ -1,16 +1,13 @@
 package fundamentals;
 
-import java.util.Arrays;
-
+import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
-import com.mongodb.ServerAddress;
 import com.mongodb.ServerApi;
 import com.mongodb.ServerApiVersion;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 
-public class VersionedAPIExample {
-
+public class VersionedApiExample {
     private static void setApiVersionOptions(String uri) {
         // start apiVersionOptions
         ServerApi serverApi = ServerApi.builder()
@@ -27,15 +24,16 @@ public class VersionedAPIExample {
                 .version(ServerApiVersion.V1)
                 .build();
 
-        ServerAddress serverAddress = new ServerAddress("localhost", 27017);
+        // Replace the uri string with your MongoDB deployment's connection string
+        String uri = "mongodb+srv://<user>:<password>@<cluster-url>?retryWrites=true&w=majority";
 
         MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(uri))
                 .serverApi(serverApi)
-                .applyToClusterSettings(builder ->
-                        builder.hosts(Arrays.asList(serverAddress)))
                 .build();
 
         MongoClient client = MongoClients.create(settings);
         // end serverAPIVersion
     }
 }
+


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-15781

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/4d2fe1e/java/docsworker-xlarge/DOCSP-15781-versioned-api/fundamentals/versioned-api/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging links in the PR description updated?


### Notes for the Reviewer:

The API links assume that the `:java-docs:` target points to the 4.3 version. Currently, some of the links do not work because the `:java-docs:` target still points to the 4.2 version. 