### PR TITLE
DOCSP-17770 https links and bson

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,9 @@ To contribute to the documentation,
 See the following documents that provide an overview of the
 documentation style and process:
 
-- `Style Guide <http://docs.mongodb.org/manual/meta/style-guide>`_
-- `Documentation Practices <http://docs.mongodb.org/manual/meta/practices>`_
-- `Documentation Organization <http://docs.mongodb.org/manual/meta/organization>`_
-- `Build Instructions <http://docs.mongodb.org/manual/meta/build>`_
+- `Style Guide <https://docs.mongodb.org/meta/style-guide/style/>`_
+- `Documentation Organization <https://docs.mongodb.org/meta/organization>`_
+- `Documentation Practices <https://docs.mongodb.org/meta/practices>`_
 
 File JIRA Tickets
 -----------------
@@ -42,7 +41,7 @@ Licenses
 --------
 
 All documentation is available under the terms of a `Creative Commons
-License <http://creativecommons.org/licenses/by-nc-sa/3.0/>`_.
+License <https://creativecommons.org/licenses/by-nc-sa/3.0/>`_.
 
 The MongoDB Documentation Project is governed by the terms of the
 `MongoDB Contributor Agreement

--- a/source/api-documentation.txt
+++ b/source/api-documentation.txt
@@ -8,8 +8,8 @@ API Documentation
    :titlesonly:
    :maxdepth: 1
 
-    Bson <http://mongodb.github.io/mongo-java-driver/4.3/apidocs/bson/index.html>
-    Core <http://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-core/index.html>
-    Java Driver (modern API) <http://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-sync/index.html>
+    BSON <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/bson/index.html>
+    Core <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-core/index.html>
+    Java Driver (modern API) <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-sync/index.html>
     Java Driver (legacy API) <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-legacy/index.html>
     

--- a/source/fundamentals/builders/filters.txt
+++ b/source/fundamentals/builders/filters.txt
@@ -19,7 +19,7 @@ In this guide, you can learn how to use **builders** to specify
 **filters** for your queries in the MongoDB Java driver.
 
 Builders are classes provided by the MongoDB Java driver that help you
-construct :ref:`Bson <bson>` objects. To learn more, see our :doc:`guide
+construct :ref:`BSON <bson>` objects. To learn more, see our :doc:`guide
 on builders </fundamentals/builders/>`. 
 
 Filters are the operations MongoDB uses to limit your results to what
@@ -50,7 +50,7 @@ types of operators:
 - :ref:`Geospatial <geospatial>`
 
 The ``Filters`` class provides static factory methods for all the MongoDB query
-operators. Each method returns an instance of the :ref:`Bson <bson>`
+operators. Each method returns an instance of the :ref:`BSON <bson>`
 type, which you can pass to any method that expects a query filter. 
 
 .. tip::

--- a/source/fundamentals/builders/indexes.txt
+++ b/source/fundamentals/builders/indexes.txt
@@ -33,7 +33,7 @@ the field. See our guide on :doc:`Indexes </fundamentals/indexes>` for
 examples of queries covered by indexes. 
 
 The ``Indexes`` class provides static factory methods for all the MongoDB index types.
-Each method returns a :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` 
+Each method returns a :java-docs:`BSON <apidocs/bson/org/bson/conversions/Bson.html>` 
 instance, which you can pass to
 :java-docs:`createIndex() <apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createIndex(org.bson.conversions.Bson,com.mongodb.client.model.IndexOptions)>`.
 

--- a/source/fundamentals/builders/projections.txt
+++ b/source/fundamentals/builders/projections.txt
@@ -28,7 +28,7 @@ query. Projection in MongoDB follows some basic rules:
 Find more information about projection mechanics :manual:`here </tutorial/project-fields-from-query-results/>`.
 
 The ``Projections`` class provides static factory methods for
-all the MongoDB projection operators. Each method returns an instance of the :ref:`Bson <bson>` type which you can pass
+all the MongoDB projection operators. Each method returns an instance of the :ref:`BSON <bson>` type which you can pass
 to any method that expects a projection.
 
 .. tip::

--- a/source/fundamentals/builders/sort.txt
+++ b/source/fundamentals/builders/sort.txt
@@ -26,7 +26,7 @@ examples of sort criteria are:
 * Alphabetical order by first name 
 
 Builders are classes provided by the MongoDB Java driver that help you
-construct :ref:`Bson <bson>` objects. To learn more, see our :doc:`guide
+construct :ref:`BSON <bson>` objects. To learn more, see our :doc:`guide
 on builders </fundamentals/builders/>`. 
 
 You should read this guide if you would like to use builders to specify sort
