### PR TITLE
Docsp 17220 client specific key trust store

### DIFF
--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -172,8 +172,8 @@ store:
       sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Number Generator>);
       MongoClientSettings settings = MongoClientSettings.builder()
                .applyToSslSettings(builder ->
-                     builder.enabled(true).
-                              context(sslContext)
+                     builder.enabled(true)
+                              .context(sslContext)
                               .build())
                .build();
       MongoClient client = MongoClients.create(settings);

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -155,13 +155,13 @@ please refer to the `JSSE Reference Guide
 
 .. _tls-disable-hostname-verification:
 
-Configure a Client Specific Trust Store and Key Store
+Configure a Client-Specific Trust Store and Key Store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can configure a client specific trust store and key store using the
+You can configure a client-specific trust store and key store using the
 ``init()`` method of the ``SSLContext`` class.
 
-The following code snippet configures a client specific trust store and key
+The following code snippet configures a client-specific trust store and key
 store:
 
 .. code-block:: java

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -182,8 +182,8 @@ store:
       System.err.println(algorithm + " is not a valid message digest algorithm");
    }
 
-For more information on the ``SSLContext`` class, see the official Oracle API
-documentation for `SSL Context <https://docs.oracle.com/en/java/javase/16/docs/api/java.base/javax/net/ssl/SSLContext.html>`__. 
+For more information on the ``SSLContext`` class, see the API
+documentation for `SSL Context <https://cr.openjdk.java.net/~iris/se/16/spec/fr/java-se-16-fr-spec/api/java.base/javax/net/ssl/SSLContext.html>`__. 
 
 Disable Hostname Verification
 -----------------------------

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -171,15 +171,15 @@ store:
       final SSLContext sslContext = SSLContext.getInstance(algorithm);
       sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Number Generator>);
       MongoClientSettings settings = MongoClientSettings.builder()
-               .applyToSslSettings(builder ->
-                     builder.enabled(true)
-                              .context(sslContext)
-                              .build())
+               .applyToSslSettings(builder -> {
+                     builder.enabled(true);
+                     builder.context(sslContext);
+               })
                .build();
       MongoClient client = MongoClients.create(settings);
    }
    catch (NoSuchAlgorithmException e) {
-      System.err.println("I'm sorry, but " + algorithm + " is not a valid message digest algorithm");
+      System.err.println(algorithm + " is not a valid message digest algorithm");
    }
 
 For more information on the ``SSLContext`` class, see the official Oracle API

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -78,7 +78,7 @@ interacts. You can configure access to these certificates in your application in
 two ways:
 
 - Through the JVM Trust Store and JVM Key Store.
-- Through a client-specific Trust Store or Keystore
+- Through a client-specific Trust Store and Key Store
 
 .. _tls-configure-jvm-truststore:
 
@@ -158,7 +158,31 @@ please refer to the `JSSE Reference Guide
 Configure a Client Specific Trust Store and Key Store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+You can also configure a trust store and key store specific to a client using an
+instance of the ``SSLContext`` class.
 
+The following code snippet configures a client specific trust store and key
+store:
+
+.. code-block:: java
+
+   try {
+     final SSLContext sslContext = SSLContext.getInstance("TLS");
+     sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Nummber Generator>);
+     MongoClientSettings settings = MongoClientSettings.builder()
+           .applyToSslSettings(builder ->
+                    builder.enabled(true).
+                             context(sslContext)
+                             .build())
+           .build();
+     MongoClient client = MongoClients.create(settings);
+   }
+   catch (NoSuchAlgorithmException e) {
+     System.err.println("I'm sorry, but TLS is not a valid message digest algorithm");
+   }
+
+For more information on the ``SSLContext`` class, see the official Oracle API
+documentation for `SSL Context <https://docs.oracle.com/en/java/javase/16/docs/api/java.base/javax/net/ssl/SSLContext.html>`__. 
 
 Disable Hostname Verification
 -----------------------------

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -74,11 +74,11 @@ Configure Certificates
 Java applications that initiate TLS/SSL requests require access to
 cryptographic certificates that prove identity for the application
 itself as well as other applications with which the application
-interacts. You can configure access to these certificates in your application in
-two ways:
+interacts. You can configure access to these certificates in your application with
+two mechanisms:
 
