### PR TITLE
DOCSP-17946 find method definition

### DIFF
--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -32,11 +32,9 @@ data from a `FindIterable
    <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/AggregateIterable.html>`__.
 
 The ``find()`` method creates and returns an instance of a
-``FindIterable`` that contains documents matching your query. 
-
-A ``FindIterable`` consists of documents matched by your search criteria
-and allows you to further specify which documents to see by setting
-parameters through methods. 
+``FindIterable``. A ``FindIterable`` allows you to browse the documents
+matched by your search criteria and to further specify which documents
+to see by setting parameters through methods.
 
 Terminal Methods
 ----------------

--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -31,9 +31,8 @@ data from a `FindIterable
    other iterables such as an `AggregateIterable
    <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/AggregateIterable.html>`__.
 
-The ``find()`` method iterates through all the documents in your
-collection to find documents that match your query and returns an
-instance of a ``FindIterable``. 
+The ``find()`` method creates and returns an instance of a
+``FindIterable`` that contains documents matching your query. 
 
 A ``FindIterable`` consists of documents matched by your search criteria
 and allows you to further specify which documents to see by setting


### PR DESCRIPTION
## Pull Request Info

Updated the definition of the find method on the cursor page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17946

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17946-CursorPageFindDefinition/fundamentals/crud/read-operations/cursor/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
