### PR TITLE
Docsp 16488 broken links

### DIFF
--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -151,7 +151,7 @@ To perform an aggregation, pass a list of aggregation stages to the
 method.
 
 The Java driver provides the 
-:java-docs:`Aggregates <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`__
+:java-docs:`Aggregates <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`
 helper class that
 contains builders for aggregation stages.
 
@@ -159,7 +159,7 @@ In the following example, the aggregation pipeline:
 
 - Uses a :manual:`$match </reference/operator/aggregation/match/>` stage to filter for documents whose
   ``categories`` array field contains the element ``Bakery``. The example uses
-  :java-docs:`Aggregates.match <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#match(org.bson.conversions.Bson)>`__
+  :java-docs:`Aggregates.match <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#match(org.bson.conversions.Bson)>`
   to build the ``$match`` stage.
 
 - Uses a :manual:`$group </reference/operator/aggregation/group/>` stage to group the matching documents by the ``stars``

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -43,9 +43,9 @@ Using ``aggregation`` operations, you can:
 - summarize data
 - group values
 
-Aggregation operations have some :manual:`limitations <core/aggregation-pipeline-limits/>` you must keep in mind:
+Aggregation operations have some :manual:`limitations </core/aggregation-pipeline-limits/>` you must keep in mind:
 
-- Returned documents must not violate the :manual:`BSON document size limit </reference/limits/#BSON-Document-Size>`
+- Returned documents must not violate the :manual:`BSON document size limit </reference/limits/#mongodb-limit-BSON-Document-Size>`
   of 16 megabytes.
 
 - Pipeline stages have a memory limit of 100 megabytes by default. If required, you may exceed this limit by using
@@ -54,7 +54,7 @@ Aggregation operations have some :manual:`limitations <core/aggregation-pipeline
 
   .. important:: ``$graphLookup`` exception
 
-     The :manual:`$graphLookup </operator/aggregation/graphLookup/>` stage has a strict memory limit of 100 megabytes
+     The :manual:`$graphLookup </reference/operator/aggregation/graphLookup/>` stage has a strict memory limit of 100 megabytes
      and will ignore ``allowDiskUse``.
 
 
@@ -146,21 +146,23 @@ Insert the Data
 Basic Aggregation Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To perform an aggregation, pass a list of aggregation stages to the `MongoCollection.aggregate() <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-core/com/mongodb/client/MongoCollection.html#aggregate(com.mongodb.client.ClientSession,java.util.List,java.lang.Class)>`__
+To perform an aggregation, pass a list of aggregation stages to the 
+:java-docs:`MongoCollection.aggregate() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#aggregate(java.util.List)>`
 method.
 
-The Java driver provides the `Aggregates <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`__
+The Java driver provides the 
+:java-docs:`Aggregates <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`__
 helper class that
 contains builders for aggregation stages.
 
 In the following example, the aggregation pipeline:
 
-- Uses a :manual:`$match <reference/operator/aggregation/match/>` stage to filter for documents whose
+- Uses a :manual:`$match </reference/operator/aggregation/match/>` stage to filter for documents whose
   ``categories`` array field contains the element ``Bakery``. The example uses
-  `Aggregates.match <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#match(org.bson.conversions.Bson)>`__
+  :java-docs:`Aggregates.match <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#match(org.bson.conversions.Bson)>`__
   to build the ``$match`` stage.
 
-- Uses a :manual:`$group <reference/operator/aggregation/group/>` stage to group the matching documents by the ``stars``
+- Uses a :manual:`$group </reference/operator/aggregation/group/>` stage to group the matching documents by the ``stars``
   field, accumulating a count of documents for each distinct value of ``stars``.
 
 .. note::
@@ -184,8 +186,10 @@ The above aggregation should produce the following results:
 Aggregation Expression Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Java driver provides builders for :java-sync-api:`accumulator expressions<com/mongodb/client/model/Accumulators.html>`
