### PR TITLE
Docsp 17095 java subject

### DIFF
--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -158,9 +158,9 @@ You may need to specify one or more of the following additional
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
       - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
-      Click on the following tabs to see sample code to instantiate a
-      ``MongoCredential`` that uses GSSAPI and one of the preceding
-      properties:
+      Select the following **SERVICE_NAME_KEY** or **JAVA_SUBJECT_KEY** tab to
+      see sample code to instantiate a ``MongoCredential`` that uses GSSAPI and
+      the selected property:
 
       .. tabs::
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -158,9 +158,9 @@ You may need to specify one or more of the following additional
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
       - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
-
-      Click on one of the following tabs to see code to instantiate a ``MongoCredential`` using
-      GSSAPI and additional properties. 
+      Click on the following tabs to see code to instantiate a
+      ``MongoCredential`` that uses GSSAPI and one of the preceding
+      properties. 
 
       .. tabs::
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -158,9 +158,9 @@ You may need to specify one or more of the following additional
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
       - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
-      Click on the following tabs to see code to instantiate a
+      Click on the following tabs to see sample code to instantiate a
       ``MongoCredential`` that uses GSSAPI and one of the preceding
-      properties. 
+      properties:
 
       .. tabs::
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -158,15 +158,21 @@ You may need to specify one or more of the following additional
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
       - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
-      Your code to instantiate a ``MongoClient`` using GSSAPI and additional
-      properties might look something like this:
 
-      .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
+      Click on one of the following tabs to see code to instantiate a ``MongoCredential`` using
+      GSSAPI and additional properties. 
 
-      Your code to specify a ``JAVA_SUBJECT_KEY`` might look something like
-      this:
+      .. tabs::
+
+         .. tab::
+            :tabid: SERVICE_NAME_KEY
+
+            .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
+
+         .. tab::
+            :tabid: JAVA_SUBJECT_KEY
       
-      .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
+            .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
 
 By default, the Java driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -178,7 +178,7 @@ By default, the Java driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
 you can change the default Kerberos ticket caching behavior to cache by process
 to improve performance.
-      
+
 .. tabs::
    :hidden:
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -163,12 +163,16 @@ You may need to specify one or more of the following additional
 
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-properties.rst
 
+      Your code to specify a ``JAVA_SUBJECT_KEY`` might look something like
+      this:
+      
+      .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
 
 By default, the Java driver caches Kerberos tickets by ``MongoClient`` instance.
 If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
 you can change the default Kerberos ticket caching behavior to cache by process
 to improve performance.
-
+      
 .. tabs::
    :hidden:
 

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -158,7 +158,7 @@ You may need to specify one or more of the following additional
       - :java-docs:`JAVA_SASL_CLIENT_PROPERTIES_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SASL_CLIENT_PROPERTIES_KEY>`
       - :java-docs:`JAVA_SUBJECT_PROVIDER_KEY <apidocs/mongodb-driver-core/com/mongodb/MongoCredential.html#JAVA_SUBJECT_PROVIDER_KEY>`
 
-      Select the following **SERVICE_NAME_KEY** or **JAVA_SUBJECT_KEY** tab to
+      Select the **SERVICE_NAME_KEY** or **JAVA_SUBJECT_KEY** tab to
       see sample code to instantiate a ``MongoCredential`` that uses GSSAPI and
       the selected property:
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
@@ -1,6 +1,6 @@
 .. code-block:: java
 
-   LoginContext loginContext = new LoginContext("something.from.jaas.config");
+   LoginContext loginContext = new LoginContext("<LoginModule implementation from JAAS config>");
    loginContext.login();
    Subject subject = loginContext.getSubject();
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
@@ -1,9 +1,9 @@
 .. code-block:: java
 
-   LoginContext loginContext = new LoginContext("<LoginModule implementation from JAAS config>");
+   LoginContext loginContext = new LoginContext(<LoginModule implementation from JAAS config>);
    loginContext.login();
    Subject subject = loginContext.getSubject();
 
    MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
-   credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_KEY, subject");
+   credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_KEY, subject);
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
@@ -1,0 +1,9 @@
+.. code-block:: java
+
+   LoginContext loginContext = new LoginContext("something.from.jaas.config");
+   loginContext.login();
+   Subject subject = loginContext.getSubject();
+
+   MongoCredential credential = MongoCredential.createGSSAPICredential(<username>);
+   credential = credential.withMechanismProperty(MongoCredential.JAVA_SUBJECT_KEY, subject");
+


### PR DESCRIPTION
## Pull Request Info

Provide example of setting `JAVA_SUBJECT` property. The docs already [contain an admonition](https://github.com/mongodb/docs-java/blob/master/source/fundamentals/enterprise-auth.txt#L124-L135) informing readers that some properties can only be set through the `MongoCredential` class. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17095

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17095-JAVA_SUBJECT/fundamentals/enterprise-auth/#kerberos--gssapi-

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
