### PR TITLE
DOCSP-17548: mention serverless compatibility

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -29,7 +29,7 @@ New features of the 4.3 Java driver release include:
 - Added connection support for
   `MongoDB Atlas Serverless Instances <https://www.mongodb.com/cloud/atlas/serverless>`__.
   For more information on setup, see our documentation on how to
-  :atlas:`Create a New Serverless Instance <tutorial/create-new-serverless-instance/>`
+  :atlas:`Create a New Serverless Instance </tutorial/create-new-serverless-instance/>`
 - Added a builder API for the ``setWindowFields`` pipeline stage to allow the use of window operators
 - Added support for setting Netty `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__
 - Added support for snapshot reads to ``ClientSession``

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -26,7 +26,7 @@ New features of the 4.3 Java driver release include:
 
 - Added support for MongoDB Versioned API. For more information, see our
   :doc:`Versioned API guide </fundamentals/versioned-api>`.
-- Added connection support for
+- Added support for connection to
   `MongoDB Atlas Serverless Instances <https://www.mongodb.com/cloud/atlas/serverless>`__.
   For more information on setup, see our documentation on how to
   :atlas:`Create a New Serverless Instance </tutorial/create-new-serverless-instance/>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -24,8 +24,13 @@ What's New in 4.3
 
 New features of the 4.3 Java driver release include:
 
-- MongoDB Versioned API. For more information, see our :doc:`Versioned API guide </fundamentals/versioned-api>`. 
-- Added a builder API for the ``setWindowFields`` pipeline stage to allow the use of window operators 
+- Added support for MongoDB Versioned API. For more information, see our
+  :doc:`Versioned API guide </fundamentals/versioned-api>`.
+- Added connection support for
+  `MongoDB Atlas Serverless Instances <https://www.mongodb.com/cloud/atlas/serverless>`__.
+  For more information on setup, see our documentation on how to
+  :atlas:`Create a New Serverless Instance <tutorial/create-new-serverless-instance/>`
+- Added a builder API for the ``setWindowFields`` pipeline stage to allow the use of window operators
 - Added support for setting Netty `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__
 - Added support for snapshot reads to ``ClientSession``
 - Limited the rate of establishing new connections per connection pool
@@ -54,11 +59,11 @@ in the field names of documents:
    * - **$**
      - Replace
      - Removed restrictions in nested documents on field names containing this character.
-     
+
    * - **$**
      - Replace
      - Kept restrictions in top-level documents on field names starting with this character. This prevents accidental use of a replace operation when the intention was to use an update operation.
-     
+
 .. note::
 
    Unacknowledged writes using dollar-prefixed or dotted keys may
@@ -82,7 +87,7 @@ New features of the 4.2 Java driver release include:
 .. important::
 
    There are breaking changes that may affect your application. See the
-   `Upgrading Guide <https://mongodb.github.io/mongo-java-driver/4.2/upgrading/>`_  
+   `Upgrading Guide <https://mongodb.github.io/mongo-java-driver/4.2/upgrading/>`_
    for more information.
 
 .. _version-4.1:
@@ -103,4 +108,4 @@ New features of the 4.1 Java driver release include:
 What's New in 4.0
 -----------------
 
-This release adds no new features. 
+This release adds no new features.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17548

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17548-serverless-mention/whats-new/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
