### PR TITLE
DOCSP-16534 fixed backticks

### DIFF
--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -303,7 +303,7 @@ the geospatial data for inclusion, intersection, and proximity. For more informa
 To create a 2dsphere index, you must specify a field that contains only **GeoJSON objects**. For more details on this
 type, see the MongoDB server manual page on :manual:`GeoJSON objects </reference/geojson>`.
 
-The ``location.geo`` field in following sample document from the ``theaters`` collection in the ``sample_mflix```
+The ``location.geo`` field in following sample document from the ``theaters`` collection in the ``sample_mflix``
 database is a GeoJSON Point object that describes the coordinates of the theater:
 
 .. code-block:: javascript

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -204,7 +204,7 @@ Multikey Indexes (Indexes on Array Fields)
 **Multikey indexes** are indexes that improve performance for queries that specify a field with an index that contains
 an array value. You can define a multikey index using the same syntax as a single field or compound index.
 
-The following example creates a compound, multikey index on the ``rated`, ``genres`` (an array of
+The following example creates a compound, multikey index on the ``rated``, ``genres`` (an array of
 Strings), and ``title`` fields:
 
 .. common-content-end
@@ -303,7 +303,7 @@ the geospatial data for inclusion, intersection, and proximity. For more informa
 To create a 2dsphere index, you must specify a field that contains only **GeoJSON objects**. For more details on this
 type, see the MongoDB server manual page on :manual:`GeoJSON objects </reference/geojson>`.
 
-The ``location.geo` field in following sample document from the ``theaters`` collection in the ``sample_mflix```
+The ``location.geo`` field in following sample document from the ``theaters`` collection in the ``sample_mflix```
 database is a GeoJSON Point object that describes the coordinates of the theater:
 
 .. code-block:: javascript


### PR DESCRIPTION
## Pull Request Info
Removed rendered backticks -- only found on indexes page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16534

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-16534-backticks/fundamentals/indexes/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