-for use with :java-sync-api:`$group <com/mongodb/client/model/Aggregates.html#group(TExpression,java.util.List)>`. You
+The Java driver provides builders for
+:java-docs:`accumulator expressions <apidocs/mongodb-driver-core/com/mongodb/client/model/Accumulators.html>`
+for use with 
+:java-docs:`$group <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#group(TExpression,java.util.List)>`. You
 must declare all other expressions in JSON format or compatible document format.
 
 .. tip::

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -273,7 +273,7 @@ mechanism:
 
       To specify the ``MONGODB-AWS`` authentication mechanism using the
       ``MongoCredential`` class, use the
-      :java-docs:`createAwsCredential() </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#createAwsCredential(java.lang.String,char%5B%5D)>`
+      :java-docs:`createAwsCredential() <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#createAwsCredential(java.lang.String,char%5B%5D)>`
       method. Your code to instantiate a ``MongoClient`` should look something like this:
 
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-aws.rst

--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -358,7 +358,7 @@ mechanism:
       ``MongoCredential`` class, use the
       :java-docs:`createMongoX509Credential() </apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#createMongoX509Credential(java.lang.String)>`
       method. Also, enable TLS by calling the
-      :java-sync-api:`applyToSslSettings() <com/mongodb/MongoClientSettings.Builder.html#applyToSslSettings(com.mongodb.Block)>`
+      :java-docs:`applyToSslSettings() <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html#applyToSslSettings(com.mongodb.Block)>`
       method and setting the ``enabled`` property to ``true`` in the
       :java-docs:`SslSettings.Builder </apidocs/mongodb-driver-core/com/mongodb/connection/SslSettings.Builder.html>`
       block. Your code to instantiate a ``MongoClient`` should look something like this:

--- a/source/fundamentals/builders/filters.txt
+++ b/source/fundamentals/builders/filters.txt
@@ -462,7 +462,7 @@ The geospatial operator methods include:
 
 The following example creates a filter that matches documents in which
 the ``point`` field contains a GeoJSON geometry that falls within
-the given :manual:`Polygon </reference/geojson/index.html#polygon>` 
+the given :manual:`Polygon </reference/geojson/#polygon>` 
 in the ``geo_points`` collection:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/Filters.java

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -201,7 +201,7 @@ The following code shows the output from this projection:
 
 
 When you've specified matching criteria in the **query** portion of your operation, use the ``elemMatch(String)`` method
-variant to specify a :manual:`positional projection </reference/operator/projection/positional/#projection/>` to include
+variant to specify a :manual:`positional projection </reference/operator/projection/positional/#sorts-and-the-positional-operator>` to include
 the first element of an array. Only documents that match the query filter will be retrieved.
 
 .. warning::
@@ -302,7 +302,7 @@ Text Score
 ----------
 
 Use the ``metaTextScore()`` method to specify a projection of
-:manual:`score of a text query </reference/operator/query/text/#return-the-text-search-score/>`
+:manual:`score of a text query </reference/operator/query/text/#text-score>`
 
 The following example projects the text score as the value of the ``score`` field:
 

--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -283,7 +283,7 @@ Current Date
 ~~~~~~~~~~~~
 Use the :java-core-api:`currentDate() <com/mongodb/client/model/Updates.html#currentDate(java.lang.String)>`
 method to assign the value of a field in an update operation to the
-current date as a :manual:`date </reference/bson-types/#document-bson-type-date>`.
+current date as a :manual:`date </reference/bson-types/#date>`.
 
 The following example sets the value of the ``lastModified`` field to
 the current date as a BSON date:
@@ -311,7 +311,7 @@ Current Timestamp
 ~~~~~~~~~~~~~~~~~
 Use the :java-core-api:`currentTimestamp() <com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
 method to assign the value of a field in an update operation to the
-current date as a :manual:`timestamp </reference/bson-types/#document-bson-type-timestamp>`. 
+current date as a :manual:`timestamp </reference/bson-types/#timestamps>`. 
 
 The following example sets the value of the ``lastModified`` field to
 the current date as a BSON timestamp:

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -57,9 +57,8 @@ connected. The following example shows each part of the connection URI:
    :alt: Connection String parts figure
 
 In this example, for the protocol, we use ``mongodb+srv`` which specifies the
