### PR TITLE
Remove collection setup code-block

### DIFF
--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -43,15 +43,15 @@ to any method that expects a projection.
 
    The examples below assume this static import.
 
-Sample Documents
-----------------
+Sample Documents and Examples
+-----------------------------
 
 The following sections feature examples that run query and projection operations
 on a sample collection called ``projection_builders``. Each section uses
 a variable named ``collection`` to refer to the ``MongoCollection`` instance
 of the ``projection_builders`` collection.
 
-The collection contains following documents, representing the years 2018
+The collection contains the following documents, representing the years 2018
 and 2019 and the monthly average temperatures in Celsius:
 
 .. code-block:: json
@@ -93,8 +93,14 @@ and 2019 and the monthly average temperatures in Celsius:
      ]
    }
 
+Projection Operations
+---------------------
+
+The following sections contain information on the available projection
+operations and how to construct them using the ``Projections`` class.
+
 Inclusion
----------
+~~~~~~~~~
 
 Use the ``include()`` method to specify the inclusion of one or more fields.
 
@@ -132,7 +138,7 @@ The following code shows the output from this projection:
    {"_id": {"$oid": "6042edc9f2b56342164e0791"}, "year": 2019, "type": "odd number, can't be a leap year"}
 
 Exclusion
----------
+~~~~~~~~~
 
 Use the ``exclude()`` method to specify the exclusion of one or more fields.
 
@@ -170,7 +176,7 @@ The following code shows the output from this projection:
 
 
 Combining Projections
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
 Use the ``fields()`` method to combine multiple projections.
 
@@ -192,7 +198,7 @@ The following code shows the output from this projection:
    {"year": 2019, "type": "odd number, can't be a leap year"}
 
 Exclusion of ``_id``
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 Use the ``excludeId()`` convenience method to specify the exclusion of the ``_id`` field:
 
@@ -212,7 +218,7 @@ The following code shows the output from this projection:
 
 
 Project an Array Element Match
-------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Use the ``elemMatch(String, Bson)`` method variant to specify an array projection that will include the first
 element of an array that matches a supplied query filter. This filtering occurs **after** all documents matching the
@@ -267,8 +273,8 @@ The following code shows the output from this projection:
 
    {"_id": {"$oid": "6042edc9f2b56342164e0791"}, "year": 2019, "temperatures": [{"month": "March", "avg": 10.43}]}
 
-Slice
------
+Project an Array Slice
+~~~~~~~~~~~~~~~~~~~~~~
 
 Use the ``slice()`` method to project a :manual:`slice </reference/operator/projection/slice/>` of an array.
 
@@ -340,8 +346,8 @@ The following code shows the output from this projection:
      ]
    }
 
-Text Score
-----------
+Project a Text Score
+~~~~~~~~~~~~~~~~~~~~
 
 Use the ``metaTextScore()`` method to specify a projection of
 :manual:`score of a text query </reference/operator/query/text/#return-the-text-search-score/>`

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -44,15 +44,15 @@ to any method that expects a projection.
    The examples below assume this static import.
 
 Sample Documents and Examples
------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following sections feature examples that run query and projection operations
 on a sample collection called ``projection_builders``. Each section uses
 a variable named ``collection`` to refer to the ``MongoCollection`` instance
 of the ``projection_builders`` collection.
 
-The collection contains the following documents, representing the years 2018
-and 2019 and the monthly average temperatures in Celsius:
+The collection contains the following documents, representing the monthly average
+temperatures in Celsius for the years 2018 and 2019:
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -46,8 +46,13 @@ to any method that expects a projection.
 Sample Documents
 ----------------
 
-The collection is set up with the following documents, representing
-the years 2018 and 2019 and the monthly average temperatures in Celsius:
+The following sections feature examples that run query and projection operations
+on a sample collection called ``projection_builders``. Each section uses
+a variable named ``collection`` to refer to the ``MongoCollection`` instance
+of the ``projection_builders`` collection.
+
+The collection contains following documents, representing the years 2018
+and 2019 and the monthly average temperatures in Celsius:
 
 .. code-block:: json
 

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -43,13 +43,50 @@ to any method that expects a projection.
 
    The examples below assume this static import.
 
-The collection is set up with the following documents:
+Sample Documents
+----------------
 
-.. literalinclude:: /includes/fundamentals/code-snippets/builders/Projections.java
-   :start-after: begin collection setup
-   :end-before: end collection setup
-   :language: java
-   :dedent:
+The collection is set up with the following documents, representing
+the years 2018 and 2019 and the monthly average temperatures in Celsius:
+
+.. code-block:: json
+
+   {
+     "year" : 2018,
+     "type" : "even number but not a leap year",
+     "temperatures" : [
+       { "month" : "January", "avg" : 9.765 },
+       { "month" : "February", "avg" : 9.675 },
+       { "month" : "March", "avg" : 10.004 },
+       { "month" : "April", "avg" : 9.983 },
+       { "month" : "May", "avg" : 9.747 },
+       { "month" : "June", "avg" : 9.65 },
+       { "month" : "July", "avg" : 9.786 },
+       { "month" : "August", "avg" : 9.617 },
+       { "month" : "September", "avg" : 9.51 },
+       { "month" : "October", "avg" : 10.042 },
+       { "month" : "November", "avg" : 9.452 },
+       { "month" : "December", "avg" : 9.86 }
+     ]
+   },
+   {
+     "year" : 2019,
+     "type" : "odd number, can't be a leap year",
+     "temperatures" : [
+       { "month" : "January", "avg" : 10.023 },
+       { "month" : "February", "avg" : 9.808 },
+       { "month" : "March", "avg" : 10.43 },
+       { "month" : "April", "avg" : 10.175 },
+       { "month" : "May", "avg" : 9.648 },
+       { "month" : "June", "avg" : 9.686 },
+       { "month" : "July", "avg" : 9.794 },
+       { "month" : "August", "avg" : 9.741 },
+       { "month" : "September", "avg" : 9.84 },
+       { "month" : "October", "avg" : 10.15 },
+       { "month" : "November", "avg" : 9.84 },
+       { "month" : "December", "avg" : 10.366 }
+     ]
+   }
 
 Inclusion
 ---------


### PR DESCRIPTION
## Pull Request Info

This removes the collection setup code block. It also adds a header for the section explaining variable names and the sample documents used. Lastly, upon examining the page I added another header and changed headers/section titles to be more consistent and better support the "On this page" widget.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16496

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/a2a5425/java/docsworker-xlarge/DOCSP-16496/fundamentals/builders/projections/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
