### PR TITLE
remove note about specifying jdk in pom.xml

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -47,25 +47,6 @@ Once you configure your dependencies, ensure they are available to your
 project which may require running your dependency manager and refreshing
 the project in your IDE.
 
-.. note::
-
-   You may need to configure the JDK version in your IDE and dependency
-   file. Refer to the documentation provided by maintainers of your IDE
-   and dependency management system.
-
-   For example, if you build with Maven in the IntelliJ IDE, you need to
-   specify your JDK version explicitly in the ``properties`` section in your
-   ``pom.xml`` file. The following example instructs Maven to use JDK
-   version 1.8 (Java 8):
-
-   .. code-block:: xml
-
-      <properties>
-          <maven.compiler.source>1.8</maven.compiler.source>
-          <maven.compiler.target>1.8</maven.compiler.target>
-      </properties>
-
-
 Create a MongoDB Cluster
 ------------------------
 


### PR DESCRIPTION
## Pull Request Info

As stated on the tin.

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=613920b8c608bec57f933cdd

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/remove-jdk-note/quick-start/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