-:manual:`DNS Seedlist Connection Format
-</reference/connection-string/#dns-seedlist-connection-format>`. This indicates
-that the hostname following it corresponds to the DNS SRV record of your
+:manual:`DNS Seedlist Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`. 
+This indicates that the hostname following it corresponds to the DNS SRV record of your
 MongoDB instance or deployment. If your instance or deployment does not have a
 DNS SRV record, use ``mongodb`` to specify the :manual:`Standard Connection
 Format </reference/connection-string/#standard-connection-string-format>`.
@@ -132,9 +131,8 @@ replica set named "myRs".
 
 .. note::
 
-   The :manual:`replicaSet option
-   </reference/connection-string/#urioption.replicaSet>` is not
-   necessary to connect to a replica set, since the driver automatically
+   The :manual:`replicaSet option </reference/connection-string/#replica-set-option>`
+   is not necessary to connect to a replica set, since the driver automatically
    detects and handles multiple hosts in the connection string as a
    replica set.
 
@@ -199,11 +197,12 @@ using a method in the ``MongoClientSettings.Builder`` class.
    .. tab:: MongoClientSettings
       :tabid: mongoclientsettings
 
-      To enable compression with :java-sync-api:`MongoClientSettings
-      <com/mongodb/MongoClientSettings.html>`, pass the
-      :java-sync-api:`compressorList()
-      <com/mongodb/MongoClientSettings.Builder.html#compressorList(java.util.List)>`
-      builder method a list of :java-sync-api:`MongoCompressor <com/mongodb/MongoCompressor.html>`
+      To enable compression with 
+      :java-docs:`MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`, 
+      pass the
+      :java-docs:`compressorList() <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html#compressorList(java.util.List)>`
+      builder method a list of 
+      :java-docs:`MongoCompressor <apidocs/mongodb-driver-core/com/mongodb/MongoCompressor.html>`
       instances. You can specify one or more compression algorithms in the list:
 
       .. code-block:: java
@@ -345,20 +344,19 @@ parameters of the connection URI to specify the behavior of the client.
      - integer
      - Specifies a time limit, in milliseconds, for the write concern. For
        more information, see the server documentation for the
-       :manual:`wtimeoutMS option
-       </reference/connection-string/#urioption.wtimeoutMS>`.
+       :manual:`wtimeoutMS option </reference/connection-string/#write-concern-options>`.
 
    * - **readPreference**
      - string
      - Specifies the read preference. For more information on values, see
-       the server documentation for the :manual:`readPreference option
-       </reference/connection-string/#urioption.readPreference>`.
+       the server documentation for the 
+       :manual:`readPreference option </reference/connection-string/#urioption.readPreference>`.
 
    * - **readPreferenceTags**
      - string
      - Specifies the read preference tags. For more information on values, see
-       the server documentation for the :manual:`readPreferenceTags option
-       </reference/connection-string/#urioption.readPreferenceTags>`.
+       the server documentation for the
+       :manual:`readPreferenceTags option </reference/connection-string/#urioption.readPreferenceTags>`.
 
    * - **maxStalenessSeconds**
      - integer
@@ -368,8 +366,7 @@ parameters of the connection URI to specify the behavior of the client.
        should be no staleness check for secondaries. The minimum value is
        either 90 seconds or the heartbeat frequency plus 10 seconds, whichever
        is greater. For more information, see the server documentation for the
-       :manual:`maxStalenessSeconds option
-       </reference/connection-string/#urioption.maxStalenessSeconds>`.
+       :manual:`maxStalenessSeconds option </reference/connection-string/#urioption.maxStalenessSeconds>`.
 
    * - **authMechanism**
      - string
@@ -430,12 +427,13 @@ parameters of the connection URI to specify the behavior of the client.
      - string
      - Specifies the UUID representation to use for read and write
        operations. For more information, see the the driver documentation
-       for the :java-sync-api:`MongoClientSettings.getUuidRepresentation() method
-       <com/mongodb/MongoClientSettings.html#getUuidRepresentation()>`.
+       for the 
+       :java-docs:`MongoClientSettings.getUuidRepresentation() method <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getUuidRepresentation()>`.
 
    * - **directConnection**
      - boolean
      - Specifies that the driver must connect to the host directly.
 