@@ -64,7 +64,7 @@ For more information about the classes and interfaces in this section, see the
 following API Documentation:
    
 - :java-docs:`Sorts <apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>` 
-- :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>`
+- :java-docs:`BSON <apidocs/bson/org/bson/conversions/Bson.html>`
 - :java-docs:`FindIterable <apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>`
 - :java-docs:`Aggregates <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`
 

--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -31,7 +31,7 @@ Some methods that expect updates are:
 - ``bulkWrite()``
 
 The ``Updates`` class provides static factory methods for all the MongoDB update
-operators. Each method returns an instance of the :ref:`Bson <bson>`
+operators. Each method returns an instance of the :ref:`BSON <bson>`
 type, which you can pass to any method that expects an update argument.
 
 .. tip::

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -282,7 +282,7 @@ further refine the ordering and matching behavior.
        | :java-docs:`collationMaxVariable() <apidocs/mongodb-driver-core/com/mongodb/client/model/Collation.Builder.html#collationMaxVariable(com.mongodb.client.model.CollationMaxVariable)>` API Documentation
 
    * - Strength
-     - | ICU level of comparison. The default value is "tertiary". For more information on each level, see the `ICU Comparison Levels <http://userguide.icu-project.org/collation/concepts#TOC-Comparison-Levels>`__.
+     - | ICU level of comparison. The default value is "tertiary". For more information on each level, see the `ICU Comparison Levels <https://unicode-org.github.io/icu/userguide/collation/concepts.htmll#comparison-levels>`__.
        | :java-docs:`collationStrength() <apidocs/mongodb-driver-core/com/mongodb/client/model/Collation.Builder.html#collationStrength(com.mongodb.client.model.CollationStrength)>` API Documentation
 
    * - Normalization

--- a/source/fundamentals/connection/jndi.txt
+++ b/source/fundamentals/connection/jndi.txt
@@ -15,7 +15,7 @@ In this guide, you can learn how to connect the MongoDB Java driver
 to your MongoDB instance using a JNDI DataSource.
 
 MongoClientFactory includes a `JNDI
-<http://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
+<https://docs.oracle.com/javase/8/docs/technotes/guides/jndi/index.html>`__
 ``ObjectFactory`` implementation that returns ``MongoClient`` instances
 based on a :ref:`connection URI <connection-uri>`. Consult the following
 guides to learn how to configure your application to connect using a
@@ -26,7 +26,7 @@ JNDI DataSource.
    .. tab:: Wildfly (formerly JBoss)
       :tabid: wildfly
 
-      1. In a `Wildfly <http://wildfly.org/>`__ installation, create a new module
+      1. In a `Wildfly <https://wildfly.org/>`__ installation, create a new module
          for MongoDB at ``modules/system/layers/base/org/mongodb/main``. Copy the
          ``mongo-java-driver.jar`` jar file into the module. Add the following
          ``module.xml`` file into the module:
@@ -64,7 +64,7 @@ JNDI DataSource.
       :tabid: tomcat
 
       1. Copy the ``mongo-java-driver.jar`` jar file into the ``lib`` directory
