### PR TITLE
Docsp 16491 typos fundamentals

### DIFF
--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -11,7 +11,7 @@ Authentication Mechanisms
    :class: singlecol
 
 In this guide, we show you how to authenticate with MongoDB using each
-**authentication mechanism** available in the MongoDB Community Edition.
+**authentication mechanism** available in MongoDB Community Edition.
 Authentication mechanisms are processes by which the driver and server
 confirm identity and establish trust to ensure security.
 
@@ -107,15 +107,15 @@ see the :manual:`SCRAM </core/security-scram/>` section of the server manual.
 
 ``SCRAM-SHA-256`` is a salted challenge-response authentication mechanism
 (SCRAM) that uses your username and password, encrypted with the ``SHA-256``
-algorithm to authenticate your user.
+algorithm, to authenticate your user.
 
 The following code snippets show how to specify the authentication mechanism,
 using the following placeholders:
 
-* ``username`` - your MongoDB username
-* ``password`` - your MongoDB user's password
-* ``hostname`` - network address of your MongoDB server, accessible by your client
-* ``port`` - port number of your MongoDB server
+* ``username`` - your MongoDB username.
+* ``password`` - your MongoDB user's password.
+* ``hostname`` - network address of your MongoDB server, accessible by your client.
+* ``port`` - port number of your MongoDB server.
 * ``authenticationDb`` - MongoDB database that contains your user's
   authentication data. If you omit this parameter, the driver uses the
   default value ``admin``.
@@ -158,16 +158,16 @@ mechanism:
    3.0, 3.2, 3.4, and 3.6.
 
 ``SCRAM-SHA-1`` is a salted challenge-response mechanism (SCRAM) that uses your
-username and password, encrypted with the ``SHA-1`` algorithm to authenticate
+username and password, encrypted with the ``SHA-1`` algorithm, to authenticate
 your user.
 
 The following code snippets show how to specify the authentication mechanism,
 using the following placeholders:
 
-* ``username`` - your MongoDB username
-* ``password`` - your MongoDB user's password
-* ``hostname`` - network address of your MongoDB server, accessible by your client
-* ``port`` - port number of your MongoDB server
+* ``username`` - your MongoDB username.
+* ``password`` - your MongoDB user's password.
+* ``hostname`` - network address of your MongoDB server, accessible by your client.
+* ``port`` - port number of your MongoDB server.
 * ``authenticationDb`` - MongoDB database that contains your user's
   authentication data. If you omit this parameter, the driver uses the
   default value ``admin``.
@@ -212,7 +212,7 @@ mechanism was deprecated starting in MongoDB 3.6 and is no longer
 supported as of MongoDB 4.0.
 
 You cannot specify this method explicitly; refer to the fallback provided
-by the :ref:`Default authentication mechanism <default-auth-mechanism>` to
+by the :ref:`default authentication mechanism <default-auth-mechanism>` to
 connect using ``MONGODB-CR``.
 
 .. _mongodb-aws-auth-mechanism:
@@ -231,14 +231,14 @@ user.
 The following code snippets show how to specify the authentication mechanism,
 using the following placeholders:
 
-* ``username`` - value of your ``AWS_ACCESS_KEY_ID``
-* ``password`` - value your ``AWS_SECRET_ACCESS_KEY``
-* ``hostname`` - network address of your MongoDB server, accessible by your client
-* ``port`` - port number of your MongoDB server
+* ``username`` - value of your ``AWS_ACCESS_KEY_ID``.
+* ``password`` - value of your ``AWS_SECRET_ACCESS_KEY``.
+* ``hostname`` - network address of your MongoDB server, accessible by your client.
+* ``port`` - port number of your MongoDB server.
 * ``authenticationDb`` - MongoDB database that contains your user's
   authentication data. If you omit this parameter, the driver uses the
   default value ``admin``.
-* ``awsSessionToken`` - value of your ``AWS_SESSION_TOKEN`` *(optional)*
+* ``awsSessionToken`` - value of your ``AWS_SESSION_TOKEN``. *(optional)*
 
 Select the :guilabel:`Connection String` or the :guilabel:`MongoCredential`
 tab below for instructions and sample code for specifying this authentication
@@ -326,8 +326,8 @@ the subject name of the client certificate.
 The following code snippets show how to specify the authentication mechanism,
 using the following placeholders:
 
