### PR TITLE
DOCSP-17190 connecting to localhost

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -97,7 +97,7 @@ connect to MongoDB.
 .. _connect-replica-set:
 
 Connect to ``localhost``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/localhost-connection.rst
 

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -96,6 +96,11 @@ connect to MongoDB.
 
 .. _connect-replica-set:
 
+Connect to ``localhost``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/localhost-connection.rst
+
 Connect to a Replica Set
 ------------------------
 

--- a/source/includes/localhost-connection.rst
+++ b/source/includes/localhost-connection.rst
@@ -1,0 +1,8 @@
+To connect to a ``mongod`` running locally, change the connection string
+to ``"mongodb://localhost:<port>"``, e.g. ``"mongodb://locahost:27017"``.
+
+Your ``mongod`` instance must be running to successfully connect to your
+database. For information on how to start your ``mongod`` instance,
+see the :manual:`Manage mongod Processes
+</tutorial/manage-mongodb-processes/#start-mongod-processes>` Server
+Manual Entry.

--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -95,6 +95,11 @@ After completing this step, you should have a working application that uses
 the Java driver to connect to your MongoDB cluster, run a query on the
 sample data, and print out the result.
 
+Connect to ``localhost``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/localhost-connection.rst
+
 Working with POJOs (Optional)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info
Added information about connecting to localhost on Quick Start and Connection.

Content is from what was done for the node-docs: https://github.com/mongodb/docs-node/pull/189 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17190

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17190-localhostConnection/quick-start/#connect-to-localhost

https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17190-localhostConnection/fundamentals/connection/#connect-to-localhost

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