-         of your `Tomcat <http://tomcat.apache.org/>`__ installation.
+         of your `Tomcat <https://tomcat.apache.org/>`__ installation.
 
       #. In the ``context.xml`` file of your application, add a resource that references
          the ``MongoClientFactory`` class and the :ref:`connection string

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -118,7 +118,7 @@ validate the TLS/SSL certificate presented by a connected MongoDB instance.
   store defined in ``javax.net.ssl.trustStore``
 
 You can create a trust store with the `keytool
-<http://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html>`__
+<https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html>`__
 command line tool provided as part of the JDK:
 
 .. code-block:: console
@@ -151,13 +151,13 @@ the MongoDB server:
   defined in ``javax.net.ssl.keyStore``
 
 You can create a key store with the `keytool
-<http://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html>`__
+<https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html>`__
 or `openssl <https://www.openssl.org/docs/apps/openssl.html>`__ command
 line tools.
 
 For more information on configuring a Java application to use TLS/SSL,
 please refer to the `JSSE Reference Guide
-<http://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html>`__.
+<https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html>`__.
 
 .. _tls-disable-hostname-verification:
 

--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -54,7 +54,7 @@ within an aggregation pipeline. To sort your query results, use the
 aggregation pipeline, use the ``Aggregates.sort()`` static factory method. Both
 of these methods receive objects that implement the ``Bson`` interface as
 arguments. For more information, see our API Documentation for the 
-:java-docs:`Bson interface <apidocs/bson/org/bson/conversions/Bson.html>`.
+:java-docs:`BSON interface <apidocs/bson/org/bson/conversions/Bson.html>`.
 
 You can use the ``sort()`` method of a ``FindIterable`` instance as follows:
 
@@ -103,7 +103,7 @@ following API Documentation:
 - :java-docs:`FindIterable <apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>` 
 - :java-docs:`Aggregates <apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`
 - :java-docs:`Sorts <apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`
-- :java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>`
+- :java-docs:`BSON <apidocs/bson/org/bson/conversions/Bson.html>`
 - :java-docs:`Document <apidocs/bson/org/bson/Document.html>`
 
 Sorting Direction

--- a/source/fundamentals/crud/read-operations/text.txt
+++ b/source/fundamentals/crud/read-operations/text.txt
@@ -83,7 +83,7 @@ Use the ``Filters.text()`` method to specify a text search.
 The ``Filters.text()`` method uses the :doc:`Filters builder
 </fundamentals/builders/filters>` to define a query filter specifying
 what to search for during the text search. The query filter is
-represented by a :ref:`Bson <bson>` instance. Pass the query filter to the
+represented by a :ref:`BSON <bson>` instance. Pass the query filter to the
 ``find()`` method to run a text search. 
 
 When you execute the ``find()`` method, MongoDB runs a text search on

--- a/source/fundamentals/data-formats/document-data-format-bson.txt
+++ b/source/fundamentals/data-formats/document-data-format-bson.txt
@@ -38,7 +38,7 @@ MongoDB and BSON
 
 The MongoDB Java Driver, which uses the BSON library, allows you to work
 with BSON data by using one of the object types that implements the
-:java-docs:`BSON <apidocs/bson/org/bson/conversions/Bson.html>` interface,
+:java-docs:`BSON interface <apidocs/bson/org/bson/conversions/Bson.html>`,
 including:
 
 - :java-docs:`Document <apidocs/bson/org/bson/Document.html>` (BSON library package)

--- a/source/fundamentals/data-formats/document-data-format-bson.txt
+++ b/source/fundamentals/data-formats/document-data-format-bson.txt
@@ -38,7 +38,7 @@ MongoDB and BSON
 
 The MongoDB Java Driver, which uses the BSON library, allows you to work
 with BSON data by using one of the object types that implements the
-:java-docs:`Bson <apidocs/bson/org/bson/conversions/Bson.html>` interface,
+:java-docs:`BSON <apidocs/bson/org/bson/conversions/Bson.html>` interface,
 including:
 
 - :java-docs:`Document <apidocs/bson/org/bson/Document.html>` (BSON library package)