-* ``hostname`` - network address of your MongoDB server, accessible by your client
-* ``port`` - port number of your MongoDB server
+* ``hostname`` - network address of your MongoDB server, accessible by your client.
+* ``port`` - port number of your MongoDB server.
 * ``authenticationDb`` - MongoDB database that contains your user's
   authentication data. If you omit this parameter, the driver uses the
   default value ``admin``.
@@ -343,7 +343,7 @@ mechanism:
 
       To specify the ``X.509`` authentication mechanism using a connection
       string, assign the ``authMechanism`` parameter the value ``MONGODB-X509``
-      value to the ``authMechanism`` and enable TLS by assigning the ``tls``
+      and enable TLS by assigning the ``tls``
       parameter a ``true`` value. Your code to instantiate a ``MongoClient``
       should look something like this:
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -246,7 +246,7 @@ parameters of the connection URI to specify the behavior of the client.
 
    * - **maxPoolSize**
      - integer
-     - Specifies the maximum size of the instance connection pool.
+     - Specifies the maximum size of the connection pool.
 
    * - **waitQueueTimeoutMS**
      - integer
@@ -292,7 +292,7 @@ parameters of the connection URI to specify the behavior of the client.
      - boolean
      - Specifies that the driver should allow invalid hostnames for TLS
        connections. Has the same effect as setting
-       **tlsAllowInvalidHostnames** to true. To configure TLS security
+       **tlsAllowInvalidHostnames** to ``true``. To configure TLS security
        constraints in other ways, use a
        :ref:`custom SSLContext <tls-custom-sslContext>`.
 
@@ -417,12 +417,12 @@ parameters of the connection URI to specify the behavior of the client.
    * - **retryWrites**
      - boolean
      - Specifies that the driver must retry supported write operations
-       if they fail due to a network error. Defaults to true.
+       if they fail due to a network error. Defaults to ``true``.
 
    * - **retryReads**
      - boolean
      - Specifies that the driver must retry supported read operations
-       if they fail due to a network error. Defaults to true.
+       if they fail due to a network error. Defaults to ``true``.
 
    * - **uuidRepresentation**
      - string

--- a/source/fundamentals/connection/jndi.txt
+++ b/source/fundamentals/connection/jndi.txt
@@ -7,7 +7,7 @@ Java Naming and Directory Interface (JNDI)
    :depth: 2
    :class: singlecol
 
-MongoClientFactory includes a `JNDI
+``MongoClientFactory`` includes a `JNDI
 <http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
 ``ObjectFactory`` implementation that returns ``MongoClient`` instances
 based on a :ref:`connection URI <connection-uri>`. Follow the guides
@@ -46,7 +46,7 @@ below to configure your application to connect using a JNDI DataSource.
 
          .. note::
 
-            Replace the placeholder connection value URI in the ``property`` tag
+            Replace the placeholder connection value in the ``property`` tag
             with a value that points to your MongoDB installation.
 
       This will make a MongoClient instance accessible via the JNDI name
@@ -58,7 +58,7 @@ below to configure your application to connect using a JNDI DataSource.
       1. Copy the ``mongo-java-driver.jar`` jar file into the ``lib`` directory
          of your `Tomcat <http://tomcat.apache.org/>`__ installation.
 
-      #. In ``context.xml`` of your application, add a resource that references
+      #. In the ``context.xml`` file of your application, add a resource that references
          the ``MongoClientFactory`` class and the :ref:`connection string
          <connection-uri>` for the MongoDB cluster:
 
@@ -74,7 +74,7 @@ below to configure your application to connect using a JNDI DataSource.
 
          .. note::
 
-            Replace the placeholder connection value URI in the ``connectionString``
+            Replace the placeholder URI in the ``connectionString``
             attribute with a value that points to your MongoDB installation.
 
       #. In ``web.xml`` of your application, add a reference to the

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -153,7 +153,7 @@ Disable Hostname Verification
 -----------------------------
 
 By default, the driver ensures that the hostname included in the server's
-TLS/SSL certificate(s) matches the hostname(s) provided when constructing
+TLS/SSL certificates matches the hostnames provided when constructing
 a ``MongoClient``. If you need to disable hostname verification for your
 application, you can explicitly disable this by setting the
 ``invalidHostNameAllowed`` property of the builder to ``true`` in the

--- a/source/fundamentals/data-formats/codecs.txt
+++ b/source/fundamentals/data-formats/codecs.txt
@@ -164,7 +164,7 @@ the ``fromCodecs()`` method:
 In the example above, we assign the ``CodecRegistry`` the following ``Codec``
 implementations:
 
