### PR TITLE
Docsp 9930 legacy api

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -210,8 +210,8 @@ see the following API documentation pages:
 - :java-docs:`one() <apidocs/mongodb-driver-legacy/com/mongodb/DBCursor.html#one()>`
 
 
-How do I use the legacy ``MongoClientOptions`` Class?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I use the legacy ``MongoClientOptions`` and ``MongoClientURI`` Classes?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is an example showing how to use the legacy ``MongoClientOptions`` class to
 set your write concern with the legacy API and the current API:
@@ -242,3 +242,4 @@ see the following API documentation pages:
 - :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
 - :java-docs:`MongoClient <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html>`
 - :java-docs:`MongoClientOptions <apidocs/mongodb-driver-legacy/com/mongodb/MongoClientOptions.html>`
+- :java-docs:`MongoClientURI <apidocs/mongodb-driver-legacy/com/mongodb/MongoClientURI.html>`

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -81,6 +81,16 @@ The output of the above code snippet should look like this:
 
    {"_id": 1, "val": 1}
 
+For more information on the legacy classes and methods used in above example,
+see the following API documentation pages:
+
+- :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
+- :java-docs:`MongoClient <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html>`
+- :java-docs:`DB <apidocs/mongodb-driver-legacy/com/mongodb/DB.html>`
+- :java-docs:`DBCollection <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html>`
+- :java-docs:`DBObject <apidocs/mongodb-driver-core/com/mongodb/DBObject.html>`
+- :java-docs:`find() <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html#find()>`
+- :java-docs:`one() <apidocs/mongodb-driver-legacy/com/mongodb/DBCursor.html#one()>`
 
 POJOs
 -----

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -41,6 +41,8 @@ For applications that require a mix of the new and legacy APIs, ``com.mongodb.Mo
 - Configuration with ``MongoClientSettings`` and ``ConnectionString``, the only difference being that you create instances via constructors instead of a factory class.
 - CRUD API using ``MongoDatabase``, and from there, ``MongoCollection``.  You can access this API via the ``getDatabase()`` method.
 
+.. _faq-legacy-connection:
+
 How do I connect with the legacy API?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -43,11 +43,17 @@ For applications that require a mix of the new and legacy APIs, ``com.mongodb.Mo
 
 .. _faq-legacy-connection:
 
-How do I connect with the legacy API?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I connect to my MongoDB instance with the legacy API?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following example shows how to connect to a MongoDB instance with the
 legacy API and the current API.
+
+Imagine we are connecting to a collection that contains only this document:
+
+.. code-block:: json
+   
+   {"_id": 1, "val": 1}
 
 .. tabs::
 
@@ -68,6 +74,12 @@ legacy API and the current API.
          :dedent:
          :start-after: start current-api-example
          :end-before: end current-api-example
+   
+   The output of the above code snippet should look like this:
+
+   .. code-block:: json
+
+      {"_id": 1, "val": 1}
 
 
 POJOs

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -75,11 +75,11 @@ Imagine we are connecting to a collection that contains only this document:
          :start-after: start current-api-example
          :end-before: end current-api-example
    
-   The output of the above code snippet should look like this:
+The output of the above code snippet should look like this:
 
-   .. code-block:: json
+.. code-block:: json
 
-      {"_id": 1, "val": 1}
+   {"_id": 1, "val": 1}
 
 
 POJOs

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -81,7 +81,7 @@ The output of the above code snippet should look like this:
 
    {"_id": 1, "val": 1}
 
-For more information on the legacy classes and methods used in above example,
+For more information on the legacy classes and methods used in the above example,
 see the following API documentation pages:
 
 - :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -89,6 +89,8 @@ see the following API documentation pages:
 - :java-docs:`DB <apidocs/mongodb-driver-legacy/com/mongodb/DB.html>`
 - :java-docs:`DBCollection <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html>`
 - :java-docs:`DBObject <apidocs/mongodb-driver-core/com/mongodb/DBObject.html>`
+- :java-docs:`getDB() <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html#getDB(java.lang.String)>`
+- :java-docs:`getCollection() <apidocs/mongodb-driver-legacy/com/mongodb/DB.html#getCollection(java.lang.String)>`
 - :java-docs:`find() <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html#find()>`
 - :java-docs:`one() <apidocs/mongodb-driver-legacy/com/mongodb/DBCursor.html#one()>`
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -52,6 +52,7 @@ legacy API and the current API.
 Imagine we are connecting to a collection that contains only this document:
 
 .. code-block:: json