--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -93,7 +93,7 @@ tab corresponding to the logging framework you would like to use in your project
    information.
    
    * `SLF4J documentation <http://www.slf4j.org/>`__
-   * `Logback documentation <http://logback.qos.ch/>`__
+   * `Logback documentation <https://logback.qos.ch/>`__
    * `Log4j2 documentation <https://logging.apache.org/log4j/2.x/manual/>`__
 
 .. tabs::
@@ -151,7 +151,7 @@ tab corresponding to the logging framework you would like to use in your project
          :ref:`example in the Configure Your Logger section of this page <configure-log-level>`.
 
       For more information on Logback, see the
-      `Logback manual <http://logback.qos.ch/manual/>`__.
+      `Logback manual <https://logback.qos.ch/manual/>`__.
    
    .. tab:: Log4j2
       :tabid: Log4j2-binding
@@ -435,7 +435,7 @@ project.
          977  [main] INFO  org.mongodb.driver.connection - Opened connection [connectionId{localValue:7, serverValue:<your server value>}] to <your connection uri>
 
       For more information on configuring Logback, see the 
-      `official Logback configuration guide <http://logback.qos.ch/manual/configuration.html#syntax>`__.
+      `official Logback configuration guide <https://logback.qos.ch/manual/configuration.html#syntax>`__.
 
       .. tabs::
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -70,7 +70,7 @@ learning material on using the Java driver to do the following:
 
 API Documentation
 -----------------
-See the `API Documentation <http://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-sync/>`__
+See the `API Documentation <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-sync/>`__
 if you are looking for technical information about classes, methods, and
 configuration objects within the MongoDB Java driver.
 

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -14,7 +14,7 @@ We are lucky to have a vibrant MongoDB Java community that includes users
 with varying levels of experience using the Java driver. We find the quickest 
 way to get support for general questions is through the `MongoDB Community Forums <https://community.mongodb.com>`_.
 
-Refer to our `support channels <http://www.mongodb.org/about/support>`_
+Refer to our `support channels <https://www.mongodb.org/about/support>`_
 documentation for more information.
 
 Bugs / Feature Requests
@@ -32,7 +32,7 @@ Bug reports in JIRA for the Java driver and the Core Server (i.e. SERVER) projec
 
 If you’ve identified a security vulnerability in a driver or any other
 MongoDB project, please report it according to the instructions found in the
-`Create a Vulnerability Report page <http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
+`Create a Vulnerability Report page <https://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report>`_.
 
 Pull Requests
 -------------

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -78,7 +78,7 @@ What's New in 4.2
 New features of the 4.2 Java driver release include:
 
 - Added Azure and GCP key stores to client-side field level encryption
-- Added Kerberos caching tickets for reuse in multiple authentication requests- Added `MongoClients <http://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html>`_ instances with ``MongoClientSettings`` or ``ConnectionString`` as the configuration
+- Added Kerberos caching tickets for reuse in multiple authentication requests- Added `MongoClients <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html>`_ instances with ``MongoClientSettings`` or ``ConnectionString`` as the configuration
 - Use of the ``explain()`` method on `find <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html#explain()>`_ and `aggregate <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-sync/com/mongodb/client/AggregateIterable.html#explain()>`_ commands
 - Added a `JsonObject <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/bson/org/bson/json/JsonObject.html>`_ class to make encoding from and decoding to JSON more efficient by avoiding an intermediate Map representation
 - Added a `BsonRepresentation <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/bson/org/bson/codecs/pojo/annotations/BsonRepresentation.html>`_ annotation that allows you to represent the``ObjectId`` BSON values as a ``String`` in `POJO <https://en.wikipedia.org/wiki/Plain_old_Java_object>`_ classes


### PR DESCRIPTION
## Pull Request Info
- Changed all http links to https 
- Updated instances of "Bson" to "BSON" 

Note: The only link not changed to http was slf4j link because it doesn't exist

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17770

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17770-httpsLinks/

Refer to the files tab to see all changes.

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