-- ``IntegerCodec``, a ``Codec`` that converts integers and is part of the BSON package.
+- ``IntegerCodec``, a ``Codec`` that converts ``Integers`` and is part of the BSON package.
 - :ref:`PowerStatusCodec <codecs-powerstatus-codec>`, our sample ``Codec``
   that converts certain Java strings to BSON booleans.
 
@@ -369,4 +369,3 @@ see the following API Documentation:
 - :java-docs:`MongoClientSettings.getDefaultCodecRegistry() <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getDefaultCodecRegistry()>`
 - :java-docs:`Codec <apidocs/bson/org/bson/codecs/Codec.html>`
 - :java-docs:`CodecProvider <apidocs/bson/org/bson/codecs/configuration/CodecProvider.html>`
-

--- a/source/fundamentals/data-formats/codecs.txt
+++ b/source/fundamentals/data-formats/codecs.txt
@@ -20,7 +20,7 @@ In this guide, you can learn about **Codecs** and the supporting classes that
 handle the encoding and decoding of Java objects to and from BSON data in
 MongoDB. The ``Codec`` abstraction allows you to map any Java type to
 a corresponding BSON type. You can use this to map your domain objects
-directly to and from BSON instead of using an intermediate map-based one such
+directly to and from BSON instead of using an intermediate map-based object such
 as ``Document`` or ``BsonDocument``.
 
 You can learn how to specify custom encoding and decoding logic using
@@ -165,7 +165,7 @@ In the example above, we assign the ``CodecRegistry`` the following ``Codec``
 implementations:
 
 - :java-docs:`IntegerCodec </apidocs/bson/org/bson/codecs/IntegerCodec.html>`,
-  a ``Codec`` that converts Integers and is part of the BSON package.
+  a ``Codec`` that converts integers and is part of the BSON package.
 - :ref:`PowerStatusCodec <codecs-powerstatus-codec>`, our sample ``Codec``
   that converts certain Java strings to BSON booleans.
 
@@ -222,7 +222,7 @@ section of this guide.
 
 When working with POJOs, consider using the  ``PojoCodecProvider`` to
 minimize duplicate code to convert commonly-used data types and customize
-the behavior. See our
+their behavior. See our
 :doc:`POJO Customization guide </fundamentals/data-formats/pojo-customization>`
 for more information.
 
@@ -348,7 +348,7 @@ After defining the conversion logic, we can perform the following:
 The following example class contains code that assigns the
 ``MonolightCodecProvider`` to the ``MongoCollection`` instance by passing it
 to the ``withCodecRegistry()`` method. The example class also inserts and
-retrieves data using the ``Monolight`` class and associated ``Codecs``:
+retrieves data using the ``Monolight`` class and associated codecs:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/MonolightCodecExample.java
    :start-after: start class

--- a/source/fundamentals/data-formats/document-data-format-bson.txt
+++ b/source/fundamentals/data-formats/document-data-format-bson.txt
@@ -16,7 +16,7 @@ Overview
 --------
 
 This guide explains the BSON data format, how MongoDB uses it, and how to
-install the BSON library independently of the MongoDB driver.
+install the BSON library independently of the MongoDB Java driver.
 
 BSON Data Format
 ----------------
@@ -36,7 +36,7 @@ MongoDB and BSON
 ----------------
 
 The MongoDB Java Driver, which uses the BSON library, allows you to work
-with BSON data by using one of the object types that implement the
+with BSON data by using one of the object types that implements the
 :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` interface,
 including:
 
@@ -58,12 +58,12 @@ These instructions show you how to add the BSON library as a dependency to
 your project. If you added the MongoDB Java driver as a dependency to your
 project, you can skip this step since the BSON library is already included
 as a required dependency of the driver. For instructions on how to add the
-MongoDB driver as a dependency to your project, see the
+MongoDB Java driver as a dependency to your project, see the
 :ref:`driver installation <add-mongodb-dependency>` section of our Quick Start
 guide.
 
 We recommend that you use the `Maven <https://maven.apache.org/>`__ or
-`Gradle <https://gradle.org/>`__ build automation tool to manage your project
+`Gradle <https://gradle.org/>`__ build automation tool to manage your project's
 dependencies. Select from the tabs below to see the dependency declaration
 for that tool:
 

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -22,9 +22,9 @@ store data.
 
 This guide explains the following topics:
 
