### PR TITLE
DOCSP-17659 replaced above and below

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -213,14 +213,14 @@ Imagine we are connecting to a collection that contains only this document:
          :start-after: start current-api-example
          :end-before: end current-api-example
    
-The output of the above code snippet should look like this:
+The output of the preceding code snippet should look like this:
 
 .. code-block:: json
    :copyable: false
 
    {"_id": 1, "val": 1}
 
-For more information on the legacy classes and methods used in the above example,
+For more information on the legacy classes and methods used in the preceding example,
 see the following API Documentation pages:
 
 - :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`
@@ -260,7 +260,7 @@ Here is an example showing how to use the legacy ``MongoClientOptions`` and
          :start-after: start current-api-mongoclientsettings-example
          :end-before: end current-api-mongoclientsettings-example
 
-For more information on the legacy classes and methods used in the above example,
+For more information on the legacy classes and methods used in the preceding example,
 see the following API Documentation pages:
 
 - :java-docs:`Legacy API Javadoc Site <apidocs/mongodb-driver-legacy/index.html>`

--- a/source/fundamentals/aggregation.txt
+++ b/source/fundamentals/aggregation.txt
@@ -143,7 +143,7 @@ In the following example, the aggregation pipeline:
    :start-after: begin aggregation one
    :end-before: end aggregation one
 
-The above aggregation should produce the following results:
+The preceding aggregation should produce the following results:
 
 .. code-block:: none
    :copyable: false
@@ -178,7 +178,7 @@ winning plans for aggregation stages that produce execution plans:
    :start-after: begin aggregation three
    :end-before: end aggregation three
 
-The above code snippet should produce the following output:
+The preceding code snippet should produce the following output:
 
 .. code-block:: none
    :copyable: false
@@ -236,7 +236,7 @@ first element in the ``categories`` field.
    :start-after: begin aggregation two
    :end-before: end aggregation two
 
-The above aggregation should produce the following results:
+The preceding aggregation should produce the following results:
 
 .. code-block:: none
    :copyable: false

--- a/source/fundamentals/builders/filters.txt
+++ b/source/fundamentals/builders/filters.txt
@@ -63,7 +63,7 @@ type, which you can pass to any method that expects a query filter.
 
       import static com.mongodb.client.model.Filters.*;
 
-   The examples below assume this static import.
+   The following examples assume this static import.
 
 The Filter examples in this guide use the following sample collections:
 
@@ -151,7 +151,7 @@ the value of the ``qty`` field equals "5" in the ``paint_purchases`` collection:
    :start-after: begin equalComparison
    :end-before: end equalComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -169,7 +169,7 @@ the value of the ``qty`` field is greater than or equal to "10" in the
    :start-after: begin gteComparison
    :end-before: end gteComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -186,7 +186,7 @@ the ``paint_purchases`` collection because the predicate is empty:
    :start-after: begin emptyComparison
    :end-before: end emptyComparison
 
-The output of the query using the operator specified above consists of
+The output of the preceding query consists of
 all the documents in the collection.
 
 .. code-block:: json
@@ -234,7 +234,7 @@ of the ``color`` field equals "pink" in the ``paint_purchases`` collection:
    :start-after: begin orComparison
    :end-before: end orComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false
@@ -277,7 +277,7 @@ containing both "A" and "D" in the ``paint_purchases`` collection:
    :start-after: begin allComparison
    :end-before: end allComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false
@@ -315,7 +315,7 @@ its value does not equal "5" or "8" in the ``paint_purchases`` collection:
    :start-after: begin existsComparison
    :end-before: end existsComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false
@@ -362,7 +362,7 @@ starting with the letter "p" in the ``paint_purchases`` collection:
    :start-after: begin regexComparison
    :end-before: end regexComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false
@@ -409,7 +409,7 @@ with bits set at positions of the corresponding bitmask "34" (i.e.
    :start-after: begin bitsComparison
    :end-before: end bitsComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false
@@ -470,7 +470,7 @@ in the ``geo_points`` collection:
    :start-after: begin geoWithinComparison
    :end-before: end geoWithinComparison
 
-The following shows the output of the query using the operator specified above:
+The following shows the output of the preceding query:
    
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/builders/indexes.txt
+++ b/source/fundamentals/builders/indexes.txt
@@ -47,7 +47,7 @@ instance, which you can pass to
 
       import static com.mongodb.client.model.Indexes.*;
 
-   The examples below assume this static import.
+   The following examples assume this static import.
 
 .. _ascending-indexes:
 

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -43,7 +43,7 @@ to any method that expects a projection.
       :language: java
       :dedent:
 
-   The examples below assume this static import.
+   The following examples assume this static import.
 
 Sample Documents and Examples
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -87,7 +87,7 @@ on the ``_id`` field:
 
    collection.find().sort(ascending("_id"));
 
-The output of the example above should look something like this: 
+The output of the preceding example should look something like this: 
 
 .. code-block:: json
    :copyable: false
@@ -115,7 +115,7 @@ on the ``_id`` field:
    
    collection.find().sort(descending("_id"));
 
-The above example should output something like this: 
+The preceding example should output something like this: 
 
 .. code-block:: json
    :copyable: false
@@ -149,7 +149,7 @@ on the ``letter`` field, and in the event of a tie, ascending order on the
    Bson orderBySort = orderBy(descending("letter"), ascending("_id"));
    collection.find().sort(orderBySort);
 
-The output of the example above should look something like this: 
+The output of the preceding example should look something like this: 
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -522,7 +522,8 @@ The preceding example updates the original document to the following state:
 Combining Multiple Update Operators
 -----------------------------------
 An application can update multiple fields of a single document by
-combining two or more of the preceding update operators. 
+combining two or more of the update operators described in the preceding
+sections. 
 
 The following example increments the value of the ``qty`` field by "6", sets
 the value of the ``color`` field to "purple", and pushes "R" to

--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -42,7 +42,7 @@ type, which you can pass to any method that expects an update argument.
 
       import static com.mongodb.client.model.Updates.*;
 
-   The examples below assume this static import.
+   The following examples assume this static import.
 
 The examples in this guide use the following document: 
 
@@ -75,7 +75,7 @@ The following example sets the value of the ``qty`` field to "11":
    :start-after: begin setUpdate
    :end-before: end setUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -101,7 +101,7 @@ The following example deletes the ``qty`` field:
    :start-after: begin unsetUpdate
    :end-before: end unsetUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -128,7 +128,7 @@ if an upsert resulted in the insert of a document:
    :start-after: begin setOnInsertUpdate
    :end-before: end setOnInsertUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -159,7 +159,7 @@ The following example increments the value of the ``qty`` field by
    :start-after: begin incUpdate
    :end-before: end incUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -186,7 +186,7 @@ The following example multiplies the value of the ``qty`` field by
    :start-after: begin mulUpdate
    :end-before: end mulUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -212,7 +212,7 @@ The following example renames the ``qty`` field to "quantity":
    :start-after: begin renameUpdate
    :end-before: end renameUpdate
    
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -237,7 +237,7 @@ specified in an update operation.
    :start-after: begin minUpdate
    :end-before: end minUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -265,7 +265,7 @@ maximum of its current value and "8":
    :start-after: begin maxUpdate
    :end-before: end maxUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -293,7 +293,7 @@ the current date as a BSON date:
    :start-after: begin currentDateUpdate
    :end-before: end currentDateUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -321,7 +321,7 @@ the current date as a BSON timestamp:
    :start-after: begin currentTimestampUpdate
    :end-before: end currentTimestampUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -361,7 +361,7 @@ The bitwise operation results in 15:
    ----
    1111
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -394,7 +394,7 @@ the ``vendor`` field:
    :start-after: begin addToSetUpdate
    :end-before: end addToSetUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -423,7 +423,7 @@ of the ``vendor`` field:
    :start-after: begin popFirstUpdate
    :end-before: end popFirstUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false
@@ -450,7 +450,7 @@ The following example removes vendor "A" and "M" from the ``vendor`` array:
    :start-after: begin pullAllUpdate
    :end-before: end pullAllUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -478,7 +478,7 @@ array:
    :start-after: begin pullUpdate
    :end-before: end pullUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
   :copyable: false
@@ -504,7 +504,7 @@ The following examples pushes "C" to the ``vendor`` array:
    :start-after: begin pushUpdate
    :end-before: end pushUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -522,7 +522,7 @@ The example above updates the original document to the following state:
 Combining Multiple Update Operators
 -----------------------------------
 An application can update multiple fields of a single document by
-combining two or more of the update operators described above. 
+combining two or more of the preceding update operators. 
 
 The following example increments the value of the ``qty`` field by "6", sets
 the value of the ``color`` field to "purple", and pushes "R" to
@@ -534,7 +534,7 @@ the ``vendor`` field:
    :start-after: begin combineUpdate
    :end-before: end combineUpdate
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
    
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -195,7 +195,7 @@ The output of the preceding code should contain the following:
    }
 
 The following code snippet shows an example operation that specifies the
-same collation and is covered by the preceding index:
+same collation and is covered by the index we created in the preceding code snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CollationCollectionExample.java
    :language: java

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -184,7 +184,7 @@ of the indexes on that collection as follows:
    :start-after: start listIndexes
    :end-before: end listIndexes
 
-The output of the code above should contain the following:
+The output of the preceding code should contain the following:
 
 .. code-block:: none
    :copyable: false
@@ -195,7 +195,7 @@ The output of the code above should contain the following:
    }
 
 The following code snippet shows an example operation that specifies the
-same collation and is covered by the index we created above:
+same collation and is covered by the preceding index:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CollationCollectionExample.java
    :language: java
@@ -294,7 +294,7 @@ further refine the ordering and matching behavior.
        | :java-docs:`numericOrdering() <apidocs/mongodb-driver-core/com/mongodb/client/model/Collation.Builder.html#numericOrdering(java.lang.Boolean)>` API Documentation
 
 You can use the ``Collation.Builder`` class to specify values for the
