### PR TITLE
Docsp 16491 typos after builders

### DIFF
--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -4,19 +4,19 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-The following compatibility table specifies the recommended version(s) of the
+The following compatibility table specifies the recommended versions of the
 MongoDB Java driver for use with a specific version of MongoDB.
 
-The first column lists the driver version(s).
+The first column lists the driver versions.
 
 .. include:: /includes/mongodb-compatibility-table-java.rst
 
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The following compatibility table specifies the recommended version(s) of the
+The following compatibility table specifies the recommended versions of the
 MongoDB Java driver for use with a specific version of Java.
 
-The first column lists the driver version(s).
+The first column lists the driver versions.
 
 .. include:: /includes/language-compatibility-table-java.rst

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -31,7 +31,7 @@ New applications should generally use the
 - Configuration with ``MongoClientSettings`` and ``ConnectionString``.  You can create instances of this interface via factory methods defined in the ``com.mongodb.client.MongoClients`` class. 
 - CRUD API using ``MongoDatabase``, and from there, ``MongoCollection``
 
-You should use ``com.mongodb.MongoClient`` class if you require support for the legacy API, which supports:
+You should use the ``com.mongodb.MongoClient`` class if you require support for the legacy API, which supports:
 
 - Configuration with ``MongoClientOptions`` and ``MongoClientURI``
 - CRUD API using ``DB``, and from there, ``DBCollection``.  You can access this API via the ``getDB()`` method.
@@ -77,7 +77,7 @@ document (in case you embed sub-documents).
 
 For example, if you have an ``Event`` class, that you extend in Java (e.g.
 ``MachineEvent`` or ``NetworkEvent``), using the discriminator identifies
-which class the PojoCodec should use to serialize/deserialize the
+which class the ``PojoCodec`` should use to serialize/deserialize the
 document. 
 
 Can I control serialization of ``LocalDate``?
@@ -105,12 +105,12 @@ and before the ``PojoCodecProvider``:
 Can I make POJOs read/write directly to the field and not use the getters/setters at all?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can configure the PojoCodecProvider to use the
+You can configure the ``PojoCodecProvider`` to use the
 ``SET_PRIVATE_FIELDS_CONVENTION``, which sets a private field through
 reflection if no public setter is available.
 
-Can I mix private, protected and public setters and getters?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Can I mix private, protected, and public setters and getters?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 No. The native POJO codec assumes that getters/setters have the same
 modifiers for each field.  
@@ -131,7 +131,7 @@ there is none at the moment.
 How do I specify the collection name for a particular POJO class? Is there an annotation?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is no annotation. We recommend adding a static in your class as shown:
+There is no annotation. We recommend adding a static string in your class as shown:
 
 .. code-block:: java
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -18,7 +18,7 @@ Why are there two types of ``MongoClient`` in the Java driver?
 
 There are two types of ``MongoClient`` because we wanted a cleaner API
 for new users that didn't have the confusion of including multiple CRUD
-API's. We wanted to ensure that the new CRUD API was available in a Java
+APIs. We wanted to ensure that the new CRUD API was available in a Java
 package structure that would work well with Java module support
 introduced in Java 9. 
 

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -170,7 +170,7 @@ executed) and rejected plans.
 .. include:: /includes/fundamentals/explain-verbosity.rst
 
 In the following example, we print the JSON representation of the
-winning plan for aggregation stages that produce execution plans: 
+winning plans for aggregation stages that produce execution plans: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/AggTour.java
    :language: java

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -102,7 +102,7 @@ method as shown below:
 .. note::
 
    When you call ``create()``, MongoDB does not create the bucket if it
-   does not exist. Instead, MongoDB creates the bucket as necssary such
+   does not exist. Instead, MongoDB creates the bucket as necessary such
    as when you upload your first file.
 
 For more information on the classes and methods mentioned in this section,

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -334,7 +334,7 @@ The following example creates a ``2dsphere`` index on the ``location.geo`` field
 
 .. warning::
 
-   Attemping to create a geospatial index on a field that is covered by a geospatial index will result in an error.
+   Attempting to create a geospatial index on a field that is covered by a geospatial index will result in an error.
 
 .. common-content-end
 .. driver-content-begin

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -24,15 +24,15 @@ index to limit the number of documents it must inspect.
 
 Indexes also:
 
-- allow efficient sorting
-- enable special capabilities like :ref:`geospatial <geo-indexes>` search
-- allow adding constraints to ensure a field value is :ref:`unique <unique-indexes>`
-- and :manual:`more </indexes/>`
+- Allow efficient sorting
+- Enable special capabilities like :ref:`geospatial <geo-indexes>` search
+- Allow adding constraints to ensure a field value is :ref:`unique <unique-indexes>`
+- And :manual:`more </indexes/>`
 
 .. tip::
 
