### PR TITLE
DOCSP-18841: fix broken links

### DIFF
--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -282,7 +282,7 @@ further refine the ordering and matching behavior.
        | `collationMaxVariable() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Collation.Builder.html#collationMaxVariable(com.mongodb.client.model.CollationMaxVariable)>`__ API Documentation
 
    * - Strength
-     - | ICU level of comparison. The default value is "tertiary". For more information on each level, see the `ICU Comparison Levels <https://unicode-org.github.io/icu/userguide/collation/concepts.htmll#comparison-levels>`__.
+     - | ICU level of comparison. The default value is "tertiary". For more information on each level, see the `ICU Comparison Levels <https://unicode-org.github.io/icu/userguide/collation/concepts.html#comparison-levels>`__.
        | `collationStrength() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Collation.Builder.html#collationStrength(com.mongodb.client.model.CollationStrength)>`__ API Documentation
 
    * - Normalization

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -96,9 +96,9 @@ mechanism:
       .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi.rst
 
 
-In order to acquire a 
+In order to acquire a
 `Kerberos ticket <https://docs.oracle.com/en/java/javase/11/docs/api/java.security.jgss/javax/security/auth/kerberos/KerberosTicket.html>`__,
-the GSSAPI Java libraries require you to specify the realm and Key Distribution 
+the GSSAPI Java libraries require you to specify the realm and Key Distribution
 Center (KDC) system properties. See the sample settings in the following example:
 
 .. code-block:: none
@@ -171,11 +171,11 @@ You may need to specify one or more of the following additional
 
          .. tab::
             :tabid: JAVA_SUBJECT_KEY
-      
+
             .. include:: /includes/fundamentals/code-snippets/auth-credentials-gssapi-subject-key.rst
 
 By default, the Java driver caches Kerberos tickets by ``MongoClient`` instance.
-If your deployment needs to frequently create and destroy ``MongoClient`` instances, 
+If your deployment needs to frequently create and destroy ``MongoClient`` instances,
 you can change the default Kerberos ticket caching behavior to cache by process
 to improve performance.
 
@@ -194,7 +194,7 @@ to improve performance.
       :tabid: MongoCredential
 
       To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
-      mechanism property and provide a 
+      mechanism property and provide a
       `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
       in your ``MongoCredential`` instance. The code to configure the Java driver to cache Kerberos tickets
       by process should resemble the following:
@@ -204,8 +204,8 @@ to improve performance.
 
 .. note::
 
-   On Windows, Oracle’s JRE uses `LSA <https://msdn.microsoft.com/en-us/library/windows/desktop/aa378326.aspx>`__
-   rather than `SSPI <https://msdn.microsoft.com/en-us/library/windows/desktop/aa380493.aspx>`__
+   On Windows, Oracle’s JRE uses `LSA <https://docs.microsoft.com/en-us/windows/win32/secauthn/lsa-authentication>`__
+   rather than `SSPI <https://docs.microsoft.com/en-us/windows/win32/secauthn/sspi>`__
    in its implementation of GSSAPI which limits interoperability with
    Windows Active Directory and implementations of single sign-on. See the
    following articles for more information:
@@ -262,7 +262,7 @@ mechanism:
 
          If you specify the ``PLAIN`` mechanism, you cannot assign
          ``authSource`` to any value other than ``$external``.
-         
+
       Your code to instantiate a ``MongoClient`` should look something like this:
 
       .. code-block:: java

--- a/source/fundamentals/enterprise-auth.txt
+++ b/source/fundamentals/enterprise-auth.txt
@@ -195,7 +195,7 @@ to improve performance.
 
       To cache Kerberos tickets by process, you must specify the ``JAVA_SUBJECT_PROVIDER``
       mechanism property and provide a
-      `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2//apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
+      `KerberosSubjectProvider <https://mongodb.github.io/mongo-java-driver/4.2/apidocs/mongodb-driver-core/com/mongodb/KerberosSubjectProvider.html#%3Cinit%3E()>`__
       in your ``MongoCredential`` instance. The code to configure the Java driver to cache Kerberos tickets
       by process should resemble the following:
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18841

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6151fd108670bd2731065d4e

### Docs staging link (requires sign-in on MongoDB Corp SSO):


[Collation Options](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18841-fixlinks/fundamentals/collations/#collation-options)

[Enterprise Auth](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18841-fixlinks/fundamentals/enterprise-auth/)


### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
