### PR TITLE
DOCSP-18552 page sections improvements

### DIFF
--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -25,20 +25,20 @@ Fundamentals
    /fundamentals/csfle
    /fundamentals/time-series
 
-The Fundamentals section contains detailed information to help you
-expand your knowledge on how to use MongoDB with the Java driver. We
-divide the information in this section into the following topics: 
+The Fundamentals section is where you will find coverage of
+core operations. This section contains information on how to:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
-- :doc:`Specify an API Version </fundamentals/versioned-api>`
+- :doc:`Use the Versioned API </fundamentals/versioned-api>`
 - :doc:`Authenticate with MongoDB </fundamentals/auth>`
-- :doc:`Use the Driver's Data Formats </fundamentals/data-formats>`
-- :doc:`Perform CRUD Operations </fundamentals/crud>`
+- :doc:`Convert between MongoDB Data Formats and Java Objects </fundamentals/data-formats>`
+- :doc:`Read from and Write to MongoDB </fundamentals/crud>`
 - :doc:`Simplify your Code with Builders </fundamentals/builders>`
-- :doc:`Perform Aggregations </fundamentals/aggregation>`
-- :doc:`Construct Indexes </fundamentals/indexes>`
-- :doc:`Specify Collations </fundamentals/collations>`
-- :doc:`Record Events in the Driver </fundamentals/logging>`
-- :doc:`Use Driver Events in your Code </fundamentals/monitoring>`
-- :doc:`Store and Retrieve Files in MongoDB </fundamentals/gridfs>`
+- :doc:`Transform your Data </fundamentals/aggregation>`
+- :doc:`Create Indexes to Efficiently Execute Queries </fundamentals/indexes>`
+- :doc:`Sort Using Collations </fundamentals/collations>`
+- :doc:`Log Events in the Driver </fundamentals/logging>`
+- :doc:`Monitor Driver Events </fundamentals/monitoring>`
+- :doc:`Store and Retrieve Large Files in MongoDB </fundamentals/gridfs>`
 - :doc:`Encrypt Fields in a Document </fundamentals/csfle>`
+- :doc:`Use a Time Series Collection </fundamentals/time-series>`

--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -25,9 +25,8 @@ Fundamentals
    /fundamentals/csfle
    /fundamentals/time-series
 
-The Fundamentals section is where you can find coverage on how to
-perform operations in the Java driver. This section contains 
-learning material to perform the following tasks:
+The Fundamentals section explains how to perform the following tasks
+using the Java driver:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
 - :doc:`Use the Versioned API </fundamentals/versioned-api>`

--- a/source/fundamentals.txt
+++ b/source/fundamentals.txt
@@ -25,8 +25,9 @@ Fundamentals
    /fundamentals/csfle
    /fundamentals/time-series
 
-The Fundamentals section is where you will find coverage of
-core operations. This section contains information on how to:
+The Fundamentals section is where you can find coverage on how to
+perform operations in the Java driver. This section contains 
+learning material to perform the following tasks:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
 - :doc:`Use the Versioned API </fundamentals/versioned-api>`
@@ -35,7 +36,7 @@ core operations. This section contains information on how to:
 - :doc:`Read from and Write to MongoDB </fundamentals/crud>`
 - :doc:`Simplify your Code with Builders </fundamentals/builders>`
 - :doc:`Transform your Data </fundamentals/aggregation>`
-- :doc:`Create Indexes to Efficiently Execute Queries </fundamentals/indexes>`
+- :doc:`Create Indexes to Speed Up Queries </fundamentals/indexes>`
 - :doc:`Sort Using Collations </fundamentals/collations>`
 - :doc:`Log Events in the Driver </fundamentals/logging>`
 - :doc:`Monitor Driver Events </fundamentals/monitoring>`

--- a/source/index.txt
+++ b/source/index.txt
@@ -67,9 +67,11 @@ using the Java driver:
 API Documentation
 -----------------
 
-The MongoDB Java driver API documentation is split into several libraries.
-Each library has detailed technical information about classes, methods, and
-configuration objects within the MongoDB Java driver:
+The MongoDB Java driver API documentation contains detailed information
+about classes and methods in the MongoDB Java driver. The driver
+contains of the following libraries organized by functionality. See the
+following table for descriptions of each library and links to the API
+documentation.
 
 .. list-table::
    :header-rows: 1
@@ -88,7 +90,7 @@ configuration objects within the MongoDB Java driver:
    * - `Java Driver <{+api+}/apidocs/mongodb-driver-sync/index.html>`__ 
      - Modern API
 
-   * - `Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ 
+   * - `Legacy Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ 
      - Legacy API
 
 FAQ
@@ -131,7 +133,7 @@ developers.
 To learn how to use MongoDB features with the Java driver, see the `How
 To's and Articles page <https://www.mongodb.com/developer/learn/?content=Articles&text=java#main>`__.
 
-To ask questions and engage in discussion with fellow developers using
+To ask questions and engage in discussions with fellow developers using
 the Java Driver, see the `forums page <https://www.mongodb.com/community/forums/tag/java>`__.
 
 MongoDB University

