### PR TITLE
DOCSP-17059 TLS v1.3 error

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -64,17 +64,16 @@ For more information on the ``MongoClientSettings`` class, see the
 How do I fix: "javax.net.ssl.SSLHandshakeException: extension (5) should not be presented in certificate_request"?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is a known error that can occur when using the TLS 1.3 protocol with
-specific versions of JDK. Before connecting to your MongoDB instance or
-cluster, you need to update your JDK to one of the following patch
-versions or newer:
+This is a `known error
+<https://bugs.openjdk.java.net/browse/JDK-8236039>`__ that can occur
+when using the TLS 1.3 protocol with specific versions of the JDK. If
+you encounter this error when connecting to your MongoDB instance or
+cluster, update your JDK to one of the following patch versions or
+newer:
 
 - JDK 11.0.7
 - JDK 13.0.3
 - JDK 14.0.2
-
-For more information on this issue, see the `JSSE Reference Guide
-<https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#enabling-tls-1.3>`__.
 
 POJOs
 -----
@@ -148,7 +147,7 @@ For example, the following methods throws an exception during encoding:
    private String getField();
    public String setField(String x); 
 
-How do I fix: "org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class X ."? 
+How do I fix: "org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class X."? 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This exception means you need to register a codec for the class since

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -61,6 +61,20 @@ tasks with the ``MongoClientSettings`` class:
 For more information on the ``MongoClientSettings`` class, see the 
 :java-docs:`API Documentation for MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`.
 
+How do I fix: javax.net.ssl.SSLHandshakeException: extension (5) should not be presented in certificate_request?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is a known error that can occur when using the TLS 1.3 protocol with
+specific versions of JDK. Before connecting to your MongoDB instance or
+cluster, you need to update your JDK to one of the preceding patch
+versions or a newer. 
+
+The issue no longer exists for the following JDK releases:
+
+- JDK 11.0.7
+- JDK 13.0.3
+- JDK 14.0.2
+
 POJOs
 -----
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -61,19 +61,20 @@ tasks with the ``MongoClientSettings`` class:
 For more information on the ``MongoClientSettings`` class, see the 
 :java-docs:`API Documentation for MongoClientSettings <apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`.
 
-How do I fix: javax.net.ssl.SSLHandshakeException: extension (5) should not be presented in certificate_request?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I fix: "javax.net.ssl.SSLHandshakeException: extension (5) should not be presented in certificate_request"?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This is a known error that can occur when using the TLS 1.3 protocol with
 specific versions of JDK. Before connecting to your MongoDB instance or
-cluster, you need to update your JDK to one of the preceding patch
-versions or a newer. 
-
-The issue no longer exists for the following JDK releases:
+cluster, you need to update your JDK to one of the following patch
+versions or newer:
 
 - JDK 11.0.7
 - JDK 13.0.3
 - JDK 14.0.2
+
+For more information on this issue, see the `JSSE Reference Guide
+<https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#enabling-tls-1.3>`__.
 
 POJOs
 -----
@@ -93,10 +94,10 @@ Can I use polymorphism in a POJO accessor?
 
 Yes, by using a discriminator.
 
-What is the discriminator?
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+What is a discriminator?
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-The discriminator is for cases where you want to use inheritance, and
+A discriminator is for cases where you want to use inheritance, and
 store multiple types of documents within the same collection or parent
 document (in case you embed sub-documents). 
 
@@ -147,8 +148,8 @@ For example, the following methods throws an exception during encoding:
    private String getField();
    public String setField(String x); 
 
-How do I fix: org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class X .? 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I fix: "org.bson.codecs.configuration.CodecConfigurationException: Can't find a codec for class X ."? 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This exception means you need to register a codec for the class since
 there is none at the moment. 

--- a/source/includes/quick-start/jdk-tls-issue.rst
+++ b/source/includes/quick-start/jdk-tls-issue.rst
@@ -17,4 +17,4 @@
    - JDK 14.0.2
 
    To resolve this error, update your JDK to one of the preceding patch
-   versions or a newer.
+   versions or a newer one.


### PR DESCRIPTION
## Pull Request Info
Added TLS v1.3 error mentioned in the note box on quickstart (https://docs.mongodb.com/drivers/java/sync/quick-start/#query-your-mongodb-cluster-from-your-application) to the FAQ page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17059

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17059-TLSv1.3Error/faq/#how-do-i-fix---javax.net.ssl.sslhandshakeexception--extension--5--should-not-be-presented-in-certificate_request--

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