-- the different MongoDB Extended JSON formats
-- how to use the BSON library to convert between Extended JSON and Java objects
-- how to create a custom conversion of BSON types
+- The different MongoDB Extended JSON formats
+- How to use the BSON library to convert between Extended JSON and Java objects
+- How to create a custom conversion of BSON types
 
 For more information on the difference between these formats, see our
 `article on JSON and BSON <https://www.mongodb.com/json-and-bson>`__.
@@ -38,7 +38,7 @@ and meet specific use cases. The **extended** format, also known as the
 **canonical** format, features specific representations for every BSON type
 for bidirectional conversion without loss of information. The **Relaxed mode**
 format is more concise and closer to ordinary JSON, but does not represent
-all the type information such as specific byte size of number fields.
+all the type information such as the specific byte size of number fields.
 
 See the table below to see a description of each format:
 
@@ -64,7 +64,7 @@ See the table below to see a description of each format:
 
    * - **Shell**
      - | JSON representation that matches the syntax used in the MongoDB shell.
-       | This format prioritizes for compatibility with the MongoDB shell which often uses JavaScript functions to represent types.
+       | This format prioritizes compatibility with the MongoDB shell which often uses JavaScript functions to represent types.
        |
        | For more information on this format, see the server manual page on :manual:`Data Types in the mongo shell </core/shell-types/>`.
 
@@ -72,7 +72,7 @@ See the table below to see a description of each format:
 
 .. note::
 
-   The ``$uuid`` Extended JSON type is parsed from a String to a
+   The driver parses the ``$uuid`` Extended JSON type from a string to a
    :java-docs:`BsonBinary </apidocs/bson/org/bson/BsonBinary.html>`
    object of binary subtype 4. For more information about ``$uuid`` field
    parsing, see the
@@ -132,7 +132,7 @@ Read Extended JSON
 Using the Document Classes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can read an Extended JSON string into Java document objects by calling
+You can read an Extended JSON string into a Java document object by calling
 the ``parse()`` static method from either the ``Document`` or ``BsonDocument``
 class, depending on which object type you need. This method parses the Extended
 JSON string in any of the formats and returns an instance of that class
@@ -164,13 +164,13 @@ Using the BSON Library
 ~~~~~~~~~~~~~~~~~~~~~~
 
 You can also read an Extended JSON string into Java objects without using
-the MongoDB driver's document classes by using the
+the MongoDB Java driver's document classes by using the
 :java-docs:`JsonReader </apidocs/bson/org/bson/json/JsonReader.html>` class.
 This class contains methods to sequentially parse the fields and values
 in any format of the Extended JSON string, and returns them as Java objects.
-MongoDB driver's document classes also use this class to parse Extended JSON.
+The driver's document classes also use this class to parse Extended JSON.
 
-The following code example shows how you can use ``JsonReader`` to convert
+The following code example shows how you can use the ``JsonReader`` class to convert
 an Extended JSON string into Java objects:
 
 .. code-block:: java
@@ -203,8 +203,8 @@ The output of this code example should look something like this:
    4794261 is type: java.lang.Long
 
 
-For additional information on the classes and methods mentioned on this
-section, see the following API documentation:
+For more information, see the :java-docs:`JsonReader
+<apidocs/bson/org/bson/json/JsonReader.html>` API Documentation.
 
 Write Extended JSON
 -------------------
@@ -242,7 +242,7 @@ class. To construct an instance of ``JsonWriter``, pass a subclass of a Java
 ``Writer`` to specify how you want to output the Extended JSON. You can
 optionally pass a :java-docs:`JsonWriterSettings </apidocs/bson/org/bson/json/JsonWriterSettings.html>`
 instance to specify options such as the Extended JSON format. By default, the
-``JsonWriter`` uses the Relaxed mode format. MongoDB driver's
+``JsonWriter`` uses the Relaxed mode format. The MongoDB Java driver's
 document classes also use this class to convert BSON to Extended JSON.
 
 The following code example shows how you can use ``JsonWriter`` to create an

--- a/source/fundamentals/data-formats/document-data-format-pojo.txt
+++ b/source/fundamentals/data-formats/document-data-format-pojo.txt
@@ -20,9 +20,9 @@ data representation.
 
 In the following sections we show:
 
-- a POJO example
-- how to configure the driver to serialize and deserialize the POJO
-- sample code to read and write documents to MongoDB using the POJO
+- A POJO example
+- How to configure the driver to serialize and deserialize POJOs
+- Sample code to read and write documents to MongoDB using POJOs
 
 .. _fundamentals-example-pojo:
 
