### PR TITLE
DOCSP-17769 updated GridFS code examples

### DIFF
--- a/source/includes/fundamentals/code-snippets/GridFSOperations.java
+++ b/source/includes/fundamentals/code-snippets/GridFSOperations.java
@@ -70,6 +70,7 @@ public final class GridFSOperations {
 
         try (GridFSUploadStream uploadStream = gridFSBucket.openUploadStream("myProject.zip", options)) {
             uploadStream.write(data);
+            uploadStream.flush();
             System.out.println("The file id of the uploaded file is: " + uploadStream.getObjectId().toHexString());
         } catch (Exception e) {
             System.err.println("The file upload failed: " + e);
@@ -109,6 +110,7 @@ public final class GridFSOperations {
 
         try (FileOutputStream streamToDownloadTo = new FileOutputStream("/tmp/myProject.zip")) {
             gridFSBucket.downloadToStream("myProject.zip", streamToDownloadTo, downloadOptions);
+            streamToDownloadTo.flush();
         }
         // end downloadToStream
     }


### PR DESCRIPTION
## Pull Request Info
Added the flush() method call to the upload a file using an output stream and download a file using an output stream section.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17769

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17769-GridFGCodeExamples/fundamentals/gridfs/#upload-a-file-using-an-output-stream

https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17769-GridFGCodeExamples/fundamentals/gridfs/#download-a-file-to-an-output-stream

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
