### PR TITLE
DOCSP-16493: add overview section to all fundamentals pages

### DIFF
--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -10,6 +10,9 @@ Authentication Mechanisms
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 In this guide, we show you how to authenticate with MongoDB using each
 **authentication mechanism** available in the MongoDB Community Edition.
 Authentication mechanisms are processes by which the driver and server

--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -3,7 +3,7 @@ Builders
 ========
 
 .. default-domain:: mongodb
-   
+
 .. toctree::
 
    /fundamentals/builders/aggregates
@@ -19,16 +19,16 @@ Builders
    :depth: 2
    :class: singlecol
 
-This section includes guides on how to use each of the available
-builders, and demonstrates the utility the Java driver builder classes
-provide. 
-
 Overview
 --------
 
+This section includes guides on how to use each of the available
+builders, and demonstrates the utility the Java driver builder classes
+provide.
+
 The Java driver provides classes to simplify the process for developers
 to use CRUD operations and the Aggregation API. The static utility methods allow you
-to build a query more efficiently. 
+to build a query more efficiently.
 
 Why Use Builders?
 -----------------
@@ -47,7 +47,7 @@ With the builder classes, you write operators as methods. The IDE
 instantly underlines and gives you a red bar on the right indicating
 something is wrong. While developing, the IDE also shows you with the
 methods you can use. It automatically completes your code with
-placeholder parameters once you select which method you want to use. 
+placeholder parameters once you select which method you want to use.
 
 Scenario
 --------
@@ -55,7 +55,7 @@ Scenario
 Imagine we want to send a marketing email to all users in our ``users``
 collection with the following criteria:
 
-- Users that identify as "female" gender 
+- Users that identify as "female" gender
 - Users that are older than "29"
 
 We only want their email address, so we'll ensure our query doesn't
@@ -99,3 +99,4 @@ Available Builders
 - :ref:`Updates <updates-builders>` for building updates.
 - :ref:`Aggregates <aggregates-builders>` for building aggregation pipelines.
 - :ref:`Indexes <indexes-builders>` for creating index keys.
+

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -12,6 +12,9 @@ Aggregates Builders
 
 .. _aggregates-builders:
 
+Overview
+--------
+
 This guide provides an overview of the :java-core-api:`Aggregates </com/mongodb/client/model/Aggregates>`
 class which provides static factory methods that build :manual:`aggregation pipeline
 stages </reference/operator/aggregation/>`.

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -15,6 +15,9 @@ Connection Guide
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 This guide shows you how to connect to a MongoDB instance or replica set
 deployment using the driver.
 

--- a/source/fundamentals/connection/jndi.txt
+++ b/source/fundamentals/connection/jndi.txt
@@ -7,6 +7,9 @@ Java Naming and Directory Interface (JNDI)
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 MongoClientFactory includes a `JNDI
 <http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
 ``ObjectFactory`` implementation that returns ``MongoClient`` instances

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -8,6 +8,9 @@ Enable TLS/SSL on a Connection
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 You can connect to MongoDB instances with the
 `TLS/SSL <https://en.wikipedia.org/wiki/Transport_Layer_Security>`__
 security protocol using the underlying TLS/SSL support in the JDK. To

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -9,7 +9,10 @@ Access Data From a Cursor
    :backlinks: none
    :depth: 2
    :class: singlecol
-   
+
+Overview
+--------
+
 Read operations that return multiple documents do not immediately return
 all values matching the query. Because a query can potentially match
 large number of documents, we need to be able to access or store the

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -10,6 +10,9 @@ Specify Which Fields to Return
    :depth: 1
    :class: singlecol
 
+Overview
+--------
+
 In this guide, you will learn how to control which fields appear in
 documents returned by read operations.
 

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -10,6 +10,9 @@ Skip Returned Results
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 In this guide, we show you how to skip a specified number of returned results.
 
 You can skip results on the returned results of a query by using the

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -10,6 +10,9 @@ Change a Document
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 In this page, you can learn how to change documents in a MongoDB collection
 using two distinct operation types: 
 

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -10,6 +10,9 @@ Insert or Update in a Single Operation
    :depth: 1
    :class: singlecol
 