@@ -30,7 +30,7 @@ Example POJO
 ------------
 
 To follow the steps in this guide, you can create your own class or use the
-following sample POJO class which describes characteristics of a flower:
+following sample POJO class which describes some characteristics of a flower:
 
 .. code-block:: java
 
@@ -99,7 +99,7 @@ following sample POJO class which describes characteristics of a flower:
    }
 
 If you are creating your own POJO for storing and retrieving data in MongoDB,
-make sure to follow the following guidelines:
+make sure to follow these guidelines:
 
 - The POJO class should not implement interfaces or extend classes from a
   framework.
@@ -119,9 +119,9 @@ To set up the driver to store and retrieve POJOs, we need to specify:
 - The ``PojoCodecProvider``, a codec provider that includes
   :doc:`Codecs </fundamentals/data-formats/codecs>` that define how to
   encode/decode the data between the POJO and MongoDB document, and which
-  POJO classes or packages that the Codecs should apply to.
+  POJO classes or packages that the codecs should apply to.
 - A :java-docs:`CodecRegistry <apidocs/bson/org/bson/codecs/configuration/CodecRegistry.html>`
-  instance that contains the Codecs and other related information.
+  instance that contains the codecs and other related information.
 - A ``MongoClient``, ``MongoDatabase``, or ``MongoCollection`` instance
   configured to use the ``CodecRegistry``.
 - A ``MongoCollection`` instance created with the POJO document class
@@ -136,7 +136,7 @@ requirements:
    In this example, we use the
    :java-docs:`automatic(true) <apidocs/bson/org/bson/codecs/pojo/PojoCodecProvider.Builder.html#automatic(boolean)>`
    setting of the :java-docs:`PojoCodecProvider.Builder <apidocs/bson/org/bson/codecs/pojo/PojoCodecProvider.Builder.html>`
-   to apply the Codecs to any class and its properties.
+   to apply the codecs to any class and its properties.
 
    .. code-block:: java
 
@@ -200,7 +200,7 @@ Once you have configured the ``MongoCollection`` instance above, you can:
 - save an instance of the POJO to the collection
 - retrieve instances of the POJO from a query on the collection
 
-The code below shows you how you can insert an instance of ``Flower`` into
+The code below shows how you can insert an instance of ``Flower`` into
 the collection and then retrieve it as a ``List`` of your POJO class objects:
 
 .. code-block:: java
@@ -234,7 +234,7 @@ Summary
 In this guide, we explained how to convert data between BSON and POJO fields
 by performing the following:
 
-- Instantiate a ``PojoCodecProvider`` which contains Codecs which define how to
+- Instantiate a ``PojoCodecProvider`` which contains codecs which define how to
   encode/decode data between BSON and the POJO fields.
 - Specify the **automatic** conversion behavior for the ``PojoCodecProvider``
   to apply the ``Codecs`` to any class and its properties.

--- a/source/fundamentals/data-formats/documents.txt
+++ b/source/fundamentals/data-formats/documents.txt
@@ -19,10 +19,10 @@ binary JSON (BSON) format. You can use documents and the data they contain
 in their fields to store data as well as issue commands or queries in
 MongoDB.
 
-For more information on terminology, structure, and limitations of documents,
+For more information on the terminology, structure, and limitations of documents,
 read our page on :manual:`Documents </core/document>` in the MongoDB manual.
 
-The Java driver and BSON library include the following classes that help you
+The MongoDB Java driver and BSON library include the following classes that help you
 access and manipulate the BSON data in documents:
 
 .. list-table::
@@ -407,7 +407,7 @@ BasicDBObject
 
 The ``BasicDBObject`` class allows you to access and manipulate document data
 using Java types. We recommend that you avoid using this class unless you
-are migrating an application from that uses an older driver version
+are migrating an application from an older driver version
 because of the following limitations:
 
 - ``BasicDBObject`` does not implement ``Map<K, V>`` and therefore
@@ -496,7 +496,7 @@ Summary
 In this guide, we covered the following topics on classes you can use to
 work with BSON data:
 
-- Described three Java classes you can use to work with MongoDB documents and
+- Described four Java classes you can use to work with MongoDB documents and
   why you might prefer one over the other.
 - Provided usage examples for each class on building documents containing
   multiple types, inserting them into a collection, and

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -643,7 +643,7 @@ For more information about the methods and classes mentioned in this section,
 see the following API Documentation:
 
 - :java-docs:`PropertyCodecProvider <apidocs/bson/org/bson/codecs/pojo/PropertyCodecProvider.html>`
