### PR TITLE
Docsp 16491 typos after crud

### DIFF
--- a/source/fundamentals/builders.txt
+++ b/source/fundamentals/builders.txt
@@ -23,7 +23,7 @@ Overview
 --------
 
 This section includes guides on how to use each of the available
-builders, and demonstrates the utility the Java driver builder classes
+builders, and demonstrates the utility the MongoDB Java driver builder classes
 provide.
 
 The Java driver provides classes to simplify the process for developers
@@ -38,14 +38,14 @@ Using the builders class, you leverage the power of:
 - The Java compiler and the IDE to find errors during development
 - The IDE for discovery and code completion
 
-The Java compiler and the IDE catch errors such as misspelled
+When using builders, the Java compiler and the IDE catch errors such as misspelled
 operators early on. When using the MongoDB shell or plain Java, you
 write operators as strings and get no visual indication of a problem,
 pushing these errors to runtime instead of compile time
 
 With the builder classes, you write operators as methods. The IDE
 instantly underlines and gives you a red bar on the right indicating
-something is wrong. While developing, the IDE also shows you with the
+something is wrong. While developing, the IDE also shows you the
 methods you can use. It automatically completes your code with
 placeholder parameters once you select which method you want to use.
 

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -153,7 +153,7 @@ Skip
 
 Use the ``skip()`` method to create a :manual:`$skip </reference/operator/aggregation/skip/>`
 pipeline stage to skip over the specified number of documents before
-passing documents into the stage.
+passing documents into the next stage.
 
 The following example creates a pipeline stage that skips the first ``5`` documents:
 
@@ -221,7 +221,7 @@ for each distinct grouping.
 .. tip::
 
    The driver includes the :java-docs:`Accumulators <apidocs/mongodb-driver-core/com/mongodb/client/model/Accumulators.html>`
-   class with static factory methods for each of the supported accumulator.
+   class with static factory methods for each of the supported accumulators.
 
 The following example creates a pipeline stage that groups documents by the value
 of the ``customerId`` field. Each group accumulates the sum and average
@@ -345,7 +345,8 @@ recursion depth information for every document.
    :language: java
    :dedent:
 
-Using ``GraphLookupOptions``, you can specify a filter that must match. In this
+Using ``GraphLookupOptions``, you can specify a filter that documents must match
+in order for MongoDB to include them in your search. In this
 example, only links with "golf" in their ``hobbies`` field will be included.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
@@ -363,7 +364,7 @@ these groups by count in descending order.
 
 .. tip::
 
-   The ``$sortByCount`` stage is identical to a ``$group`` stage with an
+   The ``$sortByCount`` stage is identical to a ``$group`` stage with a
    ``$sum`` accumulator followed by a ``$sort`` stage.
 
    .. code-block:: json
@@ -406,7 +407,7 @@ pipeline stage that adds new fields to documents.
 
 .. tip::
 
-   Use the ``$addFields`` when you do not want to project field inclusion
+   Use ``$addFields`` when you do not want to project field inclusion
    or exclusion.
 
 Th following example adds two new fields, ``a`` and ``b`` to the input documents:
@@ -421,7 +422,7 @@ Count
 -----
 
 Use the ``count()`` method to create a :manual:`$count </reference/operator/aggregation/count/>`
-pipeline stage that counts the number of documents that enter, and assigns
+pipeline stage that counts the number of documents that enter the stage, and assigns
 that value to a specified field name. If you do not specify a field,
 ``count()`` defaults the field name to "count".
 
@@ -472,7 +473,7 @@ into a bucket called "monster" for monstrously large screen sizes:
 .. tip::
 
    The driver includes the :java-docs:`Accumulators <apidocs/mongodb-driver-core/com/mongodb/client/model/Accumulators.html>`
-   class with static factory methods for each of the supported accumulator.
+   class with static factory methods for each of the supported accumulators.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
    :start-after: // begin bucketOptions
@@ -503,13 +504,13 @@ based scheme to set boundary values, and specify additional accumulators.
 The following example creates a pipeline stage that will attempt to create and evenly
 distribute documents into *10* buckets using the value of their ``price`` field,
 setting the bucket boundaries at powers of 2 (2, 4, 8, 16, ...). It also counts
-the number of documents in each bucket, and calculates the average their ``price``
+the number of documents in each bucket, and calculates their average ``price``
 in a new field called ``avgPrice``:
 
 .. tip::
 
    The driver includes the :java-docs:`Accumulators <apidocs/mongodb-driver-core/com/mongodb/client/model/Accumulators.html>`
-   class with static factory methods for each of the supported accumulator:
+   class with static factory methods for each of the supported accumulators.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
    :start-after: // begin bucketAutoOptions