-   Indexes are also used by update operations when finding the document(s) to update, delete operations when finding the
-   document(s) to delete, and by :manual:`certain stages </core/aggregation-pipeline/#pipeline-operators-and-indexes>` in
+   Indexes are also used by update operations when finding the documents to update, delete operations when finding the
+   documents to delete, and by :manual:`certain stages </core/aggregation-pipeline/#pipeline-operators-and-indexes>` in
    the aggregation framework.
 
 Query Coverage and Performance
@@ -40,10 +40,10 @@ Query Coverage and Performance
 
 When you execute a query against MongoDB, your command can include various elements:
 
-- query criteria that specify field(s) and value(s) you are looking for
-- options that affect the query's execution (e.g. read concern)
-- projection criteria to specify the fields MongoDB should return (optional)
-- sort criteria to specify the order documents will be returned from MongoDB (optional)
+- Query criteria that specify fields and values you are looking for
+- Options that affect the query's execution (e.g. read concern)
+- Projection criteria to specify the fields MongoDB should return (optional)
+- Sort criteria to specify the order documents will be returned from MongoDB (optional)
 
 When all the fields specified in the query, projection, and sort are in the same index, MongoDB returns results directly
 from the index, also called a **covered query**.
@@ -52,7 +52,7 @@ from the index, also called a **covered query**.
 
    Sort criteria must match or invert the order of the index.
 
-   Consider an index on the field ``name`` in ascending order (A-Z), ``age`` in descending order (9-0):
+   Consider an index on the field ``name`` in ascending order (A-Z) and ``age`` in descending order (9-0):
 
    .. code-block:: none
       :copyable: false
@@ -103,8 +103,8 @@ most common index types and provide sample code for creating each index type. Fo
    includes static factory methods to create index specification documents for different MongoDB Index key types.
 
 The following examples use the
-:java-docs:`createIndex <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createIndex(org.bson.conversions.Bson,com.mongodb.client.model.IndexOptions)>`
-to create various indexes, and the following setup:
+:java-docs:`createIndex() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createIndex(org.bson.conversions.Bson,com.mongodb.client.model.IndexOptions)>`
+method to create various indexes, and the following setup:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
    :language: java
@@ -243,7 +243,7 @@ language as an option when creating the index.
 
 .. tip::
 
-   Text indexes differ from the more powerful :atlas:`Atlas full text search indexes </atlas-search/>` Atlas users
+   Text indexes differ from the more powerful :atlas:`Atlas full text search indexes </atlas-search/>`. Atlas users
    should use Atlas search.
 
 .. common-content-end
@@ -298,14 +298,14 @@ Geospatial Indexes
 
 .. _geo-indexes:
 
-MongoDB supports queries of geospatial coordinate data using **2dsphere indexes**. With a 2dsphere index, you can query
+MongoDB supports queries of geospatial coordinate data using **2dsphere indexes**. With a ``2dsphere`` index, you can query
 the geospatial data for inclusion, intersection, and proximity. For more information on querying geospatial data, see
 :manual:`Geospatial Queries </geospatial-queries/>`.
 
-To create a 2dsphere index, you must specify a field that contains only **GeoJSON objects**. For more details on this
+To create a ``2dsphere`` index, you must specify a field that contains only **GeoJSON objects**. For more details on this
 type, see the MongoDB server manual page on :manual:`GeoJSON objects </reference/geojson>`.
 
-The ``location.geo`` field in following sample document from the ``theaters`` collection in the ``sample_mflix``
+The ``location.geo`` field in the following sample document from the ``theaters`` collection in the ``sample_mflix``
 database is a GeoJSON Point object that describes the coordinates of the theater:
 
 .. code-block:: javascript
@@ -358,7 +358,7 @@ The following is an example of a geospatial query using the "location.geo" index
 
 MongoDB also supports ``2d`` indexes for calculating distances on a Euclidean plane and for working with the "legacy
 coordinate pairs" syntax used in MongoDB 2.2 and earlier. See the :manual:`Geospatial Queries page </geospatial-queries>`
-in the MongoDB server manual for more further information.
+in the MongoDB server manual for more information.
 
 Unique Indexes
 ~~~~~~~~~~~~~~
@@ -382,14 +382,15 @@ The following example creates a unique, descending index on the ``theaterId`` fi
 
 .. warning::
 