-collation options above. You can call the ``build()`` method to construct a
+preceding collation options. You can call the ``build()`` method to construct a
 ``Collation`` object as shown in the following code snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/CollationCollectionExample.java
@@ -404,7 +404,7 @@ In this example, we demonstrate the following:
    :end-before: end findOneAndUpdate
 
 Since "Günter" is lexically before "Gunter" using the
-``de@collation=phonebook`` collation in ascending order, the operation above
+``de@collation=phonebook`` collation in ascending order, the preceding operation
 returns the following update document:
 
 .. code-block:: none
@@ -460,7 +460,7 @@ numerical order.
    :start-after: start findOneAndDelete
    :end-before: end findOneAndDelete
 
-After you run the operation above, your output should resemble the
+After you run the preceding operation, your output should resemble the
 following:
 
 .. code-block:: none
@@ -469,7 +469,7 @@ following:
    Deleted document: {"_id": 3, "a": "179 bananas"}
 
 The numeric value of the string "179" is greater than the number 100, so
-the above document is the only match.
+the preceding document is the only match.
 
 If we perform the same operation without the numerical ordering collation
 on the original collection of three documents, the filter matches all of
@@ -518,7 +518,7 @@ a collation by specifying the following:
    :start-after: start aggregationExample
    :end-before: end aggregationExample
 
-The code above outputs the following documents:
+The preceding code outputs the following documents:
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -79,16 +79,16 @@ authentication mechanism that does not require a username and password, omit
 this part of the connection URI.
 
 The next part of the connection string specifies the hostname or IP address and