-For a complete list of options, see the :java-sync-api:`ConnectionString
-<com/mongodb/ConnectionString.html>` API reference page.
+For a complete list of options, see the 
+:java-docs:`ConnectionString <apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html>`
+API reference page.

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -66,7 +66,7 @@ Format </reference/connection-string/#standard-connection-string-format>`.
 .. note::
 
    If your deployment is on MongoDB Atlas, follow the
-   :atlas:`Atlas driver connection guide <driver-connection?jmp=docs_driver_java>`
+   :atlas:`Atlas driver connection guide </driver-connection?jmp=docs_driver_java>`
    to retrieve your connection string.
 
 The next part of the connection string contains your username and password

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -50,8 +50,8 @@ using a method in the ``MongoClientSettings.Builder`` class.
       :tabid: mongoclientsettings
 
       To configure your ``MongoClient``'s TLS/SSL connection options using the
-      ``MongoClientSettings.Builder`` class, call the :java-sync-api:`applyToSslSettings()
-      <com/mongodb/MongoClientSettings.Builder.html#applyToSslSettings(com.mongodb.Block)>`
+      ``MongoClientSettings.Builder`` class, call the 
+      :java-docs:`applyToSslSettings() <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html#applyToSslSettings(com.mongodb.Block)>`
       method. Set the ``enabled`` property to ``true`` in the ``SslSettings.Builder``
       block to enable TLS/SSL:
 

--- a/source/fundamentals/crud/read-operations/geo.txt
+++ b/source/fundamentals/crud/read-operations/geo.txt
@@ -40,7 +40,7 @@ Here is the location of MongoDB headquarters in GeoJSON:
    }
 
 For definitive information on GeoJSON, see the
-:rfc:`official IETF specification <7946>`.
+`official IETF specification <https://datatracker.ietf.org/doc/html/rfc7946>`__.
 
 .. external resource
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -304,7 +304,7 @@ You can specify the order of the results of a
 :manual:`text search </text-search/>` by how closely the string values of
 each result's fields specified by the collection's text index match your search
 string. The text search assigns a numerical
-:manual:`text score </reference/operator/aggregation/meta/#exp._S_meta>` to
+:manual:`text score </reference/operator/aggregation/meta/>` to
 indicate how closely each result matches the search string. Use the
 ``Sorts.metaTextScore()`` static factory method to build your sort criteria to
 sort by the text score.

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -161,7 +161,7 @@ Your output should look something like this:
 For additional information on the classes and methods mentioned in this
 section, see the following resources: 
 
-- :java-sync-api:`API Documentation on insertMany() <com/mongodb/client/MongoCollection.html#insertMany>`
+- :java-docs:`API Documentation on insertMany() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#insertMany(java.util.List)>`
 - :java-docs:`API Documentation on InsertManyResult <apidocs/mongodb-driver-core/com/mongodb/client/result/InsertManyResult.html>`
 - :manual:`Manual Explanation on insertMany() </reference/method/db.collection.insertMany/>`
 - :doc:`Runnable Insert Multiple Documents Example </usage-examples/insertMany>`

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -73,7 +73,7 @@ See the table below to see a description of each format:
 .. note::
 
    The ``$uuid`` Extended JSON type is parsed from a String to a
-   :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html#<init>(java.util.UUID)>`
+   :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html>`
    object of binary subtype 4. For more information about ``$uuid`` field
    parsing, see the
    :spec:`special rules for parsing $uuid fields </extended-json.rst#special-rules-for-parsing-uuid-fields>`

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -20,8 +20,8 @@ Databases are organized into collections which contain **documents**.
 Documents
 contain literal data such as strings, numbers, and dates as well as
 other (embedded) documents. For more information on document field
-types and structure, see the server documentation for :manual:`documents
-<core/document/>`. 
+types and structure, see the server documentation for 
+:manual:`documents </core/document/>`. 
 
 Access a Database
 -----------------
@@ -169,6 +169,6 @@ normally inherit:
    settings.
 
 For more information, see the server documentation on