-- Through the JVM Trust Store and JVM Key Store.
-- Through a client-specific Trust Store and Key Store
+- The JVM Trust Store and JVM Key Store
+- A Client-Specific Trust Store and Key Store
 
 .. _tls-configure-jvm-truststore:
 
@@ -158,27 +158,28 @@ please refer to the `JSSE Reference Guide
 Configure a Client Specific Trust Store and Key Store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also configure a trust store and key store specific to a client using an
-instance of the ``SSLContext`` class.
+You can configure a client specific trust store and key store using the
+``SSLContext`` class.
 
 The following code snippet configures a client specific trust store and key
 store:
 
 .. code-block:: java
 
+   String algorithm = "TLS";
    try {
-     final SSLContext sslContext = SSLContext.getInstance("TLS");
-     sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Nummber Generator>);
-     MongoClientSettings settings = MongoClientSettings.builder()
-           .applyToSslSettings(builder ->
-                    builder.enabled(true).
-                             context(sslContext)
-                             .build())
-           .build();
-     MongoClient client = MongoClients.create(settings);
+      final SSLContext sslContext = SSLContext.getInstance(algorithm);
+      sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Nummber Generator>);
+      MongoClientSettings settings = MongoClientSettings.builder()
+               .applyToSslSettings(builder ->
+                     builder.enabled(true).
+                              context(sslContext)
+                              .build())
+               .build();
+      MongoClient client = MongoClients.create(settings);
    }
    catch (NoSuchAlgorithmException e) {
-     System.err.println("I'm sorry, but TLS is not a valid message digest algorithm");
+      System.err.println("I'm sorry, but " + algorithm + " is not a valid message digest algorithm");
    }
 
 For more information on the ``SSLContext`` class, see the official Oracle API

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -74,8 +74,11 @@ Configure Certificates
 Java applications that initiate TLS/SSL requests require access to
 cryptographic certificates that prove identity for the application
 itself as well as other applications with which the application
-interacts. To configure access to these certificates in your application,
-you should use the JVM Trust Store and the JVM Key Store.
+interacts. You can configure access to these certificates in your application in
+two ways:
+
+- Through the JVM Trust Store and JVM Key Store.
+- Through a client-specific Trust Store or Keystore
 
 .. _tls-configure-jvm-truststore:
 
@@ -151,6 +154,11 @@ please refer to the `JSSE Reference Guide
 <http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html>`__.
 
 .. _tls-disable-hostname-verification:
+
+Configure a Client Specific Trust Store and Key Store
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 
 Disable Hostname Verification
 -----------------------------

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -159,7 +159,7 @@ Configure a Client Specific Trust Store and Key Store
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can configure a client specific trust store and key store using the
-``SSLContext`` class.
+``init()`` method of the ``SSLContext`` class.
 
 The following code snippet configures a client specific trust store and key
 store:

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -169,7 +169,7 @@ store:
    String algorithm = "TLS";
    try {
       final SSLContext sslContext = SSLContext.getInstance(algorithm);
-      sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Nummber Generator>);
+      sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Number Generator>);
       MongoClientSettings settings = MongoClientSettings.builder()
                .applyToSslSettings(builder ->
                      builder.enabled(true).

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -166,7 +166,7 @@ instance in the
 :ref:`Customize TLS/SSL Configuration with an SSLContext section of this guide <tls-custom-sslContext>`.
 
 For more information on the ``SSLContext`` class, see the API
-documentation for `SSL Context <https://cr.openjdk.java.net/~iris/se/16/spec/fr/java-se-16-fr-spec/api/java.base/javax/net/ssl/SSLContext.html>`__. 
+documentation for `SSL Context <https://docs.oracle.com/en/java/javase/16/docs/api/java.base/javax/net/ssl/SSLContext.html>`__. 
 
 Disable Hostname Verification
 -----------------------------

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -161,26 +161,9 @@ Configure a Client-Specific Trust Store and Key Store
 You can configure a client-specific trust store and key store using the
 ``init()`` method of the ``SSLContext`` class.
 