-port of your MongoDB instance. In the example below, we use ``sample-hostname``
+port of your MongoDB instance. In the following example, we use ``sample-hostname``
 as the hostname and ``27017`` as the port. Replace these values to point to
 your MongoDB instance.
 
 The last part of the connection string contains connection and authentication
-options as parameters. In the example below, we set two connection options:
+options as parameters. In the following example, we set two connection options:
 ``retryWrites=true`` and ``w=majority``. For more information on connection
 options, skip to the :ref:`connection options <connection-options>` section.
 
-The code below shows how you can use the sample connection URI in a client to
+The following code shows how you can use the sample connection URI in a client to
 connect to MongoDB.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/srv.java
@@ -124,7 +124,7 @@ replica set in several different ways. To create a replica set connection:
 Each of these methods causes the driver to discover any unspecified
 hosts in the replica set.
 
-The connection string below specifies three hosts in the cluster and
+The following connection string specifies three hosts in the cluster and
 replica set named "myRs".
 
 .. code-block:: none

--- a/source/fundamentals/connection/jndi.txt
+++ b/source/fundamentals/connection/jndi.txt
@@ -17,8 +17,9 @@ to your MongoDB instance using a JNDI DataSource.
 MongoClientFactory includes a `JNDI
 <http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
 ``ObjectFactory`` implementation that returns ``MongoClient`` instances
-based on a :ref:`connection URI <connection-uri>`. Follow the following
-guides to configure your application to connect using a JNDI DataSource.
+based on a :ref:`connection URI <connection-uri>`. Consult the following
+guides to learn how to configure your application to connect using a
+JNDI DataSource. 
 
 .. tabs::
 

--- a/source/fundamentals/connection/jndi.txt
+++ b/source/fundamentals/connection/jndi.txt
@@ -17,8 +17,8 @@ to your MongoDB instance using a JNDI DataSource.
 MongoClientFactory includes a `JNDI
 <http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
 ``ObjectFactory`` implementation that returns ``MongoClient`` instances
-based on a :ref:`connection URI <connection-uri>`. Follow the guides
-below to configure your application to connect using a JNDI DataSource.
+based on a :ref:`connection URI <connection-uri>`. Follow the following
+guides to configure your application to connect using a JNDI DataSource.
 
 .. tabs::
 
@@ -35,7 +35,7 @@ below to configure your application to connect using a JNDI DataSource.
 
 
       #. Add a binding to the naming subsystem configuration that references the
-         above module, the ``MongoClientFactory`` class, and the
+         preceding module, the ``MongoClientFactory`` class, and the
          :ref:`connection string <connection-uri>` for the MongoDB cluster.
 
          .. code-block:: xml

--- a/source/fundamentals/crud/compound-operations.txt
+++ b/source/fundamentals/crud/compound-operations.txt
@@ -93,7 +93,7 @@ following options:
    :start-after: start findOneAndUpdate-example
    :end-before: end findOneAndUpdate-example
 
-The output of the above code should look like this:
+The output of the preceding code should look like this:
 
 .. code-block:: json
    :copyable: false
@@ -144,7 +144,7 @@ the returned document should be in the state after our replace operation.
    :start-after: start findOneAndReplace-example
    :end-before: end findOneAndReplace-example
 
-The output of the above code should look like this:
+The output of the preceding code should look like this:
 
 .. code-block:: json
    :copyable: false
@@ -179,7 +179,7 @@ descending sort on the ``_id`` field.
    :start-after: start findOneAndDelete-example
    :end-before: end findOneAndDelete-example
 
-The output of the above code should look like this:
+The output of the preceding code should look like this:
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/crud/query-document.txt
+++ b/source/fundamentals/crud/query-document.txt
@@ -64,8 +64,7 @@ documents where the value of ``qty`` is greater than ``7`` in the
    :start-after: begin comparisonFilter
    :end-before: end comparisonFilter
 
-The following shows the output of the query using the operator specified
-above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -95,8 +94,7 @@ collection:
    :start-after: begin logicalFilter
    :end-before: end logicalFilter
 
-The following shows the output of the query using the operator specified
-above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -122,8 +120,7 @@ documents where the size of the ``vendor`` list is ``3`` in the
    :start-after: begin arrayFilter
    :end-before: end arrayFilter
 
-The following shows the output of the query using the operator specified
-above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -147,8 +144,7 @@ documents that have a ``rating`` in the ``paint_purchases`` collection:
    :start-after: begin elementFilter
    :end-before: end elementFilter
 
-The following shows the output of the query using the operator specified
-above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -175,8 +171,7 @@ documents that have a ``color`` ending with the letter ``"k"`` in the
    :start-after: begin evaluationFilter
    :end-before: end evaluationFilter
 