+Overview
+--------
+
 Applications use insert and update operations to store and modify data.
 Sometimes, you need to choose between an insert and update depending on
 whether the document exists. MongoDB simplifies this decision for us

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -10,6 +10,9 @@ Enterprise Authentication Mechanisms
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 In this guide, we show you how to authenticate with MongoDB using each
 **authentication mechanism** available exclusively in the MongoDB Enterprise
 Edition.

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -10,6 +10,9 @@ GridFS
    :depth: 2
    :class: singlecol
 
+Overview
+--------
+
 This guide shows you how to store and retrieve large files in MongoDB using
 **GridFS**. GridFS is a specification implemented by the driver that describes
 how to split files into chunks when storing them and reassemble them when

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -20,13 +20,13 @@ MongoDB Java driver.
 
 .. What do any new terms mean?
 
-Monitoring is the process of getting information about the activities a running 
+Monitoring is the process of getting information about the activities a running
 program performs for use in an application or an application performance
-management library. 
+management library.
 
 Monitoring the MongoDB Java driver lets you understand the
 driver's resource usage and performance, and can help you make informed
-decisions when designing and debugging your application.    
+decisions when designing and debugging your application.
 
 .. What can you expect to see on this page?
 
@@ -45,7 +45,7 @@ Monitor Events
 --------------
 
 To monitor an **event**, you must register a **listener** on your ``MongoClient``
-instance. 
+instance.
 
 An event is any action that happens in a running program. The driver includes functionality
 for listening to a subset of the events that occur when the driver is running.
@@ -73,7 +73,7 @@ Command Events
 
 A command event is an event related to a MongoDB database command. Some
 examples of database commands that produce command events are ``find``,
-``insert``, ``delete``, and ``count``. 
+``insert``, ``delete``, and ``count``.
 
 To monitor command events, write a class that implements the
 ``CommandListener`` interface and register an instance of that class with your
@@ -87,13 +87,13 @@ For more information on MongoDB database commands, see the
    The driver does not publish events for commands it calls internally. This
    includes database commands the driver uses to monitor your cluster and
    commands related to connection establishment (such as the initial ``hello``
-   command). 
+   command).
 
 .. note:: Redacted Output
 
    As a security measure, the driver redacts the contents of some command events. This
    protects the sensitive information contained in these command events. For a
-   full list of redacted command events, see the 
+   full list of redacted command events, see the
    :spec:`MongoDB command monitoring specification </command-monitoring/command-monitoring.rst#security>`.
 
 Example
@@ -152,8 +152,8 @@ Server Discovery and Monitoring Events
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A server discovery and monitoring (SDAM) event is an event related to a change
-in the state of the MongoDB instance or cluster you have connected the driver to. 
- 
+in the state of the MongoDB instance or cluster you have connected the driver to.
+
 The driver defines nine SDAM events. The driver divides these nine events
 between three separate listener interfaces which each listen for three of the
 nine events. Here are the three interfaces and the events they listen for:
@@ -167,7 +167,7 @@ To monitor a type of SDAM event, write a class that
 implements one of the three interfaces above and register an instance of that
 class with your ``MongoClient`` instance.
 
-For a detailed description of each SDAM event in the driver, see the 
+For a detailed description of each SDAM event in the driver, see the
 :spec:`MongoDB SDAM monitoring specification </server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events>`.
 
 Example
@@ -271,11 +271,11 @@ the following API documentation:
 Monitor Connection Pool Events with JMX
 ---------------------------------------
 
-You can monitor connection pool events using **Java Management Extensions (JMX)**. 
+You can monitor connection pool events using **Java Management Extensions (JMX)**.
 JMX provides tools to monitor applications and devices.
 