-:manual:`read preferences <core/read-preference/>`,
-:manual:`read concerns <reference/read-concern/>`, and
-:manual:`write concerns <reference/write-concern/>`.
+:manual:`read preferences </core/read-preference/>`,
+:manual:`read concerns </reference/read-concern/>`, and
+:manual:`write concerns </reference/write-concern/>`.

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -66,7 +66,7 @@ from the index, also called a **covered query**.
    descending would require an in-memory sort.
 
 For additional information on how to ensure your index covers your query criteria and projection, see the MongoDB manual
-articles on :manual:`query coverage </core/query-optimization/#read-operations-covered-query>`.
+articles on :manual:`query coverage </core/query-optimization/#covered-query>`.
 
 Operational Considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,7 +82,7 @@ Wildcard indexes are not designed to replace workload-based index planning.
 
 For more information on designing your data model and choosing indexes appropriate for your application, see the MongoDB
 server documentation on :manual:`Indexing Strategies </applications/indexes>` and
-:manual:`Data Modeling and Indexes </core/data-model-operations/#data-model-indexes>`.
+:manual:`Data Modeling and Indexes </core/data-model-operations/#indexes>`.
 
 Index Types
 -----------

--- a/source/usage-examples.txt
+++ b/source/usage-examples.txt
@@ -35,10 +35,10 @@ operations. Each example provides:
 How to Use the Usage Examples
 -----------------------------
 
-These examples use the :atlas:`sample datasets <sample-data>` provided by
+These examples use the :atlas:`sample datasets </sample-data>` provided by
 Atlas. You can load them into your database on the free tier of MongoDB
 Atlas by following the
-:atlas:`Get Started with Atlas Guide <getting-started/#atlas-getting-started>`
+:atlas:`Get Started with Atlas Guide </getting-started/#atlas-getting-started>`
 or you can
 :guides:`import the sample dataset into a local MongoDB instance
 </server/import/>`.

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -49,5 +49,5 @@ For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
 - :java-sync-api:`runCommand <com/mongodb/client/MongoDatabase.html#runCommand(org.bson.conversions.Bson)>`