+   :copyable: false
    
    {"_id": 1, "val": 1}
 
@@ -78,6 +79,7 @@ Imagine we are connecting to a collection that contains only this document:
 The output of the above code snippet should look like this:
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "val": 1}
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -213,8 +213,8 @@ see the following API documentation pages:
 How do I use the legacy ``MongoClientOptions`` and ``MongoClientURI`` Classes?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Here is an example showing how to use the legacy ``MongoClientOptions`` class to
-set your write concern with the legacy API and the current API:
+Here is an example showing how to use the legacy ``MongoClientOptions`` and
+``MongoClientURI`` classes to set your write concern:
 
 .. tabs::
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -41,6 +41,33 @@ For applications that require a mix of the new and legacy APIs, ``com.mongodb.Mo
 - Configuration with ``MongoClientSettings`` and ``ConnectionString``, the only difference being that you create instances via constructors instead of a factory class.
 - CRUD API using ``MongoDatabase``, and from there, ``MongoCollection``.  You can access this API via the ``getDatabase()`` method.
 
+How do I connect with the legacy API?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows how to connect to a MongoDB instance with the
+legacy API and the current API.
+
+.. tabs::
+
+   .. tab:: Legacy API
+      :tabid: legacy
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/LegacyAPI.java
+         :language: java
+         :dedent:
+         :start-after: start legacy-api-example
+         :end-before: end legacy-api-example
+
+   .. tab:: Current API
+      :tabid: current
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/CurrentAPI.java
+         :language: java
+         :dedent:
+         :start-after: start current-api-example
+         :end-before: end current-api-example
+
+
 POJOs
 -----
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -41,61 +41,6 @@ For applications that require a mix of the new and legacy APIs, ``com.mongodb.Mo
 - Configuration with ``MongoClientSettings`` and ``ConnectionString``, the only difference being that you create instances via constructors instead of a factory class.
 - CRUD API using ``MongoDatabase``, and from there, ``MongoCollection``.  You can access this API via the ``getDatabase()`` method.
 
-.. _faq-legacy-connection:
-
-How do I connect to my MongoDB instance with the legacy API?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The following example shows how to connect to a MongoDB instance with the
-legacy API and the current API.
-
-Imagine we are connecting to a collection that contains only this document:
-
-.. code-block:: json
-   :copyable: false
-   
-   {"_id": 1, "val": 1}
-
-.. tabs::
-
-   .. tab:: Legacy API
-      :tabid: legacy
-
-      .. literalinclude:: /includes/fundamentals/code-snippets/LegacyAPI.java
-         :language: java
-         :dedent:
-         :start-after: start legacy-api-example
-         :end-before: end legacy-api-example
-
-   .. tab:: Current API
-      :tabid: current
-
-      .. literalinclude:: /includes/fundamentals/code-snippets/CurrentAPI.java
-         :language: java
-         :dedent:
-         :start-after: start current-api-example
-         :end-before: end current-api-example
-   
-The output of the above code snippet should look like this:
-
-.. code-block:: json
-   :copyable: false
-
-   {"_id": 1, "val": 1}
-
-For more information on the legacy classes and methods used in the above example,
-see the following API documentation pages:
-
-- :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
-- :java-docs:`MongoClient <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html>`
-- :java-docs:`DB <apidocs/mongodb-driver-legacy/com/mongodb/DB.html>`
-- :java-docs:`DBCollection <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html>`
-- :java-docs:`DBObject <apidocs/mongodb-driver-core/com/mongodb/DBObject.html>`
-- :java-docs:`getDB() <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html#getDB(java.lang.String)>`
-- :java-docs:`getCollection() <apidocs/mongodb-driver-legacy/com/mongodb/DB.html#getCollection(java.lang.String)>`
-- :java-docs:`find() <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html#find()>`
-- :java-docs:`one() <apidocs/mongodb-driver-legacy/com/mongodb/DBCursor.html#one()>`
-
 POJOs
 -----
 
@@ -204,3 +149,96 @@ POJO class:
 If you are unable to find the answer to your question here, try our forums and
 support channels listed in the :doc:`Issues and Help <issues-and-help>`
 section.