-For more information on JMX, see 
-`the official Oracle JMX documentation <https://docs.oracle.com/javase/tutorial/jmx/index.html>`__. 
+For more information on JMX, see
+`the official Oracle JMX documentation <https://docs.oracle.com/javase/tutorial/jmx/index.html>`__.
 
 JMX Support
 ~~~~~~~~~~~
@@ -283,11 +283,11 @@ JMX Support
 To enable JMX connection pool monitoring, add an instance of the
 ``JMXConnectionPoolListener`` class to your ``MongoClient`` object.
 
-The ``JMXConnectionPoolListener`` class performs the following actions: 
+The ``JMXConnectionPoolListener`` class performs the following actions:
 
 #. Creates MXBean instances for each ``mongod`` or ``mongos`` process the driver
    maintains a connection pool with.
-#. Registers these MXBean instances with the platform MBean server. 
+#. Registers these MXBean instances with the platform MBean server.
 
 MXBeans registered on the platform MBean server have the following properties:
 
@@ -300,7 +300,7 @@ MXBeans registered on the platform MBean server have the following properties:
 
    * - ``clusterId``
      - A client-generated unique identifier. This identifier ensures that
-       each MXBean the driver makes has a unique name when an application has 
+       each MXBean the driver makes has a unique name when an application has
        multiple ``MongoClient`` instances connected to the same MongoDB deployment.
 
    * - ``host``
@@ -345,12 +345,12 @@ the Java Platform.
    rather than a source of truth. For guaranteed up to date information, consult
    the following official Oracle resources:
 
-   - `JConsole documentation <https://www.oracle.com/technical-resources/articles/java/jconsole.html>`__. 
+   - `JConsole documentation <https://www.oracle.com/technical-resources/articles/java/jconsole.html>`__.
    - `JMX documentation <https://docs.oracle.com/javase/tutorial/jmx/index.html>`__
 
 The following code snippet adds a ``JMXConnectionPoolListener`` to a
 ``MongoClient`` instance. The code then pauses execution so you can
-navigate to JConsole and inspect your connection pools. 
+navigate to JConsole and inspect your connection pools.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/JMXMonitoring.java
    :language: java
@@ -369,7 +369,7 @@ Once you have started your server, open JConsole in your terminal using the
 following command:
 
 .. code-block:: shell
-   
+
    jconsole
 
 Once JConsole is open, perform the following actions in the GUI:
@@ -380,7 +380,7 @@ Once JConsole is open, perform the following actions in the GUI:
 #. Inspect your connection pool events under the ``"org.mongodb.driver"`` domain.
 
 When you no longer want to inspect your connection pools in JConsole, do the
-following: 
+following:
 
 - Exit JConsole by closing the JConsole window
 - Stop the Java program running the above code snippet
@@ -397,3 +397,4 @@ the following API documentation:
 - :java-docs:`JMXConnectionPoolListener <apidocs/mongodb-driver-core/com/mongodb/management/JMXConnectionPoolListener.html>`
 - `getPlatformMBeanServer() <https://docs.oracle.com/en/java/javase/16/docs/api/java.management/java/lang/management/ManagementFactory.html#getPlatformMBeanServer()>`__
 - `JMXConnectorServer <https://docs.oracle.com/en/java/javase/16/docs/api/java.management/javax/management/remote/JMXConnectorServer.html>`__
+

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -17,6 +17,9 @@ Versioned API
    You should only use the Versioned API feature if all the MongoDB
    servers you are connecting to support this feature.
 
+Overview
+--------
+
 This guide shows you how to specify the **Versioned API** when connecting to
 a MongoDB instance or replica set. You can use the Versioned API feature to
 force the server to run operations with behavior compatible with the

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -10,6 +10,9 @@ Quick Start
    :depth: 2
    :class: singlecol
 
+Introduction
+------------
+
 .. include:: /includes/quick-start/overview.rst
 
 Set up Your Project


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16493

Note: I moved the overview section on the builders.txt page. No new content created although the diff may make it appear that way.

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-16493-overviews/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
