### PR TITLE
DOCSP-18072 setWindowFields snippet 

### DIFF
--- a/source/includes/fundamentals/code-snippets/builders/AggBuilders.java
+++ b/source/includes/fundamentals/code-snippets/builders/AggBuilders.java
@@ -91,7 +91,7 @@ public class AggBuilders {
 
     private void setWindowFieldsStage() {
         // begin setWindowFields
-        Window pastMonth = Windows.timeRange(-1, Windows.Bound.CURRENT, MongoTimeUnit.MONTH);
+        Window pastMonth = Windows.timeRange(-1, MongoTimeUnit.MONTH, Windows.Bound.CURRENT);
         setWindowFields("$localityId", Sorts.ascending("measurementDateTime"),
                 WindowedComputations.sum("monthlyRainfall", "$rainfall", pastMonth),
                 WindowedComputations.avg("monthlyAvgTemp", "$temperature", pastMonth));


### PR DESCRIPTION
## Pull Request Info

Fixed the ordering of the parameters in the setWindowFields code snippet.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18072

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18072-SetWindowFieldsSnippet/fundamentals/builders/aggregates/#setwindowfields

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