-The following shows the output of the query using the operator specified
-above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -27,7 +27,7 @@ data from a :java-docs:`FindIterable
 
 .. note::
 
-   The ways to access and store data mentioned below apply to
+   The following ways to access and store data apply to
    other iterables such as an :java-docs:`AggregateIterable
    <apidocs/mongodb-driver-sync/com/mongodb/client/AggregateIterable.html>`.
 
@@ -110,7 +110,7 @@ winning plan for aggregation stages that produce execution plans:
    :start-after: begin explainExample
    :end-before: end explainExample
 
-The above code snippet should produce the following output:
+The preceding code snippet should produce the following output:
 
 .. code-block:: none
    :copyable: false

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -25,7 +25,7 @@ first and the limit only applies to the documents left over after
 the skip. For more information on the ``skip()`` method, see our 
 :doc:`guide on Skipping Returned Documents </fundamentals/crud/read-operations/skip/>`. 
 
-The examples below demonstrate, respectively, how to insert data into
+The following examples demonstrate, respectively, how to insert data into
 a collection, how to use ``limit()`` to restrict the number of returned documents,
 and how to combine ``limit()`` with ``skip()`` to further narrow the results returned from a query.
 
@@ -82,7 +82,7 @@ books with shorter lengths. Lastly, it limits the return value to ``3`` document
         cursor.close();
     }
 
-The code example above prints out the following three documents, sorted by
+The preceding code example prints out the following three documents, sorted by
 length:
 
 .. code-block:: java

--- a/source/fundamentals/crud/read-operations/retrieve.txt
+++ b/source/fundamentals/crud/read-operations/retrieve.txt
@@ -71,7 +71,7 @@ To address this scenario, the owner finds orders to match the criteria:
 For more information on how to build filters, see our :doc:`Filters Builders
 </fundamentals/builders/filters>` guide.
 
-The following shows the output of the query specified above:
+The following shows the output of the preceding query:
 
 .. code-block:: json
    :copyable: false
@@ -120,7 +120,7 @@ To address the scenario, the owner creates an aggregation pipeline that:
    :start-after: begin aggregateExample
    :end-before: end aggregateExample
 
-The following shows the output of the aggregation specified above:
+The following shows the output of the preceding aggregation:
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/crud/read-operations/skip.txt
+++ b/source/fundamentals/crud/read-operations/skip.txt
@@ -93,7 +93,7 @@ Using Aggregation
 - The ``sort()`` stage specifies documents to display from highest to lowest based on the ``qty`` field.
 - The ``skip()`` stage specifies to omit the first five documents. 
 
-The following shows the output of both queries specified above:
+The following shows the output of both preceding queries:
 
 .. code-block:: json
    :copyable: false
@@ -109,7 +109,7 @@ red, and white.
    If the value of skip is greater than or equal to the number of matched
    documents for a query, that query returns no documents.
 
-   If the ``skip()`` method from the example above skips the first nine
+   If the ``skip()`` method from the preceding example skips the first nine
    documents, no results would return since the specified quantity
    exceeds the number of matched documents. 
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -78,7 +78,7 @@ as follows:
    
    collection.aggregate(Arrays.asList(Aggregates.sort(ascending("_id"))));
 
-The code snippets above both sort the documents in the
+The preceding code snippets sort the documents in the
 :ref:`sample collection <sorts-crud-sort-sample>` from smallest to
 largest value of the ``_id`` field: 
 
@@ -90,7 +90,7 @@ largest value of the ``_id`` field:
    {"_id": 3, "letter": "a", "food": "maple syrup"}
    ...
 
-In the above code snippets, we specify our sort criteria using the ``Sorts``
+In the preceding code snippets, we specify our sort criteria using the ``Sorts``
 builder class. While it is possible to specify sort criteria using any class
 that implements the ``Bson`` interface, we recommend that you specify sort
 criteria through the ``Sorts`` builder. For more information on the ``Sorts``
@@ -145,7 +145,7 @@ method to specify an ascending sort on a field as follows:
 
    collection.find().sort(ascending("<field name>"));
 
-The above ``sort()`` method returns a ``FindIterable`` object that can iterate
+The preceding ``sort()`` method returns a ``FindIterable`` object that can iterate
 over the documents in your collection, sorted from smallest to largest on the
 specified field name. 
 
@@ -165,7 +165,7 @@ by the ``_id`` field:
          System.out.println(result.toJson());
    }
 
-The output of the code example above should look something like this: 
+The output of the preceding code example should look something like this: 
 
 .. code-block:: json
    :copyable: false
@@ -193,7 +193,7 @@ The following code snippet shows how to specify a descending sort on the
    collection.find().sort(descending("_id"));
 
 
-The code snippet above returns the documents in the
+The preceding code snippet returns the documents in the
 :ref:`sample collection <sorts-crud-sort-sample>`  
 in descending order: 
 
@@ -250,7 +250,7 @@ We can specify an ascending sort on the ``letter`` field followed by the
    
    collection.find().sort(ascending("letter", "_id"));
 
-The code snippet above returns the documents in the
+The preceding code snippet returns the documents in the
 :ref:`sample collection <sorts-crud-sort-sample>`  
 in the following order: 
 
@@ -287,7 +287,7 @@ tie, by performing an ascending sort on the ``_id`` field.
    Bson orderBySort = orderBy(descending("letter"), ascending("_id"));
    collection.find().sort(orderBySort);
 
-The code snippet above returns the documents in the
+The preceding code snippet returns the documents in the
 :ref:`sample collection <sorts-crud-sort-sample>`
 in the following order: 
 
@@ -361,7 +361,7 @@ The code example performs the following actions:
          System.out.println(result.toJson());
    }
 
-The output of the code example above should look something like this: 
+The output of the preceding code example should look something like this: 
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/crud/write-operations/bulk.txt
+++ b/source/fundamentals/crud/write-operations/bulk.txt
@@ -83,7 +83,7 @@ where the ``_id`` values are "3" and "4":
       :start-after: begin insertExceptionExample
       :end-before: end insertExceptionExample
 
-   The following shows the output of the code above:
+   The following shows the output of the preceding code:
 
    .. code-block:: shell
       :copyable: false
@@ -255,7 +255,7 @@ to the ``order()`` method on ``BulkWriteOptions``. This means that
 all the write operations execute regardless of errors and if any errors occur
 the bulk operation reports them at the end. 
 
-Adding to the example above, including the following specifies the bulk
+Adding to the preceding example, including the following specifies the bulk
 operations to execute in any order: 
 
 .. literalinclude:: /includes/fundamentals/code-snippets/BulkWrite.java
@@ -269,7 +269,7 @@ operations to execute in any order:
    Unordered bulk operations do not guarantee order of execution. The
    order may differ from the way you list them to optimize the runtime.
    
-   In the example above, if the ``bulkWrite()`` method decided to
+   In the preceding example, if the ``bulkWrite()`` method decided to
    perform the insert operation after the update operation, nothing
    changes with the update operation because the document does not exist
    at that point in time. Your collection then contains the following

--- a/source/fundamentals/crud/write-operations/embedded-arrays.txt
+++ b/source/fundamentals/crud/write-operations/embedded-arrays.txt
@@ -58,7 +58,7 @@ The following example performs these actions:
    :start-after: begin pushElementsExample
    :end-before: end pushElementsExample
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -100,7 +100,7 @@ The following example performs these actions:
    :start-after: begin updateValueExample
    :end-before: end updateValueExample
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -132,7 +132,7 @@ The following example performs these actions:
    :start-after: begin updateAllElementsExample
    :end-before: end updateAllElementsExample
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
@@ -172,7 +172,7 @@ The following example performs these actions:
    :start-after: begin updateValueOptionsExample
    :end-before: end updateValueOptionsExample
 
-The example above updates the original document to the following state:
+The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false

--- a/source/fundamentals/data-formats/codecs.txt
+++ b/source/fundamentals/data-formats/codecs.txt
@@ -161,7 +161,7 @@ the ``fromCodecs()`` method:
 
    CodecRegistry codecRegistry = CodecRegistries.fromCodecs(new IntegerCodec(), new PowerStatusCodec());
 
-In the example above, we assign the ``CodecRegistry`` the following ``Codec``
+In the preceding example, we assign the ``CodecRegistry`` the following ``Codec``
 implementations:
 
 - ``IntegerCodec``, a ``Codec`` that converts ``Integers`` and is part of the BSON package.
@@ -355,7 +355,7 @@ retrieves data using the ``Monolight`` class and associated codecs:
    :language: java
    :dedent:
 
-If you run the example above, you should see the following output:
+If you run the preceding example, you should see the following output:
 
 .. code-block:: none
    :copyable: false

--- a/source/fundamentals/data-formats/document-data-format-bson.txt
+++ b/source/fundamentals/data-formats/document-data-format-bson.txt
@@ -65,7 +65,7 @@ guide.
 
 We recommend that you use the `Maven <https://maven.apache.org/>`__ or
 `Gradle <https://gradle.org/>`__ build automation tool to manage your project's