--- a/source/index.txt
+++ b/source/index.txt
@@ -27,26 +27,28 @@ processing and reactive streams, we recommend the `Reactive Streams Driver
 
 The official MongoDB Java driver lets you connect your Java applications
 to MongoDB and work with your data. On this page, you can find descriptions of
-each section of the driver documentation and where to go for more resources.
+each section of the driver documentation and where to go to learn more
+about the Java driver.
 
 Quick Start
 -----------
 
-This :doc:`Quick Start </quick-start>` section is where you will
+This :doc:`Quick Start </quick-start>` section is where you can
 establish a connection to MongoDB Atlas and begin working with data.
 
 Usage Examples
 --------------
 
-The :doc:`Usage Examples </usage-examples>` section is where you will
+The :doc:`Usage Examples </usage-examples>` section is where you can
 find runnable code snippets and high-level explanations for common
 methods.
 
 Fundamentals
 ------------
 
-The Fundamentals section is where you will find coverage of
-core operations. This section contains information on how to:
+The Fundamentals section is where you can find coverage on how to
+perform operations in the Java driver. This section contains 
+learning material to perform the following tasks:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
 - :doc:`Use the Versioned API </fundamentals/versioned-api>`
@@ -55,7 +57,7 @@ core operations. This section contains information on how to:
 - :doc:`Read from and Write to MongoDB </fundamentals/crud>`
 - :doc:`Simplify your Code with Builders </fundamentals/builders>`
 - :doc:`Transform your Data </fundamentals/aggregation>`
-- :doc:`Create Indexes to Efficiently Execute Queries </fundamentals/indexes>`
+- :doc:`Create Indexes to Speed Up Queries </fundamentals/indexes>`
 - :doc:`Sort Using Collations </fundamentals/collations>`
 - :doc:`Log Events in the Driver </fundamentals/logging>`
 - :doc:`Monitor Driver Events </fundamentals/monitoring>`
@@ -66,14 +68,29 @@ core operations. This section contains information on how to:
 API Documentation
 -----------------
 
-The MongoDB Java driver API documentation is split into several parts.
-Each part has detailed technical information about classes, methods, and
+The MongoDB Java driver API documentation is split into several sections.
+Each section has detailed technical information about classes, methods, and
 configuration objects within the MongoDB Java driver:
 
-- `BSON <{+api+}/apidocs/bson/index.html>`__ (The BSON Layer)
-- `Core <{+api+}/apidocs/mongodb-driver-core/index.html>`__ (The Shared Core Classes)
-- `Java Driver <{+api+}/apidocs/mongodb-driver-sync/index.html>`__ (Modern API)
-- `Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ (Legacy API)
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 35 65
+
+   * - Section
+     - Description
+
+   * - `BSON <{+api+}/apidocs/bson/index.html>`__ 
+     - Contains the base BSON classes
+   
+   * - `Core <{+api+}/apidocs/mongodb-driver-core/index.html>`__ 
+     - Contains the shared core classes
+   
+   * - `Java Driver <{+api+}/apidocs/mongodb-driver-sync/index.html>`__ 
+     - Contains the modern API
+
+   * - `Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ 
+     - Contains the legacy API
 
 FAQ
 ---
@@ -100,30 +117,30 @@ What's New
 The :doc:`What's New </whats-new>` section lists new features and
 changes in each version.
 
-Resources
----------
+Learn
+------
 
-Visit the Developer Hub and MongoDB University for resources related to
-the MongoDB Java driver.
+Visit the Developer Hub and MongoDB University to learn more about the
+MongoDB Java driver.
 
 Developer Hub
 ~~~~~~~~~~~~~
 
-The Developer Hub contains content, resources, community, and social
-engagement for developers.
+The Developer Hub provides tutorials and social engagement for
+developers.
 
-To view articles on Java, see the `How To's and Articles page
-<https://www.mongodb.com/developer/learn/?content=Articles&text=Java>`_.
+To learn how to use MongoDB features with the Java driver, see the `How
+To's and Articles page <https://www.mongodb.com/developer/learn/?content=Articles&text=java#main>`__.
 
-To view the forum on Java, see the `forums page
-<https://www.mongodb.com/community/forums/tag/java>`_.
+To learn what fellow developers are asking about, experiencing or their
+interests in regards to the Java driver, see the `forums page
+<https://www.mongodb.com/community/forums/tag/java>`__.
 
 MongoDB University
 ~~~~~~~~~~~~~~~~~~
 