-- :java-docs:`TypeWithTypeParamaters <apidocs/bson/org/bson/codecs/pojo/TypeWithTypeParameters.html>`
+- :java-docs:`TypeWithTypeParameters <apidocs/bson/org/bson/codecs/pojo/TypeWithTypeParameters.html>`
 
 For more information on generics and type parameters, see the
 :`Oracle documentation on Invoking and Instantiating a Generic Type <https://docs.oracle.com/javase/tutorial/java/generics/types.html#instantiation>`__.

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -23,7 +23,7 @@ We show how to specify your data conversion using the :ref:`ClassModel <classmod
 and :ref:`PropertyModel <property-model>` classes. You can also learn
 about more specific customization from the section on :ref:`Advanced Configuration <pojo-advanced-configuration>`.
 
-We also show you how to use helpers such as :ref:`Conventions <conventions>`
+We also show how to use helpers such as :ref:`Conventions <conventions>`
 and :ref:`Annotations <annotations>` to specify common serialization actions.
 
 See the section on :ref:`Discriminators <pojo-discriminators>` if you want to
@@ -50,9 +50,9 @@ You can create a ``PojoCodecProvider`` instance using the
 ``PojoCodecProvider.builder()`` method. You can also chain methods to the
 builder to register any of the following:
 
-- individual POJO classes
-- package names that contain POJO classes
-- instances of ``ClassModel`` that describe conversion logic for a specific
+- Individual POJO classes
+- Package names that contain POJO classes
+- Instances of ``ClassModel`` that describe conversion logic for a specific
   POJO class
 
 The following example shows how you can specify the POJOs in a package named
@@ -124,7 +124,7 @@ A ``ClassModel`` contains the following fields:
 For more information on this class, see the :java-docs:`ClassModel </apidocs/bson/org/bson/codecs/pojo/ClassModel.html>`
 API documentation.
 
-To instantiate a ``ClassModel`` use the ``ClassModel.builder()`` method and
+To instantiate a ``ClassModel``, use the ``ClassModel.builder()`` method and
 specify your POJO class. The builder uses reflection to create the required
 metadata.
 
@@ -279,17 +279,17 @@ package:
        ``BsonProperty`` annotation to link the parameters with properties.
 
    * - ``BsonDiscriminator``
-     - Specifies a class uses a discriminator. You can set a custom
+     - Specifies that a class uses a discriminator. You can set a custom
        discriminator key and value.
 
    * - ``BsonRepresentation``
      - Specify a BSON type to store when different from the POJO property.
 
    * - ``BsonId``
-     - Marks a property to serialized as the _id property.
+     - Marks a property to serialize as the _id property.
 
    * - ``BsonIgnore``
-     - Marks a property to ignore. You can configure whether to serialized
+     - Marks a property to ignore. You can configure whether to serialize
        and/or deserialize a property.
 
    * - ``BsonProperty``
@@ -349,15 +349,15 @@ the annotations described above.
 
 The annotations in the example POJO specify the following behavior:
 
-- reference the POJO with the specified discriminator key and   value, adding
+- Reference the POJO with the specified discriminator key and   value, adding
   the ``cls`` field with the value of "AnnotatedProduct" to the BSON document
   on write operations
-- convert between the POJO ``name`` field and value and the BSON ``modelName``
+- Convert between the POJO ``name`` field and value and the BSON ``modelName``
   field and value in the document
-- convert between the POJO ``serialNumber`` field and value the BSON document
+- Convert between the POJO ``serialNumber`` field and value the BSON document
   ``_id`` field and value in the document
-- omit the ``relatedItems`` field and value when converting data
-- use the ``Product(String name)`` constructor when instantiating the POJO
+- Omit the ``relatedItems`` field and value when converting data
+- Use the ``Product(String name)`` constructor when instantiating the POJO
 
 .. _pojo-discriminators:
 
@@ -370,16 +370,16 @@ The discriminator value identifies the default value of the document field.
 
 Use discriminators to instruct the ``CodecProvider`` which object class to use
 when deserializing to different object classes from the same collection. When
-serializing the POJO to a MongoDB collection, the associated Codec sets the
+serializing the POJO to a MongoDB collection, the associated codec sets the
 discriminator key-value field, unless otherwise specified in the POJO property
 data.
 
 You can set and enable a discriminator in a POJO by performing one of the
 following:
 
-- use the ``@BsonDiscriminator`` annotation to specify the discriminator for
+- Use the ``@BsonDiscriminator`` annotation to specify the discriminator for
   the POJO class
-- or call ``enableDiscriminator(true)`` on the ``ClassModelBuilder``
+- Call ``enableDiscriminator(true)`` on the ``ClassModelBuilder``
   associated with the POJO class
 
 See the following example POJO classes that contain ``@BsonDiscriminator``
@@ -498,7 +498,7 @@ by which to determine whether to serialize a field:
        }
    }
 
-The class above specifies that any integer above 29 is not serialized and
+The class above specifies that any integer above 29 is not serialized, and,
 therefore, not included in the MongoDB document. Suppose you applied this
 custom serialization behavior to the following sample POJO:
 
@@ -553,8 +553,8 @@ Generics Support
 You can use the POJO ``Codec`` to serialize classes that contain generic
 properties if they meet the following criteria:
 
-- contain only bounded concrete type parameters
-- if it or any of its fields are part of a class hierarchy, the top-level
+- Contain only bounded concrete type parameters
+- If it or any of its fields are part of a class hierarchy, the top-level
   POJO does not contain any type parameters
 
 The ``ClassModelBuilder`` inspects and saves concrete type parameters to work
@@ -579,7 +579,7 @@ Suppose you wanted to serialize the following POJO with ``Optional`` fields:
    }
 
 You can use the following implementation of ``PropertyCodecProvider`` to
-retrieve the your custom Codec. This implementation uses the
+retrieve your custom Codec. This implementation uses the
 ``TypeWithTypeParameters`` interface to access the type information.
 
 .. code-block:: java

--- a/source/fundamentals/databases-collections.txt
+++ b/source/fundamentals/databases-collections.txt
@@ -15,11 +15,11 @@ Overview
 
 MongoDB organizes data into a hierachy of the following levels:
 
-- databases
+- Databases
 
-- collections
+- Collections
 
-- documents
+- Documents
 
 Databases are the top level of data organization in a MongoDB instance.
 Databases are organized into collections which contain **documents**.
@@ -70,8 +70,10 @@ Create a Collection
 
 Use the :java-sync-api:`createCollection()
 <com/mongodb/client/MongoDatabase.html#createCollection(java.lang.String,com.mongodb.client.model.CreateCollectionOptions)>`