-dependencies. Select from the tabs below to see the dependency declaration
+dependencies. Select from the following tabs to see the dependency declaration
 for that tool:
 
 .. tabs::
@@ -86,6 +86,6 @@ for that tool:
 
       .. include:: /includes/fundamentals/code-snippets/bson-gradle-versioned.rst
 
-If you are not using one of the tools listed above, you can include it in
+If you are not using one of the preceding tools, you can include it in
 your project by downloading the JAR file directly from the
 `sonatype repository <https://repo1.maven.org/maven2/org/mongodb/bson/>`__.

--- a/source/fundamentals/data-formats/document-data-format-extended-json.txt
+++ b/source/fundamentals/data-formats/document-data-format-extended-json.txt
@@ -43,7 +43,7 @@ for bidirectional conversion without loss of information. The **Relaxed mode**
 format is more concise and closer to ordinary JSON, but does not represent
 all the type information such as the specific byte size of number fields.
 
-See the table below to see a description of each format:
+See the following table to see a description of each format:
 
 .. list-table::
    :header-rows: 1
@@ -152,7 +152,7 @@ an example Extended JSON string into a ``Document`` object using the
    Document doc = Document.parse(ejsonStr);
    System.out.println(doc);
 
-The output of the code above should look something like this:
+The output of the preceding code should look something like this:
 
 .. code-block:: none
    :copyable: False

--- a/source/fundamentals/data-formats/document-data-format-pojo.txt
+++ b/source/fundamentals/data-formats/document-data-format-pojo.txt
@@ -126,7 +126,7 @@ To set up the driver to store and retrieve POJOs, we need to specify:
 - A ``MongoCollection`` instance created with the POJO document class
   bound to the ``TDocument`` generic type.
 
-Follow the following steps to see how to perform each of the configuration
+Consult the following steps to see how to perform each of the configuration
 requirements:
 
 1. Configure the ``PojoCodecProvider``. In this example, we use the ``automatic(true)``

--- a/source/fundamentals/data-formats/document-data-format-pojo.txt
+++ b/source/fundamentals/data-formats/document-data-format-pojo.txt
@@ -126,7 +126,7 @@ To set up the driver to store and retrieve POJOs, we need to specify:
 - A ``MongoCollection`` instance created with the POJO document class
   bound to the ``TDocument`` generic type.
 
-Follow the steps below to see how to perform each of the configuration
+Follow the following steps to see how to perform each of the configuration
 requirements:
 
 1. Configure the ``PojoCodecProvider``. In this example, we use the ``automatic(true)``
@@ -155,7 +155,7 @@ requirements:
 
    .. _get-default-codec-registry-example:
 
-   See the code below to see how to instantiate the ``CodecRegistry``:
+   See the following code to see how to instantiate the ``CodecRegistry``:
 
    .. code-block:: java
 
@@ -189,12 +189,12 @@ requirements:
 
       MongoCollection<Flower> collection = database.getCollection("flowers", Flower.class);
 
-Once you have configured the ``MongoCollection`` instance above, you can:
+Once you have configured the preceding ``MongoCollection`` instance, you can:
 
 - save an instance of the POJO to the collection
 - retrieve instances of the POJO from a query on the collection
 
-The code below shows how you can insert an instance of ``Flower`` into
+The following code shows how you can insert an instance of ``Flower`` into
 the collection and then retrieve it as a ``List`` of your POJO class objects:
 
 .. code-block:: java