+
+
+Legacy API
+----------
+
+.. _faq-legacy-connection:
+
+How do I connect to my MongoDB instance with the legacy API?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following example shows how to connect to a MongoDB instance with the
+legacy API and the current API.
+
+Imagine we are connecting to a collection that contains only this document:
+
+.. code-block:: json
+   :copyable: false
+   
+   {"_id": 1, "val": 1}
+
+.. tabs::
+
+   .. tab:: Legacy API
+      :tabid: legacy
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/LegacyAPI.java
+         :language: java
+         :dedent:
+         :start-after: start legacy-api-example
+         :end-before: end legacy-api-example
+
+   .. tab:: Current API
+      :tabid: current
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/CurrentAPI.java
+         :language: java
+         :dedent:
+         :start-after: start current-api-example
+         :end-before: end current-api-example
+   
+The output of the above code snippet should look like this:
+
+.. code-block:: json
+   :copyable: false
+
+   {"_id": 1, "val": 1}
+
+For more information on the legacy classes and methods used in the above example,
+see the following API documentation pages:
+
+- :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
+- :java-docs:`MongoClient <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html>`
+- :java-docs:`DB <apidocs/mongodb-driver-legacy/com/mongodb/DB.html>`
+- :java-docs:`DBCollection <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html>`
+- :java-docs:`DBObject <apidocs/mongodb-driver-core/com/mongodb/DBObject.html>`
+- :java-docs:`getDB() <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html#getDB(java.lang.String)>`
+- :java-docs:`getCollection() <apidocs/mongodb-driver-legacy/com/mongodb/DB.html#getCollection(java.lang.String)>`
+- :java-docs:`find() <apidocs/mongodb-driver-legacy/com/mongodb/DBCollection.html#find()>`
+- :java-docs:`one() <apidocs/mongodb-driver-legacy/com/mongodb/DBCursor.html#one()>`
+
+
+How do I use the legacy ``MongoClientOptions`` Class?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here is an example showing how to use the legacy ``MongoClientOptions`` class to
+set your write concern with the legacy API and the current API:
+
+.. tabs::
+
+   .. tab:: Legacy API
+      :tabid: legacy
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/LegacyAPI.java
+         :language: java
+         :dedent:
+         :start-after: start legacy-api-mongoclientoptions-example
+         :end-before: end legacy-api-mongoclientoptions-example
+
+   .. tab:: Current API
+      :tabid: current
+
+      .. literalinclude:: /includes/fundamentals/code-snippets/CurrentAPI.java
+         :language: java
+         :dedent:
+         :start-after: start current-api-mongoclientsettings-example
+         :end-before: end current-api-mongoclientsettings-example
+
+For more information on the legacy classes and methods used in the above example,
+see the following API documentation pages:
+
+- :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
+- :java-docs:`MongoClient <apidocs/mongodb-driver-legacy/com/mongodb/MongoClient.html>`
+- :java-docs:`MongoClientOptions <apidocs/mongodb-driver-legacy/com/mongodb/MongoClientOptions.html>`

--- a/source/includes/fundamentals/code-snippets/CurrentAPI.java
+++ b/source/includes/fundamentals/code-snippets/CurrentAPI.java
@@ -1,0 +1,31 @@
+package com.mycompany.app;
+
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+
+import java.net.URL;
+
+public class CurrentAPI {
+
+    private static final String COLLECTION = "test";
+    private static final String DATABASE = "test";
+    private static final ConnectionString URI = new ConnectionString(System.getenv("DRIVER_URL"));
+
+    public static void main(String[] args) throws InterruptedException {
+        // start current-api-example
+        MongoClient client = MongoClients.create(URI);
+        MongoDatabase db = client.getDatabase(DATABASE);
+        MongoCollection col = db.getCollection(COLLECTION);
+        System.out.println(col.find().first().toString());
+        // end current-api-example
+
+    }
+
+
+
+}

--- a/source/includes/fundamentals/code-snippets/CurrentAPI.java
+++ b/source/includes/fundamentals/code-snippets/CurrentAPI.java
@@ -41,7 +41,7 @@ public class CurrentAPI {
                 .applyConnectionString(new ConnectionString(URI))
                 .writeConcern(WriteConcern.W1).build();
         MongoClient client = MongoClients.create(options);
-        // end legacy-api-mongoclientsettings-example
+        // end current-api-mongoclientsettings-example
         client.close();
     }
 

