### PR TITLE
Docsp 17140 output not copyable

### DIFF
--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -90,6 +90,7 @@ on the ``_id`` field:
 The output of the example above should look something like this: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
@@ -117,6 +118,7 @@ on the ``_id`` field:
 The above example should output something like this: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 6, "letter": "c", "food": "maple donut"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
@@ -150,6 +152,7 @@ on the ``letter`` field, and in the event of a tie, ascending order on the
 The output of the example above should look something like this: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 6, "letter": "c", "food": "maple donut"}

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -96,6 +96,7 @@ If you do not need to specify a variant, omit everything after the locale
 code as follows:
 
 .. code-block:: none
+   :copyable: false
 
    "de"
 
@@ -407,6 +408,7 @@ Since "Günter" is lexically before "Gunter" using the
 returns the following update document:
 
 .. code-block:: none
+   :copyable: false
 
   {
     lastErrorObject: { updatedExisting: true, n: 1 },
@@ -462,6 +464,7 @@ After you run the operation above, your output should resemble the
 following:
 
 .. code-block:: none
+   :copyable: false
 
    Deleted document: {"_id": 3, "a": "179 bananas"}
 

--- a/source/fundamentals/crud/read-operations/geo.txt
+++ b/source/fundamentals/crud/read-operations/geo.txt
@@ -233,6 +233,7 @@ meters from the
 The output of the code snippet should look something like this:
 
 .. code-block:: json
+   :copyable: false
    
    {"location": {"address": {"city": "Bronx"}}}
    {"location": {"address": {"city": "New York"}}}
@@ -283,6 +284,7 @@ described in the figure above.
 The output of the code snippet should look something like this:
 
 .. code-block:: json
+   :copyable: false
 
    {"location": {"address": {"city": "Baldwin"}}}
    {"location": {"address": {"city": "Levittown"}}}

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -86,6 +86,7 @@ The code example above prints out the following three documents, sorted by
 length:
 
 .. code-block:: java
+   :copyable: false
 
     Document{{_id=2, title=Les Misérables, author=Hugo, length=1462}}
     Document{{_id=6, title=A Dance with Dragons, author=Martin, length=1104}}
@@ -122,6 +123,7 @@ This operation returns the documents that describe the fourth through sixth
 longest books:
 
 .. code-block:: java
+   :copyable: false
 
     Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
     Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
@@ -140,6 +142,7 @@ collection, returning only small subsets of the collection at one time.
   For example, consider the following data:
 
   .. code-block:: java
+     :copyable: false
 
       { type: "computer", data: "1", serial_no: 235235 }
       { type: "computer", data: "2", serial_no: 235237 }

--- a/source/fundamentals/crud/read-operations/project.txt
+++ b/source/fundamentals/crud/read-operations/project.txt
@@ -79,6 +79,7 @@ this projection to ``find()`` with an empty query document yields the
 following results:
 
 .. code-block:: json
+   :copyable: false
 
    { "_id": 1, "name": "apples" }
    { "_id": 2, "name": "bananas" }
@@ -117,6 +118,7 @@ excludes the ``qty`` and ``rating`` fields. Chaining this projection to
 ``find()`` with an empty query document yields the following results:
 
 .. code-block:: javascript
+   :copyable: false
 
    { "name": "apples" }
    { "name": "bananas" }
@@ -141,6 +143,7 @@ This example that identifies two fields to include in the projection yields
 the following results:
 
 .. code-block:: json
+   :copyable: false
 
      { "name": "apples", "rating": 3 }
      { "name": "bananas", "rating": 1 }

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -74,6 +74,7 @@ For more information on how to build filters, see our :doc:`Filters Builders
 The following shows the output of the query specified above:
 
 .. code-block:: json
+   :copyable: false
 
    { "_id": 2, "color": "green", "qty": 8 }
    { "_id": 3, "color": "purple", "qty": 4 }
@@ -122,6 +123,7 @@ To address the scenario, the owner creates an aggregation pipeline that:
 The following shows the output of the aggregation specified above:
 
 .. code-block:: json
+   :copyable: false
 
    { "_id": "green", "qty": 19 }
    { "_id": "purple", "qty": 14 }
@@ -185,6 +187,7 @@ future inserts or updates to their collection.
 An insert notification looks similar to the following:
 
 .. code-block::
+   :copyable: false
 
    Received a change to the collection: ChangeStreamDocument{
       operationType=OperationType{value='insert'},

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -83,6 +83,7 @@ The code snippets above both sort the documents in the
 largest value of the ``_id`` field: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
@@ -167,6 +168,7 @@ by the ``_id`` field:
 The output of the code example above should look something like this: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
@@ -196,6 +198,7 @@ The code snippet above returns the documents in the
 in descending order: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 6, "letter": "c", "food": "maple donut"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
@@ -226,6 +229,7 @@ field on which we perform the sort, the following documents could be returned
 in any order:
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    {"_id": 5, "letter": "a", "food": "milk and cookies"}
@@ -251,6 +255,7 @@ The code snippet above returns the documents in the
 in the following order: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 2, "letter": "a", "food": "donuts and coffee"}
    {"_id": 3, "letter": "a", "food": "maple syrup"}
@@ -287,6 +292,7 @@ The code snippet above returns the documents in the
 in the following order: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 1, "letter": "c", "food": "coffee with milk"}
    {"_id": 6, "letter": "c", "food": "maple donut"}
@@ -358,6 +364,7 @@ The code example performs the following actions:
 The output of the code example above should look something like this: 
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": 6, "letter": "c", "food": "maple donut", "score": 1.5}
    {"_id": 2, "letter": "a", "food": "donuts and coffee", "score": 0.75}

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -86,6 +86,7 @@ where the ``_id`` values are "3" and "4":
    The following shows the output of the code above:
 
    .. code-block:: shell
+      :copyable: false
 
       A MongoBulkWriteException occurred with the following message:  
       Bulk write operation error on server sample-shard-00-02.pw0q4.mongodb.net:27017. 

--- a/source/fundamentals/crud/write-operations/change-a-document.txt
+++ b/source/fundamentals/crud/write-operations/change-a-document.txt
@@ -98,6 +98,7 @@ following:
 Your output should look something like this:
 
 .. code-block:: none   
+   :copyable: false
 
     Matched document count: 5
     Modified document count: 5
@@ -105,6 +106,7 @@ Your output should look something like this:
 The following shows the updated documents in the ``paint_inventory`` collection:
 
 .. code-block:: json 
+   :copyable: false
 
     { "_id": 1, "color": "red", "qty": 25 }
     { "_id": 2, "color": "purple", "qty": 28 }
@@ -175,6 +177,7 @@ following:
 Your output should look something like this:
 
 .. code-block:: none   
+   :copyable: false
 
     Matched document count: 1
     Modified document count: 1
@@ -182,6 +185,7 @@ Your output should look something like this:
 The following shows the updated document:
 
 .. code-block:: json
+   :copyable: false
 
     { "_id": 5, "color": "orange", "qty": 25 }
 

--- a/source/fundamentals/crud/write-operations/delete.txt
+++ b/source/fundamentals/crud/write-operations/delete.txt
@@ -74,7 +74,8 @@ collection where the ``qty`` is ``0`` and pass the query to the
 The following shows the documents remaining in the ``paint_inventory``
 collection: 
 
-.. code-block:: json    
+.. code-block:: json
+   :copyable: false  
 
     { "_id": 1, "color": "red", "qty": 5 }
     { "_id": 2, "color": "purple", "qty": 8 }
@@ -101,7 +102,8 @@ method:
 The following shows the documents remaining in the ``paint_inventory``
 collection:
 
-.. code-block:: json   
+.. code-block:: json
+   :copyable: false
 
     { "_id": 1, "color": "red", "qty": 5 }
     { "_id": 2, "color": "purple", "qty": 8 }
@@ -126,7 +128,8 @@ method:
 Unlike the other delete methods, ``findOneAndDelete()`` returns the
 deleted document: 
 
-.. code-block:: json   
+.. code-block:: json
+   :copyable: false
 
     { "_id": 2, "color": "purple", "qty": 8 }
 
@@ -138,7 +141,8 @@ deleted document:
 The following shows the documents remaining in the ``paint_inventory``
 collection:
 
-.. code-block:: json   
+.. code-block:: json
+   :copyable: false  
 
     { "_id": 1, "color": "red", "qty": 5 }
     { "_id": 8, "color": "black", "qty": 8 }

--- a/source/fundamentals/crud/write-operations/insert.txt
+++ b/source/fundamentals/crud/write-operations/insert.txt
@@ -132,6 +132,7 @@ your collection.
    If you look inside your collection, you should see the following documents:
    
    .. code-block:: json
+      :copyable: false
 
       { "_id": 3, "color": "red", "qty": 5 }
       { "_id": 4, "color": "purple", "qty": 10 }

--- a/source/fundamentals/crud/write-operations/upsert.txt
+++ b/source/fundamentals/crud/write-operations/upsert.txt
@@ -67,6 +67,7 @@ where the ``color`` is ``"orange"``, specify an update to ``increment`` the
 The method returns:
 
 .. code-block:: json   
+   :copyable: false
 
     AcknowledgedUpdateResult{ matchedCount=0, modifiedCount=0, upsertedId=BsonObjectId{ value=606b4cfc1601f9443b5d6978 }} 
 
@@ -79,6 +80,7 @@ This ``AcknowledgedUpdateResult`` tells us:
 The following shows the documents in the ``paint_inventory`` collection:
 
 .. code-block:: json   
+   :copyable: false
 
     { "_id": { "$oid": "606b4cfbcd83be7518b958da" }, "color": "red", "qty": 5 }
     { "_id": { "$oid": "606b4cfbcd83be7518b958db" }, "color": "purple", "qty": 8 }
@@ -102,7 +104,8 @@ The following shows the documents in the ``paint_inventory`` collection:
 
     The method returns:
 
-    .. code-block:: json  
+    .. code-block:: json
+       :copyable: false 
     
         AcknowledgedUpdateResult{ matchedCount=0, modifiedCount=0, upsertedId=null }
 

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -307,12 +307,14 @@ expressions, to simplify the Relaxed mode JSON output.
 The output of this code should look something like this:
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": "507f1f77bcf86cd799439012", "createdAt": "2020-09-30T21:00:09Z", "myNumber": 4794261}
 
 Without specifying the converters, the Relaxed mode JSON output should look something like this:
 
 .. code-block:: json
+   :copyable: false
 
    {"_id": {"$oid": "507f1f77bcf86cd799439012"}, "createdAt": {"$date": "2020-09-30T21:00:09Z"}, "myNumber": 4794261}
 

--- a/source/fundamentals/data-formats/documents.txt
+++ b/source/fundamentals/data-formats/documents.txt
@@ -355,6 +355,7 @@ here is how to query your data using a ``JsonObject``:
 The output should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    query result in extended json format: {"_id": {"$oid": "6035210f35bd203721c3eab8"}, "name": "Gabriel García Márquez", "dateOfDeath": {"$date": "2014-04-17T04:00:00Z"}, "novels": [{"title": "One Hundred Years of Solitude", "yearPublished": 1967}, {"title": "Chronicle of a Death Foretold", "yearPublished": 1981}, {"title": "Love in the Time of Cholera", "yearPublished": 1985}]}
 
@@ -403,6 +404,7 @@ The output should look something like this:
    The output of this code should look something like this:
  
    .. code-block:: none
+      :copyable: false
 
       query result in relaxed json format: {"_id": "6035210f35bd203721c3eab8", "name": "Gabriel García Márquez", "dateOfDeath": {"$date": "2014-04-17T04:00:00Z"}, "novels": [{"title": "One Hundred Years of Solitude", "yearPublished": 1967}, {"title": "Chronicle of a Death Foretold", "yearPublished": 1981}, {"title": "Love in the Time of Cholera", "yearPublished": 1985}]}
 

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -401,6 +401,7 @@ The following shows sample documents created from the POJOs above in a
 single MongoDB collection:
 
 .. code-block:: json
+   :copyable: false
 
    { "_cls": "AnonymousUser", "_id": ObjectId("<Object ID>"),  ... }
    { "_cls": "RegisteredUser", "_id": ObjectId("<Object ID>"), ... }
@@ -684,6 +685,7 @@ class and the resulting document when using the default behavior of the
 The resulting document should look something like this:
 
 .. code-block:: json
+   :copyable: false
 
    { name: "Robin", height: 51, Family: "ADELIE" }
 

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -386,6 +386,7 @@ The following example creates a unique, descending index on the ``theaterId`` fi
    Java driver will raise a ``DuplicateKeyException``, and MongoDB will throw an error resembling the following:
 
    .. code-block:: none
+      :copyable: false
 
       E11000 duplicate key error index
 
@@ -450,6 +451,7 @@ If you call ``listIndex()`` on a collection that contains a text index,
 the output might resemble the following: 
 
 .. code-block:: json
+   :copyable: false
 
    { "v": 2, "key": {"_id": 1}, "name": "_id_" }
    { "v": 2, "key": {"_fts": "text", "_ftsx": 1}, "name": "title_text", "weights": {"title": 1}, 

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -58,6 +58,7 @@ can't find the ``slf4j-api`` artifact, the driver logs the following warning wit
 ``java.util.logging`` and disables all further logging:
 
 .. code-block:: none
+   :copyable: false
 
    WARNING: SLF4J not found on the classpath.  Logging is disabled for the 'org.mongodb.driver' component
 
@@ -136,6 +137,7 @@ tab corresponding to the logging framework you would like to use in your project
       You should see output that resembles the following:
 
       .. code-block:: none
+         :copyable: false
 
          ...
          16:03:59.468 [main] INFO org.mongodb.driver.connection - Opened connection [connectionId{localValue:7, serverValue:<server value>}] to <connection uri>
@@ -198,6 +200,7 @@ tab corresponding to the logging framework you would like to use in your project
       You should see output that resembles the following:
 
       .. code-block:: none
+         :copyable: false
 
          12:35:00.438 [main] ERROR <my package path> - Logging an Error
 
@@ -278,6 +281,7 @@ project.
       You should see output that resembles the following.
 
       .. code-block:: none
+         :copyable: false
 
          ...
          1317 [cluster-ClusterId{value='<your cluster id>', description='null'}-<your connection uri>] INFO  org.mongodb.driver.cluster - Discovered replica set primary <your connection uri>
@@ -332,6 +336,7 @@ project.
       You should see output that resembles the following.
 
       .. code-block:: none
+         :copyable: false
 
          ...
          10:14:57.633 [cluster-ClusterId{value=<your cluster id>, description='null'}-<your connection uri>] INFO  org.mongodb.driver.cluster - Discovered replica set primary <your connection uri>
@@ -423,6 +428,7 @@ project.
       You should see output that resembles the following.
 
       .. code-block:: none
+         :copyable: false
 
          ...
          829  [cluster-rtt-ClusterId{value='<some value>', description='null'}-<your connection URI>] INFO  org.mongodb.driver.connection - Opened connection [connectionId{localValue:2, serverValue:<your server value>}] to <your connection uri>    
@@ -464,6 +470,7 @@ project.
       You should see output that resembles the following.
 
       .. code-block:: none
+         :copyable: false
 
          ...
          15:40:23.005 [cluster-ClusterId{value='<some value>', description='null'}-<your connection uri>] INFO  org.mongodb.driver.connection - Opened connection [connectionId{localValue:3, serverValue:<your server value>}] to <your connection uri>

--- a/source/includes/quick-start/pojo-query-output.rst
+++ b/source/includes/quick-start/pojo-query-output.rst
@@ -2,6 +2,7 @@ When you run the ``QuickStartPojoExample`` class, it should output the details o
 movie from the sample dataset which should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Movie [
      plot=A young man is accidentally sent 30 years into the past...,

--- a/source/includes/quick-start/query-output.rst
+++ b/source/includes/quick-start/query-output.rst
@@ -2,6 +2,7 @@ When you run the ``QuickStart`` class, it should output the details of the
 movie from the sample dataset which will look something like this:
 
 .. code-block:: json
+   :copyable: false
 
    {
      _id: ...,

--- a/source/usage-examples/bulkWrite.txt
+++ b/source/usage-examples/bulkWrite.txt
@@ -59,6 +59,7 @@ unique index on your collection, an exception is raised that should look
 something like this: 
 
 .. code-block:: sh
+   :copyable: false
 
    The bulk write operation failed due to an error: Bulk write operation error on server <hostname>. Write errors: [BulkWriteError{index=0, code=11000, message='E11000 duplicate key error collection: ... }].
 
@@ -82,6 +83,7 @@ to ``bulkWrite()`` includes examples of the ``InsertOneModel``,
 The output should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Result statistics:
    inserted: 3

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -40,6 +40,7 @@ When you run the above command, you should see output similar to the
 following:
 
 .. code-block:: none
+   :copyable: false
 
    dbStats: {"db": "sample_mflix", "collections": 5, "views": 0, "objects": 75595, "avgObjSize": 692.1003770090614, "dataSize": 52319328, "storageSize": 29831168, "numExtents": 0, "indexes": 9, "indexSize": 14430208, "fileSize": 0, "nsSizeMB": 0, "ok": 1}
 

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -67,6 +67,7 @@ If you run the sample code above, you should see output that looks something
 like this (exact numbers may vary depending on your data):
 
 .. code-block:: none
+   :copyable: false
 
    Estimated number of documents in the movies collection: 23541
    Number of movies from Spain: 755

--- a/source/usage-examples/deleteMany.txt
+++ b/source/usage-examples/deleteMany.txt
@@ -42,6 +42,7 @@ When you run the example, you should see output that reports the number of
 documents deleted in your call to ``deleteMany()``.
 
 .. code-block:: none
+   :copyable: false
 
    Deleted document count: 4
 

--- a/source/usage-examples/deleteOne.txt
+++ b/source/usage-examples/deleteOne.txt
@@ -36,6 +36,7 @@ When you run the example, if the query filter you passed in your call to
 that looks something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Deleted document count: 1
 
@@ -43,6 +44,7 @@ If your query filter does not match a document in your collection,
 your call to ``deleteOne()`` removes no documents and returns the following:
 
 .. code-block:: none
+   :copyable: false
 
    Deleted document count: 0
 

--- a/source/usage-examples/distinct.txt
+++ b/source/usage-examples/distinct.txt
@@ -54,6 +54,7 @@ year for all the movies that Carl Franklin was included as a director,
 which should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    1992
    1995

--- a/source/usage-examples/insertMany.txt
+++ b/source/usage-examples/insertMany.txt
@@ -35,6 +35,7 @@ When you run the example, you should see output that resembles the following
 with the inserted documents' ``ObjectId`` values in each of the value fields:
 
 .. code-block:: none
+   :copyable: false
 
    Inserted document ids: {0=BsonObjectId{value=...}, 1=BsonObjectId{value=...}}
 

--- a/source/usage-examples/insertOne.txt
+++ b/source/usage-examples/insertOne.txt
@@ -35,6 +35,7 @@ When you run the example, you should see output that resembles the following
 with the inserted document's ``ObjectId`` in the value field:
 
 .. code-block:: none
+   :copyable: false
 
    Inserted document id: BsonObjectId{value=...}
 

--- a/source/usage-examples/replaceOne.txt
+++ b/source/usage-examples/replaceOne.txt
@@ -34,6 +34,7 @@ For example, if you try to specify a value for the immutable field
 document, the method throws a ``MongoWriteException`` with the message:
 
 .. code-block:: none
+   :copyable: false
 
    After applying the update, the (immutable) field '_id' was found to have been altered to _id: ObjectId('...)
 
@@ -42,6 +43,7 @@ rules, the method throws a ``MongoWriteException`` with an error
 message that should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    E11000 duplicate key error collection: ...
 
@@ -84,6 +86,7 @@ After you run the example, you should see output that looks something like
 this:
 
 .. code-block:: none
+   :copyable: false
 
    Modified document count: 1
    Upserted id: null
@@ -91,6 +94,7 @@ this:
 Or if the example resulted in an upsert:
 
 .. code-block:: none
+   :copyable: false
 
    Modified document count: 0
    Upserted id: BsonObjectId{value=...}
@@ -98,6 +102,7 @@ Or if the example resulted in an upsert:
 If you query the replaced document, it should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Document {
      { _id=...,

--- a/source/usage-examples/updateMany.txt
+++ b/source/usage-examples/updateMany.txt
@@ -36,6 +36,7 @@ a value for the immutable field ``_id`` in your update document, the
 ``MongoWriteException`` with the message:
 
 .. code-block:: none
+   :copyable: false
 
    Performing an update on the path '_id' would modify the immutable field '_id'
 
@@ -44,6 +45,7 @@ rules, the method throws a ``MongoWriteException`` with an error
 message that should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    E11000 duplicate key error collection: ...
 
@@ -78,6 +80,7 @@ After you run the example, you should see output that looks something like
 this:
 
 .. code-block:: none
+   :copyable: false
 
    Modified document count: 53
 
@@ -85,6 +88,7 @@ If you query the updated document or documents, they should look something like
 this:
 
 .. code-block:: none
+   :copyable: false
 
    [
      Document {

--- a/source/usage-examples/updateOne.txt
+++ b/source/usage-examples/updateOne.txt
@@ -34,6 +34,7 @@ your update document, the method throws a ``MongoWriteException`` with the
 message:
 
 .. code-block:: none
+   :copyable: false
 
    Performing an update on the path '_id' would modify the immutable field '_id'
 
@@ -42,6 +43,7 @@ rules, the method throws a ``MongoWriteException`` with an error
 message that should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    E11000 duplicate key error collection: ...
 
@@ -75,6 +77,7 @@ simplified syntax. For more information on the ``Updates`` builder, see our
 After you run the example, you should see output that looks something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Modified document count: 1
    Upserted id: null
@@ -82,6 +85,7 @@ After you run the example, you should see output that looks something like this:
 Or if the example resulted in an upsert:
 
 .. code-block:: none
+   :copyable: false
 
    Modified document count: 0
    Upserted id: BsonObjectId{value=...}
@@ -90,6 +94,7 @@ Or if the example resulted in an upsert:
 If you query the updated document, it should look something like this:
 
 .. code-block:: none
+   :copyable: false
 
    Document {
      { _id=...,

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -128,6 +128,7 @@ the ``Watch`` application that is similar to the following. Only the
 pipeline filters out the ``delete`` operation:
 
 .. code-block::
+   :copyable: false
 
    Received a change to the collection: ChangeStreamDocument{
      operationType=OperationType{value='insert'},
@@ -158,6 +159,7 @@ You should also see output from the ``WatchCompanion`` application that
 is similar to the following:
 
 .. code-block::
+   :copyable: false
 
    Success! Inserted document id: BsonObjectId{value=5ec3...}
    Updated 1 document.


### PR DESCRIPTION
## Pull Request Info

Make all output code snippets have attribute ":copyable: false".

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17140

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17140-Output-Not-Copyable/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