--- a/source/fundamentals/data-formats/documents.txt
+++ b/source/fundamentals/data-formats/documents.txt
@@ -101,7 +101,7 @@ frequently-used BSON and Java types:
    * - String
      - ``java.lang.String``
 
-The mapping table above shows the default mapping when working with the
+The preceding mapping table shows the default mapping when working with the
 ``Document`` class. You can customize the type mapping by specifying a
 custom codec. For more information on customizing mapped types, see our guide
 on using :doc:`Codecs </fundamentals/data-formats/codecs>`.
@@ -155,7 +155,7 @@ data from the collection using the following code:
 
 .. note::
 
-   The code sample above uses helper methods that check the returned type
+   The preceding code sample uses helper methods that check the returned type
    and throw an exception if it is unable to cast the field value.
    You can call the ``get()`` method specified by the ``Map`` interface
    to retrieve field values as type ``Object`` and to skip type checking.
@@ -270,7 +270,7 @@ data from the collection using the following code:
 
 .. note::
 
-   The code sample above uses helper methods that check the returned type
+   The preceding code sample uses helper methods that check the returned type
    and throw a ``BsonInvalidOperationException`` if it is unable to cast
    the field value. You can call the ``get()`` method specified by the
    ``Map`` interface to retrieve field values as type ``BsonValue`` and
@@ -366,7 +366,7 @@ The output should look something like this:
    along with ``JsonWriterSettings`` to specify your desired JSON
    format.
    
-   Below is a code example where we read and write
+   The following code example reads and writes
    to our MongoDB instance using 
    :manual:`Relaxed mode JSON </reference/mongodb-extended-json/>`
    strings and output ``ObjectId`` instances as hex strings:
@@ -486,7 +486,7 @@ data from the collection using the following code:
 
 .. note::
 
-   The code sample above uses helper methods that check the returned type
+   The preceding code sample uses helper methods that check the returned type
    and throw an exception if it is unable to cast the field value.
    You can call the ``get()`` method to retrieve values as type
    ``Object`` and to skip type checking. 

--- a/source/fundamentals/data-formats/documents.txt
+++ b/source/fundamentals/data-formats/documents.txt
@@ -369,7 +369,7 @@ The output should look something like this:
    The following code example reads and writes
    to our MongoDB instance using 
    :manual:`Relaxed mode JSON </reference/mongodb-extended-json/>`
-   strings and output ``ObjectId`` instances as hex strings:
+   strings and outputs ``ObjectId`` instances as hex strings:
 
    .. code-block:: java
   

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -297,7 +297,7 @@ package:
        when storing a POJO value.
 
 The following code snippet shows a sample POJO called ``Product`` that uses
-the annotations described above.
+the preceding annotations.
 
 .. _bson-annotation-code-example:
 
@@ -397,7 +397,7 @@ annotations and example documents that contain the discriminator fields:
       // class code
   }
 
-The following shows sample documents created from the POJOs above in a
+The following shows sample documents created from the preceding POJOs in a
 single MongoDB collection:
 
 .. code-block:: json
@@ -498,7 +498,7 @@ by which to determine whether to serialize a field:
        }
    }
 
-The class above specifies that any integer above 29 is not serialized, and,
+The preceding class specifies that any integer greater than 29 is not serialized, and,
 therefore, not included in the MongoDB document. Suppose you applied this
 custom serialization behavior to the following sample POJO:
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -98,7 +98,7 @@ mechanism:
 In order to acquire a 
 `Kerberos ticket <https://docs.oracle.com/en/java/javase/11/docs/api/java.security.jgss/javax/security/auth/kerberos/KerberosTicket.html>`__,
 the GSSAPI Java libraries require you to specify the realm and Key Distribution 
-Center (KDC) system properties. See the sample settings in the example below:
+Center (KDC) system properties. See the sample settings in the following example:
 
 .. code-block:: none
 

--- a/source/fundamentals/gridfs.txt
+++ b/source/fundamentals/gridfs.txt
@@ -46,8 +46,8 @@ defined in the GridFS specification:
 - The ``chunks`` collection stores the binary file chunks.
 - The ``files`` collection stores the file metadata.
 
-When you create a new GridFS bucket, the driver creates the collections
-referenced above, prefixed with the default bucket name ``fs``, unless
+When you create a new GridFS bucket, the driver creates the preceding 
+collections, prefixed with the default bucket name ``fs``, unless
 you specify a different name. The driver also creates an index on each
 collection to ensure efficient retrieval of the files and related
 metadata. The driver only creates the GridFS bucket on the first write
@@ -137,7 +137,7 @@ Upload a File Using an Input Stream
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This section shows you how to upload a file to a GridFS bucket using an input
-stream. The code example below shows how you can use a ``FileInputStream`` to
+stream. The following code example shows how you can use a ``FileInputStream`` to
 read data from a file in your filesystem and upload it to GridFS by performing
 the following operations:
 
@@ -162,7 +162,7 @@ Upload a File Using an Output Stream
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This section shows you how to upload a file to a GridFS bucket by writing to
-an output stream. The code example below shows how you can write to a
+an output stream. The following code example shows how you can write to a
 ``GridFSUploadStream`` to send data to GridFS by performing the following
 operations:
 
@@ -218,7 +218,7 @@ from which you can access the results.
 The following code example shows you how to retrieve and print file metadata
 from all your files in a GridFS bucket. Among the different ways that you can
 traverse the retrieved results from the ``GridFSFindIterable``, the example
-uses a ``Consumer`` functional interface to print the results below:
+uses a ``Consumer`` functional interface to print the following results:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/GridFSOperations.java
    :language: java
@@ -340,7 +340,7 @@ rather than its file name.
    want to rename, and pass each file id in separate calls to the ``rename()``
    method.
 