--- a/source/includes/fundamentals/code-snippets/CurrentAPI.java
+++ b/source/includes/fundamentals/code-snippets/CurrentAPI.java
@@ -7,6 +7,7 @@ import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import org.bson.Document;
+import org.bson.conversions.Bson;
 
 import java.net.URL;
 
@@ -20,8 +21,9 @@ public class CurrentAPI {
         // start current-api-example
         MongoClient client = MongoClients.create(URI);
         MongoDatabase db = client.getDatabase(DATABASE);
-        MongoCollection col = db.getCollection(COLLECTION);
-        System.out.println(col.find().first().toString());
+        MongoCollection<Document> col = db.getCollection(COLLECTION);
+        Document doc = col.find().first();
+        System.out.println(doc.toJson());
         // end current-api-example
 
     }

--- a/source/includes/fundamentals/code-snippets/CurrentAPI.java
+++ b/source/includes/fundamentals/code-snippets/CurrentAPI.java
@@ -1,7 +1,7 @@
 package com.mycompany.app;
 
 
-import com.mongodb.ConnectionString;
+import com.mongodb.*;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
@@ -15,9 +15,16 @@ public class CurrentAPI {
 
     private static final String COLLECTION = "test";
     private static final String DATABASE = "test";
-    private static final ConnectionString URI = new ConnectionString(System.getenv("DRIVER_URL"));
+    private static String URI = System.getenv("DRIVER_URL");
 
     public static void main(String[] args) throws InterruptedException {
+        CurrentAPI c = new CurrentAPI();
+        c.example1();
+        c.example2();
+
+    }
+
+    private void example1() {
         // start current-api-example
         MongoClient client = MongoClients.create(URI);
         MongoDatabase db = client.getDatabase(DATABASE);
@@ -25,8 +32,19 @@ public class CurrentAPI {
         Document doc = col.find().first();
         System.out.println(doc.toJson());
         // end current-api-example
-
+        client.close();
     }
+
+    private void example2() {
+        // start current-api-mongoclientsettings-example
+        MongoClientSettings options = MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(URI))
+                .writeConcern(WriteConcern.W1).build();
+        MongoClient client = MongoClients.create(options);
+        // end legacy-api-mongoclientsettings-example
+        client.close();
+    }
+
 
 
 

--- a/source/includes/fundamentals/code-snippets/LegacyAPI.java
+++ b/source/includes/fundamentals/code-snippets/LegacyAPI.java
@@ -10,8 +10,8 @@ public class LegacyAPI {
 
     public static void main(String[] args) {
         // start legacy-api-example
-        MongoClient mongoClient = new MongoClient(URI);
-        DB db = mongoClient.getDB(DATABASE);
+        MongoClient client = new MongoClient(URI);
+        DB db = client.getDB(DATABASE);
         DBCollection col = db.getCollection(COLLECTION);
         DBObject doc = col.find().one();
         System.out.println(doc.toString());

--- a/source/includes/fundamentals/code-snippets/LegacyAPI.java
+++ b/source/includes/fundamentals/code-snippets/LegacyAPI.java
@@ -1,0 +1,21 @@
+package com.mycompany.app;
+
+import com.mongodb.*;
+
+public class LegacyAPI {
+
+    private static final String COLLECTION = "test";
+    private static final String DATABASE = "test";
+    private static final ConnectionString URI = new ConnectionString(System.getenv("DRIVER_URL"));
+
+    public static void main(String[] args) {
+        // start legacy-api-example
+        MongoClient mongoClient = new MongoClient(URI);
+        DB db = mongoClient.getDB(DATABASE);
+        DBCollection col = db.getCollection(COLLECTION);
+        DBObject doc = col.find().one();
+        System.out.println(doc.toString());
+        // end legacy-api-example
+    }
+
+}

--- a/source/includes/fundamentals/code-snippets/LegacyAPI.java
+++ b/source/includes/fundamentals/code-snippets/LegacyAPI.java
@@ -27,10 +27,10 @@ public class LegacyAPI {
 
     private void example2() {
         // start legacy-api-mongoclientoptions-example
-        MongoClientOptions options = MongoClientOptions.builder()
-                .writeConcern(WriteConcern.W1)
-                .build();
-        MongoClient client = new MongoClient(URI, options);
+        MongoClientURI mongoURI = new MongoClientURI(URI,
+                MongoClientOptions.builder()
+                        .writeConcern(WriteConcern.W1));
+        MongoClient client = new MongoClient(mongoURI);
         // end legacy-api-mongoclientoptions-example
         client.close();
     }

--- a/source/includes/fundamentals/code-snippets/LegacyAPI.java
+++ b/source/includes/fundamentals/code-snippets/LegacyAPI.java
@@ -6,9 +6,15 @@ public class LegacyAPI {
 
     private static final String COLLECTION = "test";
     private static final String DATABASE = "test";
-    private static final ConnectionString URI = new ConnectionString(System.getenv("DRIVER_URL"));
+    private static final String URI = System.getenv("DRIVER_URL");
 
     public static void main(String[] args) {
+        LegacyAPI l = new LegacyAPI();
+        l.example1();
+        l.example2();
+    }
+
+    private void example1() {
         // start legacy-api-example
         MongoClient client = new MongoClient(URI);
         DB db = client.getDB(DATABASE);
@@ -16,6 +22,18 @@ public class LegacyAPI {
         DBObject doc = col.find().one();
         System.out.println(doc.toString());
         // end legacy-api-example
+        client.close();
     }
+
+    private void example2() {
+        // start legacy-api-mongoclientoptions-example
+        MongoClientOptions options = MongoClientOptions.builder()
+                .writeConcern(WriteConcern.W1)
+                .build();
+        MongoClient client = new MongoClient(URI, options);
+        // end legacy-api-mongoclientoptions-example
+        client.close();
+    }
+
 
 }

--- a/source/includes/legacy-redirect.rst
+++ b/source/includes/legacy-redirect.rst
@@ -1,0 +1,4 @@
+.. note:: Legacy API
+
+   For information on setting up a connection with the legacy MongoDB Java
+   driver API, :ref:`see our FAQ page <faq-legacy-connection>`. 

--- a/source/includes/legacy-redirect.rst
+++ b/source/includes/legacy-redirect.rst
@@ -1,4 +1,5 @@
 .. note:: Legacy API
 
-   For information on setting up a connection with the legacy MongoDB Java
-   driver API, :ref:`see our FAQ page <faq-legacy-connection>`. 
+   If you are using the **legacy API**, 
+   :ref:`see our FAQ page <faq-legacy-connection>`
+   to learn what changes you need to make to this code example.

--- a/source/includes/legacy-redirect.rst
+++ b/source/includes/legacy-redirect.rst
@@ -1,5 +1,5 @@
 .. note:: Legacy API
 
-   If you are using the **legacy API**, 
+   If you are using the legacy API, 
    :ref:`see our FAQ page <faq-legacy-connection>`
    to learn what changes you need to make to this code example.

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -89,6 +89,8 @@ The output should look something like this:
    updated: 2
    deleted: 1
 
+.. include:: /includes/legacy-redirect.rst
+
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -43,6 +43,8 @@ following:
 
    dbStats: {"db": "sample_mflix", "collections": 5, "views": 0, "objects": 75595, "avgObjSize": 692.1003770090614, "dataSize": 52319328, "storageSize": 29831168, "numExtents": 0, "indexes": 9, "indexSize": 14430208, "fileSize": 0, "nsSizeMB": 0, "ok": 1}
 
+.. include:: /includes/legacy-redirect.rst
+
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -70,6 +70,8 @@ like this (exact numbers may vary depending on your data):
    Estimated number of documents in the movies collection: 23541
    Number of movies from Spain: 755
 
+.. include:: /includes/legacy-redirect.rst
+
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -38,11 +38,6 @@ sub-document.
 .. literalinclude:: /includes/usage-examples/code-snippets/DeleteMany.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`faq </faq>` to determine
-   what changes you need to make to this code example.
-
 When you run the example, you should see output that reports the number of
 documents deleted in your call to ``deleteMany()``.
 
@@ -50,6 +45,8 @@ documents deleted in your call to ``deleteMany()``.
 
    Deleted document count: 4
 
+.. include:: /includes/legacy-redirect.rst
+   
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -31,11 +31,6 @@ filter to match movies with the ``title`` exactly matching the text
 .. literalinclude:: /includes/usage-examples/code-snippets/DeleteOne.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
-
 When you run the example, if the query filter you passed in your call to
 ``deleteOne()`` matches a document and removes it, you should see output
 that looks something like this:
@@ -50,6 +45,8 @@ documents are removed and your call to ``deleteOne()`` returns the following:
 .. code-block:: none
 
    Deleted document count: 0
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -49,11 +49,6 @@ match movies that include "Carl Franklin" as one of the values in the
 .. literalinclude:: /includes/usage-examples/code-snippets/Distinct.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine
-   what changes you need to make to this code example.
-
 When you run the example, you should see output that reports each distinct
 year for all the movies that Carl Franklin was included as a director,
 which should look something like this:
@@ -65,6 +60,8 @@ which should look something like this:
    1998
    ...
 
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/find.txt
+++ b/source/usage-examples/find.txt
@@ -57,10 +57,8 @@ the ``movies`` collection. It uses the following objects and methods:
 .. literalinclude:: /includes/usage-examples/code-snippets/Find.java
    :language: java
 
-.. note::
 
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/findOne.txt
+++ b/source/usage-examples/findOne.txt
@@ -52,11 +52,8 @@ It uses the following objects and methods:
 .. literalinclude:: /includes/usage-examples/code-snippets/FindOne.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
-
+.. include:: /includes/legacy-redirect.rst
+  
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -31,17 +31,14 @@ collection.
 .. literalinclude:: /includes/usage-examples/code-snippets/InsertMany.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
-
 When you run the example, you should see output that resembles the following
 with the inserted document ``ObjectId`` in each of the value fields:
 
 .. code-block:: none
 
    Inserted document ids: {0=BsonObjectId{value=...}, 1=BsonObjectId{value=...}}
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -31,17 +31,14 @@ collection.
 .. literalinclude:: /includes/usage-examples/code-snippets/InsertOne.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
-
 When you run the example, you should see output that resembles the following
 with the inserted document ``ObjectId`` in the value field:
 
 .. code-block:: none
 
    Inserted document id: BsonObjectId{value=...}
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -80,9 +80,6 @@ The following snippet uses the following objects and methods:
 .. literalinclude:: /includes/usage-examples/code-snippets/ReplaceOne.java
    :language: java
 
-If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine what
-changes you need to make to this code example.
-
 After you run the example, you should see output that looks something like
 this:
 
@@ -108,6 +105,8 @@ If you query the replaced document, it should look something like this:
        fullplot=A dramatization of the true story of Roberta Guaspari who co-founded the Opus 118 Harlem School of Music
      }
    }
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -74,9 +74,6 @@ section for more information.
 .. literalinclude:: /includes/usage-examples/code-snippets/UpdateMany.java
    :language: java
 
-If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine
-what changes you need to make to this code example.
-
 After you run the example, you should see output that looks something like
 this:
 
@@ -100,6 +97,8 @@ this:
      },
      ...
    ]
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -72,11 +72,6 @@ for more information.
 .. literalinclude:: /includes/usage-examples/code-snippets/UpdateOne.java
    :language: java
 
-.. note::
-
-   If you are using the **legacy API**, see the :doc:`FAQ </faq>` to determine 
-   what changes you need to make to this code example.
-
 After you run the example, you should see output that looks something like this:
 
 .. code-block:: none
@@ -105,6 +100,8 @@ If you query the updated document, it should look something like this:
        lastUpdated=Timestamp{...}
      }
    }
+
+.. include:: /includes/legacy-redirect.rst
 
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -163,6 +163,8 @@ is similar to the following:
    Updated 1 document.
    Deleted 1 document.
 
+.. include:: /includes/legacy-redirect.rst
+
 Visit the following resources for additional material on the classes and
 methods presented above:
 


### PR DESCRIPTION
## Pull Request Info

Add note to usage examples linking to FAQ entry that describes differences connecting to a MongoDB instance between the  current and legacy Java APIs.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-9930

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/25fdd6e/java/docsworker-xlarge/DOCSP-9930-Legacy-API/faq/#how-do-i-connect-to-my-mongodb-instance-with-the-legacy-api-

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