-MongoDB University contains free courses to inspire and educate everyone
-to learn MongoDB. It has the best-in-class training and empowers
-everyone to be successful.
+MongoDB University provides free courses to teach everyone how to use
+MongoDB.
 
 Take the free online course taught by MongoDB
 `````````````````````````````````````````````

--- a/source/index.txt
+++ b/source/index.txt
@@ -46,9 +46,8 @@ methods.
 Fundamentals
 ------------
 
-The Fundamentals section is where you can find coverage on how to
-perform operations in the Java driver. This section contains 
-learning material to perform the following tasks:
+The Fundamentals section explains how to perform the following tasks
+using the Java driver:
 
 - :doc:`Connect to MongoDB </fundamentals/connection>`
 - :doc:`Use the Versioned API </fundamentals/versioned-api>`
@@ -68,8 +67,8 @@ learning material to perform the following tasks:
 API Documentation
 -----------------
 
-The MongoDB Java driver API documentation is split into several sections.
-Each section has detailed technical information about classes, methods, and
+The MongoDB Java driver API documentation is split into several libraries.
+Each library has detailed technical information about classes, methods, and
 configuration objects within the MongoDB Java driver:
 
 .. list-table::
@@ -77,20 +76,20 @@ configuration objects within the MongoDB Java driver:
    :stub-columns: 1
    :widths: 35 65
 
-   * - Section
+   * - Library
      - Description
 
    * - `BSON <{+api+}/apidocs/bson/index.html>`__ 
-     - Contains the base BSON classes
+     - Base BSON classes
    
    * - `Core <{+api+}/apidocs/mongodb-driver-core/index.html>`__ 
-     - Contains the shared core classes
+     - Shared core classes
    
    * - `Java Driver <{+api+}/apidocs/mongodb-driver-sync/index.html>`__ 
-     - Contains the modern API
+     - Modern API
 
    * - `Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ 
-     - Contains the legacy API
+     - Legacy API
 
 FAQ
 ---
@@ -132,9 +131,8 @@ developers.
 To learn how to use MongoDB features with the Java driver, see the `How
 To's and Articles page <https://www.mongodb.com/developer/learn/?content=Articles&text=java#main>`__.
 
-To learn what fellow developers are asking about, experiencing or their
-interests in regards to the Java driver, see the `forums page
-<https://www.mongodb.com/community/forums/tag/java>`__.
+To ask questions and engage in discussion with fellow developers using
+the Java Driver, see the `forums page <https://www.mongodb.com/community/forums/tag/java>`__.
 
 MongoDB University
 ~~~~~~~~~~~~~~~~~~
@@ -142,8 +140,8 @@ MongoDB University
 MongoDB University provides free courses to teach everyone how to use
 MongoDB.
 
-Take the free online course taught by MongoDB
-`````````````````````````````````````````````
+Take the free online course taught by MongoDB instructors
+`````````````````````````````````````````````````````````
 
 .. list-table::
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -27,7 +27,7 @@ processing and reactive streams, we recommend the `Reactive Streams Driver
 
 The official MongoDB Java driver lets you connect your Java applications
 to MongoDB and work with your data. On this page, you can find descriptions of
-each section of the driver documentation.
+each section of the driver documentation and where to go for more resources.
 
 Quick Start
 -----------
@@ -66,9 +66,14 @@ core operations. This section contains information on how to:
 API Documentation
 -----------------
 
-The `API documentation <{+api+}/apidocs/mongodb-driver-sync/>`__
-has detailed technical information about classes, methods, and
-configuration objects within the MongoDB Java driver.
+The MongoDB Java driver API documentation is split into several parts.
+Each part has detailed technical information about classes, methods, and
+configuration objects within the MongoDB Java driver:
+
+- `BSON <{+api+}/apidocs/bson/index.html>`__ (The BSON Layer)
+- `Core <{+api+}/apidocs/mongodb-driver-core/index.html>`__ (The Shared Core Classes)
+- `Java Driver <{+api+}/apidocs/mongodb-driver-sync/index.html>`__ (Modern API)
+- `Java Driver <{+api+}/apidocs/mongodb-driver-legacy/index.html>`__ (Legacy API)
 
 FAQ
 ---
@@ -95,11 +100,33 @@ What's New
 The :doc:`What's New </whats-new>` section lists new features and
 changes in each version.
 
-Additional Learning
--------------------
+Resources
+---------
+
+Visit the Developer Hub and MongoDB University for resources related to
+the MongoDB Java driver.
+
+Developer Hub
+~~~~~~~~~~~~~
+
+The Developer Hub contains content, resources, community, and social
+engagement for developers.
+
+To view articles on Java, see the `How To's and Articles page
+<https://www.mongodb.com/developer/learn/?content=Articles&text=Java>`_.
+
+To view the forum on Java, see the `forums page
+<https://www.mongodb.com/community/forums/tag/java>`_.
+
+MongoDB University
+~~~~~~~~~~~~~~~~~~
+
+MongoDB University contains free courses to inspire and educate everyone
+to learn MongoDB. It has the best-in-class training and empowers
+everyone to be successful.
 
 Take the free online course taught by MongoDB
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`````````````````````````````````````````````
 
 .. list-table::
 


### PR DESCRIPTION
## Pull Request Info

Improved each landing page section by:
- adding each section of the API documentation
- putting the learning material + forums at the bottom of the page

Note: The leafy guy wasn't used since the visual design team asked us not to.

Also, I updated the fundamentals drawers page (to the landing page's fundamentals section) since I forgot to in my previous PR.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18552

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6143a97ac608bec57fdfcdb0

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18552-PageSectionsImprovements/

https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18552-PageSectionsImprovements/fundamentals/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