-The code example below shows you how to update the name of the file referenced
+The following code example shows you how to update the name of the file referenced
 by the ``fileId`` variable to "mongodbTutorial.zip":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/GridFSOperations.java
@@ -368,7 +368,7 @@ method. You must specify the file by its file id rather than its file name.
    the file id values from the files you want to delete, and pass each file id
    in separate calls to the ``delete()`` method.
 
-The code example below shows you how to delete the file referenced by the
+The following code example shows you how to delete the file referenced by the
 ``fileId`` variable:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/GridFSOperations.java
@@ -386,7 +386,7 @@ API Documentation.
 Delete a GridFS Bucket
 ----------------------
 
-The code example below shows you how to delete the default GridFS bucket
+The following code example shows you how to delete the default GridFS bucket
 on the database named "mydb". If you need to reference a custom named bucket,
 see the section of this guide on
 :ref:`how to create a custom bucket <gridfs-create-custom-bucket>`.

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -151,7 +151,7 @@ The following example creates an index in ascending order on the ``title`` field
    :end-before: end single index
 .. driver-content-end
 
-The following is an example of a query that would be covered by the index created above:
+The following is an example of a query that would be covered by the preceding index:
 
 .. driver-content-begin
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
@@ -187,7 +187,7 @@ The following example creates a compound index on the ``type`` and ``rated`` fie
    :start-after: begin compound index
    :end-before: end compound index
 
-The following is an example of a query that would be covered by the index created above:
+The following is an example of a query that would be covered by the preceding index:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
    :language: java
@@ -217,7 +217,7 @@ Strings), and ``title`` fields:
    :start-after: begin multikey index
    :end-before: end multikey index
 
-The following is an example of a query that would be covered by the index created above:
+The following is an example of a query that would be covered by the preceding index:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
    :language: java
@@ -261,7 +261,7 @@ The following example creates a text index on the ``plot`` field:
    :start-after: begin text index
    :end-before: end text index
 
-The following is an example of a query that would use the index created above. Note that the ``sort`` is
+The following is an example of a query that would use the preceding index. Note that the ``sort`` is
 omitted because text indexes do not contain sort order.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -151,7 +151,7 @@ The following example creates an index in ascending order on the ``title`` field
    :end-before: end single index
 .. driver-content-end
 
-The following is an example of a query that would be covered by the preceding index:
+The following is an example of a query that would be covered by the index created in the preceding code snippet:
 
 .. driver-content-begin
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
@@ -187,7 +187,7 @@ The following example creates a compound index on the ``type`` and ``rated`` fie
    :start-after: begin compound index
    :end-before: end compound index
 
-The following is an example of a query that would be covered by the preceding index:
+The following is an example of a query that would be covered by the index created in the preceding code snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
    :language: java
@@ -217,7 +217,7 @@ Strings), and ``title`` fields:
    :start-after: begin multikey index
    :end-before: end multikey index
 
-The following is an example of a query that would be covered by the preceding index:
+The following is an example of a query that would be covered by the index created in the preceding code snippet:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java
    :language: java
@@ -261,7 +261,7 @@ The following example creates a text index on the ``plot`` field:
    :start-after: begin text index
    :end-before: end text index
 
-The following is an example of a query that would use the preceding index. Note that the ``sort`` is
+The following is an example of a query that would use the index created in the preceding code snippet. Note that the ``sort`` is
 omitted because text indexes do not contain sort order.
 
 .. literalinclude:: /includes/fundamentals/code-snippets/IndexPage.java

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -246,7 +246,7 @@ project.
       be accessible from your classpath. 
 
       The Logback framework defines the following log levels. The
-      following lists the log levels in order from most urgent to least
+      following lists the log levels, ordered from most urgent to least
       urgent: 
       
       - ERROR
@@ -300,7 +300,7 @@ project.
       be accessible from your classpath. 
 
       The Log4j2 framework defines the following log levels. The following lists the
-      log levels in order from most urgent to least urgent: 
+      log levels, ordered from most urgent to least urgent: 
       
       - FATAL
       - ERROR

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -76,7 +76,7 @@ To set up a logger, you must include the following in your project.
     to your project's dependency list. You will see this in the example below.
 
 A binding is a piece of code that connects the ``slf4j-api`` artifact with a
-logging framework. The example below shows how to bind the ``slf4j-api`` artifact
+logging framework. The following example shows how to bind the ``slf4j-api`` artifact
 to the two most popular logging frameworks, Log4j2 and Logback.
 
 Example - Set Up
@@ -87,7 +87,7 @@ tab corresponding to the logging framework you would like to use in your project
 
 .. note:: Dependency Versions
 
-   The versions listed below are illustrative rather than a
+   The following versions listed are illustrative rather than a
    source of truth. You should check the official documentation for SLF4J and
    your logging framework of choice for guaranteed up-to-date version
    information.
@@ -129,7 +129,7 @@ tab corresponding to the logging framework you would like to use in your project
                   implementation 'ch.qos.logback:logback-classic:1.2.3'
                }
 
-      Once you have included the above dependency, connect to your
+      Once you have included the preceding dependency, connect to your
       MongoDB instance and retrieve a document with the following code.
 
       .. include:: /includes/fundamentals/logging.rst
@@ -184,7 +184,7 @@ tab corresponding to the logging framework you would like to use in your project
                   implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
                }
     
-      Once you have included the above dependency, log an error using the
+      Once you have included the preceding dependency, log an error using the
       following code.
 
       .. code-block:: java
@@ -245,8 +245,8 @@ project.
       ``logback.xml`` file does not have to be in a specific location, but it must
       be accessible from your classpath. 
 
-      The Logback framework defines the following log levels. You can
-      see the log levels listed below in order from most urgent to least
+      The Logback framework defines the following log levels. The
+      following lists the log levels in order from most urgent to least
       urgent: 
       
       - ERROR
