### PR TITLE
DOCSP-18551 landing page improvements

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -32,25 +32,21 @@ each section of the driver documentation.
 Quick Start
 -----------
 
-This :doc:`Quick Start </quick-start>` section shows how to establish
-a connection to MongoDB Atlas and begin working with data.
+This :doc:`Quick Start </quick-start>` section is where you will
+establish a connection to MongoDB Atlas and begin working with data.
 
 Usage Examples
 --------------
 
-The :doc:`Usage Examples </usage-examples>` section is where to find
-runnable code snippets and high-level explanations for common methods.
+The :doc:`Usage Examples </usage-examples>` section is where you will
+find runnable code snippets and high-level explanations for common
+methods.
 
 Fundamentals
 ------------
 
 The Fundamentals section is where you will find coverage of
 core operations. This section contains information on how to:
-
-
-Whether you are new to MongoDB or you want to brush up on the core
-concepts, you can check out the Fundamentals section which contains
-learning material on using the Java driver to do the following:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
 - :doc:`Use the Versioned API </fundamentals/versioned-api>`

--- a/source/index.txt
+++ b/source/index.txt
@@ -20,16 +20,90 @@ MongoDB Java Driver
 Introduction
 ------------
 
-The official MongoDB Java Driver enables Java applications to connect to
-and work with data in MongoDB. On this page, you can find descriptions of
-each section of the driver documentation.
-
-If you are working with asynchronous stream processing and reactive
-streams, we recommend the `Reactive Streams Driver
+Welcome to the MongoDB Java driver documentation. This documentation is
+for the *synchronous* driver. If you are working with asynchronous stream
+processing and reactive streams, we recommend the `Reactive Streams Driver
 <https://mongodb.github.io/mongo-java-driver-reactivestreams/>`__.
 
+The official MongoDB Java driver lets you connect your Java applications
+to MongoDB and work with your data. On this page, you can find descriptions of
+each section of the driver documentation.
+
+Quick Start
+-----------
+
+This :doc:`Quick Start </quick-start>` section shows how to establish
+a connection to MongoDB Atlas and begin working with data.
+
+Usage Examples
+--------------
+
+The :doc:`Usage Examples </usage-examples>` section is where to find
+runnable code snippets and high-level explanations for common methods.
+
+Fundamentals
+------------
+
+The Fundamentals section is where you will find coverage of
+core operations. This section contains information on how to:
+
+
+Whether you are new to MongoDB or you want to brush up on the core
+concepts, you can check out the Fundamentals section which contains
+learning material on using the Java driver to do the following:
+
+- :doc:`Connect to MongoDB </fundamentals/connection>`
+- :doc:`Use the Versioned API </fundamentals/versioned-api>`
+- :doc:`Authenticate with MongoDB </fundamentals/auth>`
+- :doc:`Convert between MongoDB Data Formats and Java Objects </fundamentals/data-formats>`
+- :doc:`Read from and Write to MongoDB </fundamentals/crud>`
+- :doc:`Simplify your Code with Builders </fundamentals/builders>`
+- :doc:`Transform your Data </fundamentals/aggregation>`
+- :doc:`Create Indexes to Efficiently Execute Queries </fundamentals/indexes>`
+- :doc:`Sort Using Collations </fundamentals/collations>`
+- :doc:`Log Events in the Driver </fundamentals/logging>`
+- :doc:`Monitor Driver Events </fundamentals/monitoring>`
+- :doc:`Store and Retrieve Large Files in MongoDB </fundamentals/gridfs>`
+- :doc:`Encrypt Fields in a Document </fundamentals/csfle>`
+- :doc:`Use a Time Series Collection </fundamentals/time-series>`
+
+API Documentation
+-----------------
+
+The `API documentation <{+api+}/apidocs/mongodb-driver-sync/>`__
+has detailed technical information about classes, methods, and
+configuration objects within the MongoDB Java driver.
+
+FAQ
+---
+
+The :doc:`Frequently Asked Questions (FAQ) </faq>` section provides answers
+to commonly asked questions about the MongoDB Java Driver.
+
+Issues & Help
+-------------
+
+The :doc:`Issues & Help </issues-and-help>` section explains how to report
+bugs, contribute to the driver, and find additional resources for asking
+questions and receiving help.
+
+Compatibility
+-------------
+
+The :doc:`Compatibility </compatibility>` section shows compatibility charts
+with JVM and MongoDB server versions.
+
+What's New
+----------
+
+The :doc:`What's New </whats-new>` section lists new features and
+changes in each version.
+
+Additional Learning
+-------------------
+
 Take the free online course taught by MongoDB
----------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
 
@@ -40,57 +114,3 @@ Take the free online course taught by MongoDB
      - `M220J: MongoDB for Java Developers <https://university.mongodb.com/courses/M220J/about>`_
 
        Learn the essentials of Java application development with MongoDB.
-
-
-Usage Examples
---------------
-The :doc:`Usage Examples </usage-examples>` section provides
-runnable code snippets and explanations for common methods. We recommend
-this section for users that are new to the MongoDB Java driver.
-
-Fundamentals
-------------
-Whether you are new to MongoDB or you want to brush up on the core
-concepts, you can check out the Fundamentals section which contains
-learning material on using the Java driver to do the following:
-
-- :doc:`Connect to MongoDB </fundamentals/connection>`
-- :doc:`Specify an API Version </fundamentals/versioned-api>`
-- :doc:`Authenticate with MongoDB </fundamentals/auth>`
-- :doc:`Use the Driver's Data Formats </fundamentals/data-formats>`
-- :doc:`Perform CRUD Operations </fundamentals/crud>`
-- :doc:`Simplify your Code with Builders </fundamentals/builders>`
-- :doc:`Perform Aggregations </fundamentals/aggregation>`
-- :doc:`Construct Indexes </fundamentals/indexes>`
-- :doc:`Specify Collations </fundamentals/collations>`
-- :doc:`Record Events in the Driver </fundamentals/logging>`
-- :doc:`Use Driver Events in your Code </fundamentals/monitoring>`
-- :doc:`Store and Retrieve Files in MongoDB </fundamentals/gridfs>`
-- :doc:`Encrypt Fields in a Document </fundamentals/csfle>`
-
-API Documentation
------------------
-See the `API Documentation <{+api+}/apidocs/mongodb-driver-sync/>`__
-if you are looking for technical information about classes, methods, and
-configuration objects within the MongoDB Java driver.
-
-FAQ
----
-The :doc:`Frequently Asked Questions (FAQ) </faq>` section provides answers
-to commonly asked questions about the MongoDB Java Driver.
-
-Issues & Help
--------------
-The :doc:`Issues & Help </issues-and-help>` section explains how to report
-bugs, contribute to the driver, and find additional resources for asking
-questions and receiving help.
-
-Compatibility
--------------
-The :doc:`Compatibility </compatibility>` section shows compatibility charts
-with JVM and MongoDB server versions.
-
-What's New
-----------
-The :doc:`What's New </whats-new>` section shows new features and
-changes in each version.


### PR DESCRIPTION
## Pull Request Info

Implemented all bullets listed in the Jira ticket except for "Explain what a driver is (for all driver landing pages)" because I felt that saying `The official MongoDB Java driver lets you connect your Java applications to MongoDB and work with your data.` defines it. 

I also moved the M220 course to the bottom of the page under "Additional Learning".

Note: Some changes from our team PR meeting aren't implemented here because there is a [separate ticket](https://jira.mongodb.org/browse/DOCSP-18552) to edit sections overall after this one is complete. 


### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18551

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=613bd63dc608bec57f54b583

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18551-LandingPageImprovements/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