-   Attempting to perform a write operation that stores a duplicate value that violates the unique index, the MongoDB
+   If you perform a write operation that stores a duplicate value that violates the unique index, the MongoDB
    Java driver will raise a ``DuplicateKeyException``, and MongoDB will throw an error resembling the following:
 
-.. code-block:: none
+   .. code-block:: none
 
-   E11000 duplicate key error index
+      E11000 duplicate key error index
 
 Refer to the :manual:`Unique Indexes page </core/index-unique>` in the MongoDB server manual for more information.
+
 .. driver-content-end
 
 Remove an Index

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -64,8 +64,8 @@ can't find the ``slf4j-api`` artifact, the driver logs the following warning wit
 To set up a logger, you must include the following in your project.
 
 * The ``slf4j-api`` artifact
-* a logging framework 
-* a **binding**
+* A logging framework 
+* A **binding**
 
 .. note:: 
 
@@ -367,7 +367,7 @@ its own. You can think of this as similar to class inheritance in Java.
 
 The MongoDB Java driver defines the following logger names to organize different
 logging events in the driver. Here are the logger names defined in the driver
-and the logging events they correspond with. 
+and the logging events they correspond to. 
 
 * ``org.mongodb.driver.authenticator`` : authentication
 * ``org.mongodb.driver.client`` : events related to ``MongoClient`` instances

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -363,7 +363,7 @@ The above code snippet should produce output that looks like this:
 .. code-block:: none
    :copyable: false
 
-   Navigate to JConcole to see your connection pools...
+   Navigate to JConsole to see your connection pools...
 
 Once you have started your server, open JConsole in your terminal using the
 following command:
@@ -391,10 +391,6 @@ Oracle:
 - `JConsole Documentation <https://www.oracle.com/technical-resources/articles/java/jconsole.html>`__.
 - `Monitoring and Management Guide <https://docs.oracle.com/en/java/javase/16/management/monitoring-and-management-using-jmx-technology.html>`__
 
-For more information on the classes and methods mentioned in this section, see
-the following API Documentation:
-
-- :java-docs:`JMXConnectionPoolListener <apidocs/mongodb-driver-core/com/mongodb/management/JMXConnectionPoolListener.html>`
-- `getPlatformMBeanServer() <https://docs.oracle.com/en/java/javase/16/docs/api/java.management/java/lang/management/ManagementFactory.html#getPlatformMBeanServer()>`__
-- `JMXConnectorServer <https://docs.oracle.com/en/java/javase/16/docs/api/java.management/javax/management/remote/JMXConnectorServer.html>`__
-
+For more information on the ``JMXConnectionPoolListener`` class, see
+the API Documentation for
+:java-docs:`JMXConnectionPoolListener <apidocs/mongodb-driver-core/com/mongodb/management/JMXConnectionPoolListener.html>`.

--- a/source/includes/fundamentals/code-snippets/IndexPage.java
+++ b/source/includes/fundamentals/code-snippets/IndexPage.java
@@ -98,7 +98,7 @@ public class IndexPage {
     private void textIndex() {
         System.out.println("text index");
         // begin text index
-        // create a text index of the "fullplot" field in the "movies" collection
+        // create a text index of the "plot" field in the "movies" collection
         // if a text index already exists with a different configuration, this will
         // error
         try {

--- a/source/includes/fundamentals/code-snippets/JMXMonitoring.java
+++ b/source/includes/fundamentals/code-snippets/JMXMonitoring.java
@@ -19,7 +19,7 @@ public class JMXMonitoring {
                         .build();
         MongoClient mongoClient = MongoClients.create(settings);
         try {
-            System.out.println("Navigate to JConcole to see your connection pools...");
+            System.out.println("Navigate to JConsole to see your connection pools...");
             Thread.sleep(Long.MAX_VALUE);
         } catch (Exception e) {
             e.printStackTrace();

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -25,7 +25,7 @@ driver, please open a case in our issue management tool, JIRA:
 
 * `Create an account and login <https://jira.mongodb.org>`_.
 * Navigate to `the JAVA project <https://jira.mongodb.org/browse/JAVA>`_.
-* Click **Create Issue**. Please provide as much information as possible
+* Click :guilabel:`Create`. Please provide as much information as possible
   about the issue and the steps to reproduce it.
 
 Bug reports in JIRA for the Java driver and the Core Server (i.e. SERVER) project are **public**.


### PR DESCRIPTION
## Pull Request Info

Typos for pages after Fundamentals > Builders.

In order to expedite the final typo review PR, recently created fundamentals pages only had admonitions read for typos. The pages that were not read thoroughly in this review were:

- Collations
- GridFS
- Monitoring

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-16491

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-16491-Typos-After-Builders/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