@@ -299,8 +299,8 @@ project.
       ``log4j2.xml`` file does not have to be in a specific location, but it must
       be accessible from your classpath. 
 
-      The Log4j2 framework defines the following log levels. You can see the
-      log levels listed below in order from most urgent to least urgent: 
+      The Log4j2 framework defines the following log levels. The following lists the
+      log levels in order from most urgent to least urgent: 
       
       - FATAL
       - ERROR

--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -131,7 +131,7 @@ counter.
    :start-after: start monitor-command-example
    :end-before: end monitor-command-example
 
-The above code snippet should produce output that looks like this:
+The preceding code snippet should produce output that looks like this:
 
 .. code-block:: none
    :copyable: false
@@ -166,7 +166,7 @@ nine events. Here are the three interfaces and the events they listen for:
 - ``ServerMonitorListener``: heartbeat related events
 
 To monitor a type of SDAM event, write a class that
-implements one of the three interfaces above and register an instance of that
+implements one of the three preceding interfaces and register an instance of that
 class with your ``MongoClient`` instance.
 
 For a detailed description of each SDAM event in the driver, see the
@@ -197,7 +197,7 @@ The following code adds an instance of the ``IsWritable`` class to a
    :start-after: start monitor-cluster-example
    :end-before: end monitor-cluster-example
 
-The above code snippet should produce output that looks like this:
+The preceding code snippet should produce output that looks like this:
 
 .. code-block:: none
    :copyable: false
@@ -252,7 +252,7 @@ librarian.
    :start-after: start monitor-cp-example
    :end-before: end monitor-cp-example
 
-The above code snippet should produce output that looks like this:
+The preceding code snippet should produce output that looks like this:
 
 .. code-block:: none
    :copyable: false
@@ -360,7 +360,7 @@ navigate to JConsole and inspect your connection pools.
    :start-after: start jmx-example
    :end-before: end jmx-example
 
-The above code snippet should produce output that looks like this:
+The preceding code snippet should produce output that looks like this:
 
 .. code-block:: none
    :copyable: false
@@ -376,7 +376,7 @@ following command:
 
 Once JConsole is open, perform the following actions in the GUI:
 
-#. Select the Java process running the above example code.
+#. Select the Java process running the preceding example code.
 #. Press :guilabel:`Insecure Connection` in the warning dialog box.
 #. Click on the :guilabel:`MBeans` tab.
 #. Inspect your connection pool events under the ``"org.mongodb.driver"`` domain.
@@ -385,7 +385,7 @@ When you no longer want to inspect your connection pools in JConsole, do the
 following:
 
 - Exit JConsole by closing the JConsole window
-- Stop the Java program running the above code snippet
+- Stop the Java program running the preceding code snippet
 
 For more information on JMX and JConsole, see the following resources from
 Oracle:

--- a/source/fundamentals/versioned-api.txt
+++ b/source/fundamentals/versioned-api.txt
@@ -55,7 +55,7 @@ version of the Versioned API.
    "strict" option is disabled. See the section on
    :ref:`Versioned API Options <versioned-api-options>` for more information.
 
-The example below shows how you can instantiate a ``MongoClient`` that
+The following example shows how you can instantiate a ``MongoClient`` that
 sets the Versioned API version and connects to a server by performing the
 following operations:
 

--- a/source/includes/quick-start/overview.rst
+++ b/source/includes/quick-start/overview.rst
@@ -10,5 +10,5 @@ MongoDB Atlas is a fully-managed cloud database service that hosts your data
 on MongoDB clusters. In this guide, we show you how to get started with your
 own free (no credit card required) cluster.
 
-Follow the steps below to connect your Java application with a MongoDB Atlas
+Follow the following steps to connect your Java application with a MongoDB Atlas
 cluster.

--- a/source/includes/quick-start/overview.rst
+++ b/source/includes/quick-start/overview.rst
@@ -10,5 +10,5 @@ MongoDB Atlas is a fully-managed cloud database service that hosts your data
 on MongoDB clusters. In this guide, we show you how to get started with your
 own free (no credit card required) cluster.
 
-Follow the following steps to connect your Java application with a MongoDB Atlas
+Consult the following steps to connect your Java application with a MongoDB Atlas
 cluster.

--- a/source/usage-examples/command.txt
+++ b/source/usage-examples/command.txt
@@ -36,7 +36,7 @@ statistics from a specific MongoDB database.
   :language: java
 
 
-When you run the above command, you should see output similar to the
+When you run the preceding command, you should see output similar to the
 following:
 
 .. code-block:: none

--- a/source/usage-examples/count.txt
+++ b/source/usage-examples/count.txt
@@ -63,7 +63,7 @@ collection with ``Canada`` in the ``countries`` field.
 .. literalinclude:: /includes/usage-examples/code-snippets/CountDocuments.java
   :language: java
 
-If you run the sample code above, you should see output that looks something
+If you run the preceding sample code, you should see output that looks something
 like this (exact numbers may vary depending on your data):
 
 .. code-block:: none

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -122,7 +122,7 @@ events by performing changes to the collection.
 .. literalinclude:: /includes/usage-examples/code-snippets/WatchCompanion.java
    :language: java
 
-If you run the applications above in sequence, you should see output from
+If you run the preceding applications in sequence, you should see output from
 the ``Watch`` application that is similar to the following. Only the
 ``insert`` and ``update`` operations are printed, since the aggregation
 pipeline filters out the ``delete`` operation:


### PR DESCRIPTION
## Pull Request Info
Replaced all instances of above/below with preceding/following in applicable places.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17659

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17659-RemoveBelowAndAbove/

I'm not going to link to every page and every section since there are many -- take a look in the files tab to assure the edit still makes sense.

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