-method of a ``MongoDatabase`` instance to create a collection called
-"exampleCollection" in a database of your connected MongoDB instance:
+method of a ``MongoDatabase`` instance to create a collection
+in a database of your connected MongoDB instance.
+
+The following example creates a collection called "exampleCollection":
 
 .. code-block:: java
 
@@ -80,7 +82,7 @@ method of a ``MongoDatabase`` instance to create a collection called
 You can specify collection options like maximum size and document
 validation rules using the :java-docs:`CreateCollectionOptions
 <apidocs/mongodb-driver-core/com/mongodb/client/model/CreateCollectionOptions.html>`
-class. ``createCollection()`` accepts an instance of
+class. The ``createCollection()`` method accepts an instance of
 ``CreateCollectionOptions`` as an optional second parameter.
 
 Document Validation
@@ -135,8 +137,8 @@ You can remove a collection from the database using the
    documents within that collection and all indexes on that collection.
    Only drop collections that contain data that is no longer needed.
 
-Specify Read Preferences, Read Concerns and  Write Concerns
------------------------------------------------------------
+Specify Read Preferences, Read Concerns, and  Write Concerns
+------------------------------------------------------------
 
 **Read preferences**, **read concerns**, and **write concerns** control
 how the driver routes read operations and waits for acknowledgement for

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -11,10 +11,10 @@ Enterprise Authentication Mechanisms
    :class: singlecol
 
 In this guide, we show you how to authenticate with MongoDB using each
-**authentication mechanism** available exclusively in the MongoDB Enterprise
+**authentication mechanism** available exclusively in MongoDB Enterprise
 Edition.
 
-You can use the following mechanisms with the latest version of the MongoDB
+You can use the following mechanisms with the latest version of MongoDB
 Enterprise Edition:
 
 - :ref:`Kerberos (GSSAPI) <gssapi-auth-mechanism>`
@@ -68,8 +68,8 @@ mechanism:
       To specify the GSSAPI authentication mechanism using a connection
       string:
 