-- :manual:`command <reference/command/>`
-- :manual:`dbStats <reference/command/dbStats/>`
+- :manual:`command </reference/command/>`
+- :manual:`dbStats </reference/command/dbStats/>`

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -75,8 +75,8 @@ like this (exact numbers may vary depending on your data):
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`countDocuments() <com/mongodb/client/MongoCollection.html#countDocuments()>`
-- :java-sync-api:`estimatedDocumentCount() <com/mongodb/client/MongoCollection.html#estimatedDocumentCount()>`
-- :java-sync-api:`CountOptions <com/mongodb/client/model/CountOptions.html>`
-- :java-sync-api:`EstimatedDocumentCountOptions <com/mongodb/client/model/EstimatedDocumentCountOptions.html>`
+- :java-docs:`countDocuments() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#countDocuments()>`
+- :java-docs:`estimatedDocumentCount() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#estimatedDocumentCount()>`
+- :java-docs:`CountOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/CountOptions.html>`
+- :java-docs:`EstimatedDocumentCountOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/EstimatedDocumentCountOptions.html>`
 

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -31,8 +31,6 @@ specify the behavior of the call:
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 10 20
-
 
    * - Method
      - Optional Paramter Class

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -31,6 +31,8 @@ specify the behavior of the call:
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
+   :widths: 10 20
+
 
    * - Method
      - Optional Paramter Class

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -50,7 +50,6 @@ documents deleted in your call to ``deleteMany()``.
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`deleteMany() <com/mongodb/client/MongoCollection.html#deleteMany(org.bson.conversions.Bson)>`
-- :java-sync-api:`deleteResult <com/mongodb/client/result/DeleteResult.html>`
-- :java-sync-api:`drop() <com/mongodb/client/MongoCollection.html#drop()>`
-
+- :java-docs:`deleteMany() </apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#deleteMany(org.bson.conversions.Bson)>`
+- :java-docs:`DeleteResult </apidocs/mongodb-driver-core/com/mongodb/client/result/DeleteResult.html>`
+- :java-docs:`drop() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#drop()>`

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -51,7 +51,6 @@ documents are removed and your call to ``deleteOne()`` returns the following:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`deleteOne <com/mongodb/client/MongoCollection.html#deleteOne(org.bson.conversions.Bson)>`
-- :java-sync-api:`DeleteOneResult <com/mongodb/client/result/DeleteResult.html?is-external=true>`
-- :java-sync-api:`eq Filter <com/mongodb/client/model/Filters.html#eq(java.lang.String,TItem)>`
-  
+- :java-docs:`deleteOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#deleteOne(org.bson.conversions.Bson)>`
+- :java-docs:`DeleteResult </apidocs/mongodb-driver-core/com/mongodb/client/result/DeleteResult.html>`
+- :java-docs:`eq() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#eq(java.lang.String,TItem)>`  

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -43,6 +43,6 @@ with the inserted document ``ObjectId`` in each of the value fields:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`insertMany() <com/mongodb/client/MongoCollection.html#insertMany>`
-- :java-sync-api:`Document <bson/org/bson/Document.html>`
-- :java-sync-api:`InsertManyResult <com/mongodb/client/result/InsertManyResult.html>`
+- :java-docs:`insertMany() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#insertMany(java.util.List)>`
+- :java-docs:`Document <apidocs/bson/org/bson/Document.html>`
+- :java-docs:`InsertManyResult <apidocs/mongodb-driver-core/com/mongodb/client/result/InsertManyResult.html>`

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -43,7 +43,7 @@ with the inserted document ``ObjectId`` in the value field:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`insertOne <com/mongodb/client/MongoCollection.html#insertOne(TDocument)>`
-- :java-sync-api:`Document <bson/org/bson/Document.html>`
-- :java-sync-api:`InsertOneResult <com/mongodb/client/result/InsertOneResult.html>`
+- :java-docs:`insertOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#insertOne(TDocument)>`
+- :java-docs:`Document <apidocs/bson/org/bson/Document.html>`
+- :java-docs:`InsertOneResult <apidocs/mongodb-driver-core/com/mongodb/client/result/InsertOneResult.html>`
 

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -111,7 +111,7 @@ If you query the replaced document, it should look something like this:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`ReplaceOne <com/mongodb/client/MongoCollection.html#replaceOne(org.bson.conversions.Bson,TDocument)>`
-- :java-sync-api:`ReplaceOptions <com/mongodb/client/model/ReplaceOptions.html>`
-- :java-sync-api:`UpdateResult <com/mongodb/client/result/UpdateResult.html>`
-- :java-sync-api:`Filters.eq <com/mongodb/client/model/Filters.html#eq(TItem)>`
+- :java-docs:`ReplaceOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#replaceOne(org.bson.conversions.Bson,TDocument)>`
+- :java-docs:`ReplaceOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/ReplaceOptions.html?is-external=true>`
+- :java-docs:`UpdateResult <apidocs/mongodb-driver-core/com/mongodb/client/result/UpdateResult.html>`
+- :java-docs:`eq() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#eq(java.lang.String,TItem)>`

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -104,7 +104,7 @@ For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
 - :java-docs:`UpdateMany <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#updateMany(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
-- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html.html>`
+- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html>`
 - :java-docs:`combine() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
 - :java-docs:`addToSet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
 - :java-docs:`currentTimestamp() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -103,10 +103,9 @@ this:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`UpdateMany <com/mongodb/client/MongoCollection.html#updateMany(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
-- :java-sync-api:`UpdateOptions <com/mongodb/client/model/UpdateOptions.html>`
-- :java-sync-api:`Updates.combine <com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
-- :java-sync-api:`Updates.addToSet <com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
-- :java-sync-api:`Updates.currentTimestamp <com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
-- :java-sync-api:`UpdateResult <com/mongodb/client/result/UpdateResult.html>`
-
+- :java-docs:`UpdateMany <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#updateMany(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
+- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html.html>`
+- :java-docs:`combine() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
+- :java-docs:`addToSet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
+- :java-docs:`currentTimestamp() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
+- :java-docs:`UpdateResult <apidocs/mongodb-driver-core/com/mongodb/client/result/UpdateResult.html>`

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -106,11 +106,10 @@ If you query the updated document, it should look something like this:
 For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
-- :java-sync-api:`UpdateOne <com/mongodb/client/MongoCollection.html#updateOne(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
-- :java-sync-api:`UpdateOptions <com/mongodb/client/model/UpdateOptions.html>`
-- :java-sync-api:`Updates.combine <com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
-- :java-sync-api:`Updates.set <com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`
-- :java-sync-api:`Updates.addToSet <com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
-- :java-sync-api:`Updates.currentTimestamp <com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
-- :java-sync-api:`UpdateResult <com/mongodb/client/result/UpdateResult.html>`
-
+- :java-docs:`UpdateOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#updateOne(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
+- :java-docs:`UpdateOptions <apidocs/mongodb-driver-sync/com/mongodb/client/model/UpdateOptions.html>`
+- :java-docs:`combine() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
+- :java-docs:`set() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`
+- :java-docs:`addToSet() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
+- :java-docs:`currentTimestamp() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
+- :java-docs:`UpdateResult <apidocs/mongodb-driver-sync/com/mongodb/client/result/UpdateResult.html>`

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -107,9 +107,9 @@ For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
 - :java-docs:`UpdateOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#updateOne(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