-The following code snippet configures a client-specific trust store and key
-store:
-
-.. code-block:: java
-
-   String algorithm = "TLS";
-   try {
-      final SSLContext sslContext = SSLContext.getInstance(algorithm);
-      sslContext.init(<Your Key Managers>, <Your Trust Managers>, <A Secure Random Number Generator>);
-      MongoClientSettings settings = MongoClientSettings.builder()
-               .applyToSslSettings(builder -> {
-                     builder.enabled(true);
-                     builder.context(sslContext);
-               })
-               .build();
-      MongoClient client = MongoClients.create(settings);
-   }
-   catch (NoSuchAlgorithmException e) {
-      System.err.println(algorithm + " is not a valid message digest algorithm");
-   }
+You can find an example showing how to configure a client with an ``SSLContext``
+instance in the 
+`Customize TLS/SSL Configuration with an SSLContext section of this guide <https://docs.mongodb.com/drivers/java/sync/current/fundamentals/connection/tls/#customize-tls-ssl-configuration-with-an-sslcontext>`__.
 
 For more information on the ``SSLContext`` class, see the API
 documentation for `SSL Context <https://cr.openjdk.java.net/~iris/se/16/spec/fr/java-se-16-fr-spec/api/java.base/javax/net/ssl/SSLContext.html>`__. 

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -163,7 +163,7 @@ You can configure a client-specific trust store and key store using the
 
 You can find an example showing how to configure a client with an ``SSLContext``
 instance in the 
-`Customize TLS/SSL Configuration with an SSLContext section of this guide <https://docs.mongodb.com/drivers/java/sync/current/fundamentals/connection/tls/#customize-tls-ssl-configuration-with-an-sslcontext>`__.
+:ref:`Customize TLS/SSL Configuration with an SSLContext section of this guide <tls-custom-sslContext>`.
 
 For more information on the ``SSLContext`` class, see the API
 documentation for `SSL Context <https://cr.openjdk.java.net/~iris/se/16/spec/fr/java-se-16-fr-spec/api/java.base/javax/net/ssl/SSLContext.html>`__. 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -24,8 +24,13 @@ What's New in 4.3
 
 New features of the 4.3 Java driver release include:
 
-- MongoDB Versioned API. For more information, see our :doc:`Versioned API guide </fundamentals/versioned-api>`. 
-- Added a builder API for the ``setWindowFields`` pipeline stage to allow the use of window operators 
+- Added support for MongoDB Versioned API. For more information, see our
+  :doc:`Versioned API guide </fundamentals/versioned-api>`.
+- Added support for connection to
+  `MongoDB Atlas Serverless Instances <https://www.mongodb.com/cloud/atlas/serverless>`__.
+  For more information on setup, see our documentation on how to
+  :atlas:`Create a New Serverless Instance </tutorial/create-new-serverless-instance/>`
+- Added a builder API for the ``setWindowFields`` pipeline stage to allow the use of window operators
 - Added support for setting Netty `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__
 - Added support for snapshot reads to ``ClientSession``
 - Limited the rate of establishing new connections per connection pool
@@ -54,11 +59,11 @@ in the field names of documents:
    * - **$**
      - Replace
      - Removed restrictions in nested documents on field names containing this character.
-     
+
    * - **$**
      - Replace
      - Kept restrictions in top-level documents on field names starting with this character. This prevents accidental use of a replace operation when the intention was to use an update operation.
-     
+
 .. note::
 
    Unacknowledged writes using dollar-prefixed or dotted keys may
@@ -82,7 +87,7 @@ New features of the 4.2 Java driver release include:
 .. important::
 
    There are breaking changes that may affect your application. See the
-   `Upgrading Guide <https://mongodb.github.io/mongo-java-driver/4.2/upgrading/>`_  
+   `Upgrading Guide <https://mongodb.github.io/mongo-java-driver/4.2/upgrading/>`_
    for more information.
 
 .. _version-4.1:
@@ -103,4 +108,4 @@ New features of the 4.1 Java driver release include:
 What's New in 4.0
 -----------------
 
-This release adds no new features. 
+This release adds no new features.


### PR DESCRIPTION
## Pull Request Info
Client specific trust and key stores

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17220

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17220-Client-Specific-Key-Trust-Store/fundamentals/connection/tls/#configure-a-client-specific-trust-store-and-key-store

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