-      - assign the ``authMechanism`` URL parameter to the value ``GSSAPI``
-      - (optional) assign the ``authSource`` URL parameter to the value ``$external``
+      - Assign the ``authMechanism`` URL parameter to the value ``GSSAPI``
+      - (*optional*) Assign the ``authSource`` URL parameter to the value ``$external``
 
       .. note::
 
@@ -193,7 +193,7 @@ to improve performance.
    On Windows, Oracle’s JRE uses `LSA <https://msdn.microsoft.com/en-us/library/windows/desktop/aa378326.aspx>`__
    rather than `SSPI <https://msdn.microsoft.com/en-us/library/windows/desktop/aa380493.aspx>`__
    in its implementation of GSSAPI which limits interoperability with
-   Windows Active Directory and implementation of single sign-on. See the
+   Windows Active Directory and implementations of single sign-on. See the
    following articles for more information:
 
    - `JDK-8054026 <https://bugs.openjdk.java.net/browse/JDK-8054026>`__
@@ -240,8 +240,8 @@ mechanism:
       To specify the LDAP (PLAIN) authentication mechanism using a connection
       string:
 
-      - assign the ``authMechanism`` URL parameter to the value ``PLAIN``
-      - (*optional*) assign the ``authSource`` URL parameter to the value ``$external``
+      - Assign the ``authMechanism`` URL parameter to the value ``PLAIN``
+      - (*optional*) Assign the ``authSource`` URL parameter to the value ``$external``
 
       .. note::
 

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -29,23 +29,23 @@ When you use the Versioned API feature with an official MongoDB driver, you
 can update your driver or server without worrying about backward compatibility
 issues of the commands covered by the Versioned API.
 
-See the server manual page on `Versioned API <https://docs.mongodb.com/v5.0/reference/versioned-api/>`__
+See the server manual page on the `Versioned API <https://docs.mongodb.com/v5.0/reference/versioned-api/>`__
 for more information including a list of commands it covers.
 
-The following sections describe how you can enable Versioned API for
+The following sections describe how you can enable the Versioned API for
 your MongoDB client and the options that you can specify.
 
-Enable Versioned API on a MongoDB Client
-----------------------------------------
+Enable the Versioned API on a MongoDB Client
+--------------------------------------------
 
 To enable the Versioned API, you must specify an API version in the settings
 of your MongoDB client. Once you instantiate a ``MongoClient`` instance with
-a specified Versioned API, all commands you run with that client use that
+a specified API version, all commands you run with that client use that
 version of the Versioned API.
 
 .. tip::
 
-   If you need to run commands using a more than one version of the Versioned
+   If you need to run commands using more than one version of the Versioned
    API, instantiate a separate client with that version.
 
    If you need to run commands not covered by the Versioned API, make sure the
@@ -75,7 +75,7 @@ following operations:
 .. warning::
 
    If you specify an API version and connect to a MongoDB server that does
-   not support Versioned API, your application may raise an exception when
+   not support the Versioned API, your application may raise an exception when
    executing a command on your MongoDB server. If you use a ``MongoClient``
    that specifies the API version to query a server that does not support it,
    your query could fail with an exception message that includes the
@@ -103,7 +103,7 @@ section, see the following API documentation:
 Versioned API Options
 ---------------------
 
-You can enable or disable optional behavior related to Versioned API as
+You can enable or disable optional behavior related to the Versioned API as
 described in the following table.
 
 .. list-table::
@@ -115,7 +115,7 @@ described in the following table.
      - Description
 
    * - Strict
-     - | **Optional**. When set, if you call a command that is not part of declared API version, the driver raises an exception.
+     - | **Optional**. When set, if you call a command that is not part of the declared API version, the driver raises an exception.
        |
        | Default: **false**
        | For more information, see the :java-docs:`strict() <apidocs/mongodb-driver-core/com/mongodb/ServerApi.Builder.html#strict(boolean)>` API documentation.

--- a/source/includes/fundamentals/auth-specify.rst
+++ b/source/includes/fundamentals/auth-specify.rst
@@ -1,8 +1,8 @@
 You can specify your authentication mechanism and credentials when connecting
 to MongoDB using either of the following:
 
-- a connection string
-- a ``MongoCredential`` factory method
+- A connection string
+- A ``MongoCredential`` factory method
 
 A **connection string** (also known as a **connection uri**) specifies how to
 connect and authenticate to your MongoDB cluster.


### PR DESCRIPTION
## Pull Request Info

Typos from start of fundamentals through Fundamentals > Data Formats

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16491

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-16491-Typos-Fundamentals/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
