### PR TITLE
Add csfle guide

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -22,6 +22,4 @@ Fundamentals
    /fundamentals/logging
    /fundamentals/monitoring
    /fundamentals/gridfs
-
-..
-  /fundamentals/csfle
+   /fundamentals/csfle

--- a/source/fundamentals/csfle.txt
+++ b/source/fundamentals/csfle.txt
@@ -4,6 +4,15 @@ Client-Side Field Level Encryption
 
 .. default-domain:: mongodb
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
 Client-Side Field Level Encryption (CSFLE) allows you to encrypt
 specific data fields within a document with your MongoDB client application before sending the data to the server.
 Starting in MongoDB 4.2 Enterprise, you can perform this client-side encryption automatically.

--- a/source/includes/fundamentals/code-snippets/libmongocrypt-gradle-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/libmongocrypt-gradle-versioned.rst
@@ -1,6 +1,6 @@
 .. code-block:: groovy
 
    dependencies {
-       compile 'org.mongodb:mongodb-crypt:1.1.0'
+       compile 'org.mongodb:mongodb-crypt:1.2.0'
    }
 

--- a/source/includes/fundamentals/code-snippets/libmongocrypt-maven-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/libmongocrypt-maven-versioned.rst
@@ -4,7 +4,7 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>mongodb-crypt</artifactId>
-           <version>1.1.0</version>
+           <version>1.2.0</version>
        </dependency>
    </dependencies>
 


### PR DESCRIPTION
## Pull Request Info

Add CSFLE guide to TOC. Update Mongo Crypt Version. Add basic style items as well like "On This Page" widget and "Overview" header.

### Issue JIRA link:

https://jira.mongodb.org/browse/DOCSP-16557 (Retroactively Made)

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/e20ccd0/java/docsworker-xlarge/add-CSFLE-guide/fundamentals/csfle/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