-- :java-docs:`UpdateOptions <apidocs/mongodb-driver-sync/com/mongodb/client/model/UpdateOptions.html>`
-- :java-docs:`combine() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
-- :java-docs:`set() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`
-- :java-docs:`addToSet() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
-- :java-docs:`currentTimestamp() <apidocs/mongodb-driver-sync/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
-- :java-docs:`UpdateResult <apidocs/mongodb-driver-sync/com/mongodb/client/result/UpdateResult.html>`
+- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html.html>`
+- :java-docs:`combine() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
+- :java-docs:`set() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`
+- :java-docs:`addToSet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`
+- :java-docs:`currentTimestamp() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`
+- :java-docs:`UpdateResult <apidocs/mongodb-driver-core/com/mongodb/client/result/UpdateResult.html>`

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -107,7 +107,7 @@ For additional information on the classes and methods mentioned on this
 page, see the following API documentation:
 
 - :java-docs:`UpdateOne <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#updateOne(org.bson.conversions.Bson,java.util.List,com.mongodb.client.model.UpdateOptions)>`
-- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html.html>`
+- :java-docs:`UpdateOptions <apidocs/mongodb-driver-core/com/mongodb/client/model/UpdateOptions.html>`
 - :java-docs:`combine() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#combine(org.bson.conversions.Bson...)>`
 - :java-docs:`set() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`
 - :java-docs:`addToSet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -27,7 +27,7 @@ New features of the 4.2 Java driver release include:
 - Added Kerberos caching tickets for reuse in multiple authentication requests
 - Added `MongoClients <http://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html>`_ instances with ``MongoClientSettings`` or ``ConnectionString`` as the configuration
 -  The ``explain()`` method can now be used on `find <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#explain()>`_ and `aggregate <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/AggregateIterable.html#explain()>`_ commands
-- Added a `JsonObject <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/bson/org/bson/json/JsonObject.html#%3Cinit%3E(java.lang.String)>`_ class to make encoding from and decoding to JSON more efficient by avoiding an intermediate Map representation
+- Added a `JsonObject <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/bson/org/bson/json/JsonObject.html>`_ class to make encoding from and decoding to JSON more efficient by avoiding an intermediate Map representation
 - Added a `BsonRepresentation <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/bson/org/bson/codecs/pojo/annotations/BsonRepresentation.html>`_ annotation that allows ``ObjectId`` BSON values to be represented as a ``String`` in `POJO <https://en.wikipedia.org/wiki/Plain_old_Java_object>`_ classes
 - Added a `Filters.empty() <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#empty()>`_ method
 


### PR DESCRIPTION
## Pull Request Info

Fix Broken Links For Docs Release

### Issue JIRA link:

https://jira.mongodb.org/browse/DOCSP-16488

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/25ccaf3/java/docsworker-xlarge/DOCSP-16488-Broken-Links/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?

Some API links on the Versioned API Page Are expected not to work. See the [Versioned API PR](https://github.com/mongodb/docs-java/pull/87) For more details

- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
