### PR TITLE
DOCSP-17577 moved geospatial figure

### DIFF
--- a/source/fundamentals/crud/read-operations/geo.txt
+++ b/source/fundamentals/crud/read-operations/geo.txt
@@ -267,11 +267,7 @@ To search for geospatial data within a specified shape use the ``geoWithin()``
 static utility method of the ``Filters`` builder class. The ``geoWithin()``
 method constructs a query with the ``$geoWithin`` query operator. 
 
-.. figure:: /includes/figures/geo_geometry.png
-   :alt: Area of Long Island we are searching for movie theaters
-
-The following example searches for movie theaters in the section of Long Island
-described in the figure above.
+The following example searches for movie theaters in the section of Long Island.
 
 .. _example_range_query:
 
@@ -280,6 +276,11 @@ described in the figure above.
    :dedent:
    :start-after: begin rangeExample
    :end-before: end rangeExample
+
+The following figure shows the ``longIslandTriangle`` created.
+
+.. figure:: /includes/figures/geo_geometry.png
+   :alt: Area of Long Island we are searching for movie theaters
 
 The output of the code snippet should look something like this:
 

--- a/source/fundamentals/crud/read-operations/geo.txt
+++ b/source/fundamentals/crud/read-operations/geo.txt
@@ -267,7 +267,7 @@ To search for geospatial data within a specified shape use the ``geoWithin()``
 static utility method of the ``Filters`` builder class. The ``geoWithin()``
 method constructs a query with the ``$geoWithin`` query operator. 
 
-The following example searches for movie theaters in the section of Long Island.
+The following example searches for movie theaters in a section of Long Island.
 
 .. _example_range_query:
 
@@ -276,11 +276,6 @@ The following example searches for movie theaters in the section of Long Island.
    :dedent:
    :start-after: begin rangeExample
    :end-before: end rangeExample
-
-The following figure shows the ``longIslandTriangle`` created.
-
-.. figure:: /includes/figures/geo_geometry.png
-   :alt: Area of Long Island we are searching for movie theaters
 
 The output of the code snippet should look something like this:
 
@@ -293,6 +288,12 @@ The output of the code snippet should look something like this:
    {"location": {"address": {"city": "Mount Vernon"}}}
    {"location": {"address": {"city": "Massapequa"}}}
 
+The following figure shows the polygon defined by the
+``longIslandTriangle`` variable and dots representing the locations of
+the movie theaters returned by our query. 
+
+.. figure:: /includes/figures/geo_geometry.png
+   :alt: Area of Long Island we are searching for movie theaters
 
 For more information on the ``$geoWithin`` operator, see the
 :manual:`reference documentation for $geoWithin </reference/operator/query/geoWithin/>`


### PR DESCRIPTION
## Pull Request Info
I moved the figure after the code snippet so the user won't need any additional context.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17577

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17577-GeoSpatialImage/fundamentals/crud/read-operations/geo/#query-within-a-range

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