--- a/source/fundamentals/builders/filters.txt
+++ b/source/fundamentals/builders/filters.txt
@@ -388,16 +388,16 @@ The bitwise operator methods include:
      - Matches
       
    * - :java-docs:`bitsAllSet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#bitsAllSet(java.lang.String,long)>`
-     - documents when the specified bits of a field are set (i.e. "1").
+     - documents where the specified bits of a field are set (i.e. "1").
 
    * - :java-docs:`bitsAllClear() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#bitsAllClear(java.lang.String,long)>`
-     - documents when the specified bits of a field are clear (i.e. "0").
+     - documents where the specified bits of a field are clear (i.e. "0").
       
    * - :java-docs:`bitsAnySet() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#bitsAnySet(java.lang.String,long)>`
-     - documents when at least one of the specified bits of a field are set (i.e. "1").
+     - documents where at least one of the specified bits of a field are set (i.e. "1").
      
    * - :java-docs:`bitsAnyClear() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#bitsAnyClear(java.lang.String,long)>`
-     - documents when at least one of the specified bits of a field are clear (i.e. "0").
+     - documents where at least one of the specified bits of a field are clear (i.e. "0").
 
 The following example matches documents that have a ``bitField`` field
 with bits set at positions of the corresponding bitmask "34" (i.e.

--- a/source/fundamentals/builders/filters.txt
+++ b/source/fundamentals/builders/filters.txt
@@ -451,13 +451,13 @@ The geospatial operator methods include:
      - geometries containing a geospatial data value (GeoJSON or legacy coordinate pairs) that exist within the specified circle, using spherical geometry.
 
    * - :java-docs:`geoIntersects() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#geoIntersects(java.lang.String,org.bson.conversions.Bson)>`
-     - geometries that intersect with a GeoJSON geometry. The 2dsphere index supports ``$geoIntersects``.
+     - geometries that intersect with a GeoJSON geometry. The ``2dsphere`` index supports ``$geoIntersects``.
 
    * - :java-docs:`near() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#near(java.lang.String,org.bson.conversions.Bson,java.lang.Double,java.lang.Double)>`
-     - geospatial objects in proximity to a point. Requires a geospatial index. The 2dsphere and 2d indexes support ``$near``.
+     - geospatial objects in proximity to a point. Requires a geospatial index. The ``2dsphere`` and ``2d`` indexes support ``$near``.
 
    * - :java-docs:`nearSphere() <apidocs/mongodb-driver-core/com/mongodb/client/model/Filters.html#nearSphere(java.lang.String,org.bson.conversions.Bson,java.lang.Double,java.lang.Double)>`
-     - geospatial objects in proximity to a point on a sphere. Requires a geospatial index. The 2dsphere and 2d indexes support ``$nearSphere``.
+     - geospatial objects in proximity to a point on a sphere. Requires a geospatial index. The ``2dsphere`` and ``2d`` indexes support ``$nearSphere``.
 
 The following example creates a filter that matches documents in which
 the ``point`` field contains a GeoJSON geometry that falls within

--- a/source/fundamentals/builders/indexes.txt
+++ b/source/fundamentals/builders/indexes.txt
@@ -55,7 +55,7 @@ Ascending Indexes
 -----------------
 
 An ascending index enables you to sort query results by the value of the
-indexed field(s) from smallest to largest.
+indexed fields from smallest to largest.
 
 In order to create an ascending index, first call the
 :java-docs:`ascending() <apidocs/mongodb-driver-core/com/mongodb/client/model/Indexes.html#ascending(java.lang.String...)>`
@@ -83,7 +83,7 @@ Descending Indexes
 ------------------
 
 A descending index enables you to sort query results by the value of the
-indexed field(s) from largest to smallest.
+indexed fields from largest to smallest.
 
 In order to create a descending index, first call the
 :java-docs:`descending() <apidocs/mongodb-driver-core/com/mongodb/client/model/Indexes.html#descending(java.lang.String...)>`
@@ -173,16 +173,16 @@ field:
 Geospatial Indexes
 ------------------
 
-A geo2dsphere index groups documents by the coordinates in the indexed field.
+A ``2dsphere`` index groups documents by the coordinates in the indexed field.
 
-In order to create a geo2dsphere index, first call the
+In order to create a ``2dsphere`` index, first call the
 :java-docs:`geo2dsphere() <apidocs/mongodb-driver-core/com/mongodb/client/model/Indexes.html#geo2dsphere(java.lang.String...)>`
 builder method to create a ``Bson`` instance that represents the index
 document, passing the name or names of the fields you want to index.
 Then, call the ``createIndex()`` method on the collection, passing the ``Bson``
 instance that contains the index document.
 
-The following example specifies a geo2dsphere index on the ``location`` field:
+The following example specifies a ``2dsphere`` index on the ``location`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Indexes.java
    :language: java

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -351,7 +351,7 @@ The following code shows the output from this projection:
 Project a Text Score
 ~~~~~~~~~~~~~~~~~~~~
 
-Use the ``metaTextScore()`` method to specify a projection of
+Use the ``metaTextScore()`` method to specify a projection of the
 :manual:`score of a text query </reference/operator/query/text/#text-score>`
 
 The following example projects the text score as the value of the ``score`` field:

--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -18,7 +18,7 @@ Overview
 In this guide, you can learn how to specify **updates** using
 :doc:`builders </fundamentals/builders/>` in the MongoDB Java driver.
 
-Update builders provide helper methods for the following types of updates:
+The ``Updates`` builder provides helper methods for the following types of updates:
 
 - :ref:`Field Updates <field_updates>`
 - :ref:`Array Updates <array_updates>`
@@ -26,9 +26,9 @@ Update builders provide helper methods for the following types of updates:
 
 Some methods that expect updates are:
 
-- updateOne()
-- updateMany()
-- bulkWrite()
+- ``updateOne()``
+- ``updateMany()``
+- ``bulkWrite()``
 
 The ``Updates`` class provides static factory methods for all the MongoDB update
 operators. Each method returns an instance of the :ref:`Bson <bson>`
@@ -212,7 +212,7 @@ The following example renames the ``qty`` field to "quantity":
    :start-after: begin renameUpdate
    :end-before: end renameUpdate
    
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -237,7 +237,7 @@ specified in an update operation.
    :start-after: begin minUpdate
    :end-before: end minUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -265,7 +265,7 @@ maximum of its current value and "8":
    :start-after: begin maxUpdate
    :end-before: end maxUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -280,9 +280,9 @@ The example above updates the document to the following state:
 
 Current Date
 ~~~~~~~~~~~~
-Use the :java-docs:`apidocs/mongodb-driver-core/currentDate() <com/mongodb/client/model/Updates.html#currentDate(java.lang.String)>`
+Use the :java-docs:`currentDate() <com/mongodb/client/model/Updates.html#currentDate(java.lang.String)>`
 method to assign the value of a field in an update operation to the
-current date as a :manual:`date </reference/bson-types/#date>`.
+current date as a :manual:`BSON date </reference/bson-types/#date>`.
 
 The following example sets the value of the ``lastModified`` field to
 the current date as a BSON date:
@@ -293,7 +293,7 @@ the current date as a BSON date:
    :start-after: begin currentDateUpdate
    :end-before: end currentDateUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -321,7 +321,7 @@ the current date as a BSON timestamp:
    :start-after: begin currentTimestampUpdate
    :end-before: end currentTimestampUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -339,11 +339,11 @@ Bit
 Use the :java-docs:`bitwiseOr() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#bitwiseOr(java.lang.String,int)>`,
 :java-docs:`bitwiseAnd() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#bitwiseAnd(java.lang.String,int)>`,
 and :java-docs:`bitwiseXor() <apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#bitwiseXor(java.lang.String,int)>`
-methods to perform a bitwise update of the integral value of a field in
+methods to perform a bitwise update of the integer value of a field in
 an update operation. 
 
-The following example performs a bitwise AND between the number
-"10" and the integral value of the ``qty`` field: 
+The following example performs a bitwise ``AND`` between the number
+"10" and the integer value of the ``qty`` field: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -361,7 +361,7 @@ The bitwise operation results in 15:
    ----
    1111
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -394,7 +394,7 @@ the ``vendor`` field:
    :start-after: begin addToSetUpdate
    :end-before: end addToSetUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -423,7 +423,7 @@ of the ``vendor`` field:
    :start-after: begin popFirstUpdate
    :end-before: end popFirstUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -450,7 +450,7 @@ The following example removes vendor "A" and "M" from the ``vendor`` array:
    :start-after: begin pullAllUpdate
    :end-before: end pullAllUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -478,7 +478,7 @@ array:
    :start-after: begin pullUpdate
    :end-before: end pullUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -504,7 +504,7 @@ The following examples pushes "C" to the ``vendor`` array:
    :start-after: begin pushUpdate
    :end-before: end pushUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -534,7 +534,7 @@ the ``vendor`` field:
    :start-after: begin combineUpdate
    :end-before: end combineUpdate
 
-The example above updates the document to the following state:
+The example above updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false


### PR DESCRIPTION
## Pull Request Info
Builders Section Typos

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16491

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-16491-Typos-After-Crud/fundamentals/builders/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
