### PR TITLE
DOCSP-18917 added minPoolSize

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -298,9 +298,15 @@ parameters of the connection URI to specify the behavior of the client.
      - Type
      - Description
 
+   * - **minPoolSize**
+     - integer
+     - Specifies the minimum number of connections that must exist at
+       any moment in a single connection pool.
+
    * - **maxPoolSize**
      - integer
-     - Specifies the maximum size of the connection pool.
+     - Specifies the maximum number of connections that a connection
+       pool may have at a given time.
 
    * - **waitQueueTimeoutMS**
      - integer


### PR DESCRIPTION
## Pull Request Info

Added the `minPoolSize` connection option and updated the description for `maxPoolSize`.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18917

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6160be268670bd2731adf692

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-18917-addingMinPoolSize/fundamentals/connection/#connection-options

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
