### PR TITLE
DOCSP-19214: fix rst formatting on cursor page

### DIFF
--- a/source/fundamentals/crud/read-operations/cursor.txt
+++ b/source/fundamentals/crud/read-operations/cursor.txt
@@ -14,7 +14,7 @@ Overview
 --------
 
 In this guide, you can learn how to access data using a **cursor** with the
-MongoDB Java driver. 
+MongoDB Java driver.
 
 A cursor is a mechanism that allows an application to iterate over database
 results while only holding a subset of them in memory at a given time. The
@@ -23,7 +23,7 @@ matched documents in batches as opposed to returning them all at once.
 
 This page uses an initiating method, ``find()`` to show how to access
 data from a `FindIterable
-<{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>`__. 
+<{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/FindIterable.html>`__.
 
 .. note::
 
@@ -41,13 +41,13 @@ Terminal Methods
 
 Terminal methods execute an operation on the MongoDB server after
 configuring all parameters of an ``Iterable`` instance controlling the
-operation. 
+operation.
 
 First
 ~~~~~
 
 Use the ``first()`` method to retrieve the first document in your query
-results: 
+results:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/Cursor.java
    :language: java
@@ -56,21 +56,21 @@ results:
    :end-before: end firstExample
 
 This method is often used when your query filter will match one
-document, such as when filtering by a unique index. 
+document, such as when filtering by a unique index.
 
 Into
 ~~~~
 
-Use the ``into()`` method to store your query results in a ``List``: 
+Use the ``into()`` method to store your query results in a ``List``:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/Cursor.java
    :language: java
    :dedent:
    :start-after: begin intoExample
    :end-before: end intoExample
-   
+
 This method is often used when your query filter returns a small number
-of documents that can fit into available memory. 
+of documents that can fit into available memory.
 
 Cursor
 ~~~~~~
@@ -80,7 +80,7 @@ ensure that the cursor closes if there is an early termination:
 
 .. code-block:: java
    :copyable: true
-   
+
    MongoCursor<Document> cursor = collection.find().cursor();
 
 For more information on how to ensure a cursor closes, see the :ref:`cursor cleanup section <cursor_cleanup>`.
@@ -89,17 +89,17 @@ Explain
 ~~~~~~~
 
 Use the ``explain()`` method to view information about how MongoDB
-executes your operation. 
+executes your operation.
 
 The ``explain()`` method returns **execution plans** and performance
 statistics. An execution plan is a potential way MongoDB
 can complete an operation. The ``explain()`` method provides both the
-winning plan (the plan MongoDB executed) and rejected plans. 
+winning plan (the plan MongoDB executed) and rejected plans.
 
 .. include:: /includes/fundamentals/explain-verbosity.rst
 
 The following example prints the JSON representation of the
-winning plan for aggregation stages that produce execution plans: 
+winning plan for aggregation stages that produce execution plans:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/Cursor.java
    :language: java
@@ -115,9 +115,9 @@ The preceding code snippet should produce the following output:
    { "stage": "COLLSCAN", "direction": "forward" }
 
 For more information on the explain operation, see the following
-Server Manual Entries: 
+Server Manual Entries:
 
-- :manual:`Explain Output </reference/explain-results/>` 
+- :manual:`Explain Output </reference/explain-results/>`
 - :manual:`Query Plans </core/query-plans/>`
 
 For more information about the methods and classes mentioned in this section,
@@ -133,13 +133,13 @@ Usage Patterns
 --------------
 
 A ``MongoCursor`` and ``FindIterable`` allow you to access query results
-one document at a time, abstracting away network and caching logic. 
+one document at a time, abstracting away network and caching logic.
 
 Functional Iteration
 ~~~~~~~~~~~~~~~~~~~~~
 
 Pass a function to the ``forEach()`` method of a ``FindIterable`` to
-iterate through results in a functional style: 
+iterate through results in a functional style:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/Cursor.java
    :language: java
@@ -151,7 +151,7 @@ iterate through results in a functional style:
 
    Initiating methods return objects that implement the ``Iterable`` interface which allows you
    to iterate through them using iterator methods. Sometimes, we use an enhanced
-   for-each loop to iterate through results: 
+   for-each loop to iterate through results:
 
    .. code-block:: java
 
@@ -167,7 +167,7 @@ iterate through results in a functional style:
 Conditional Iteration
 ~~~~~~~~~~~~~~~~~~~~~
 
-Use the ``hasNext() `` method to check if there are any documents
+Use the ``hasNext()`` method to check if there are any documents
 available in the cursor, and then use the ``next()`` method to retrieve
 the next available document from the cursor:
 
@@ -180,7 +180,7 @@ the next available document from the cursor:
 For more information about the methods and classes mentioned in this section,
 see the following API Documentation:
 
-- `forEach() <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Iterable.html?is-external=true#forEach(java.util.function.Consumer)>`__ 
+- `forEach() <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Iterable.html?is-external=true#forEach(java.util.function.Consumer)>`__
 - `hasNext() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCursor.html#hasNext()>`__
 - `next() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCursor.html#next()>`__
 
@@ -201,7 +201,7 @@ server:
    :dedent:
    :start-after: begin closeExample
    :end-before: end closeExample
-   
+
 Try with Resources Statement
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info

See line 170 for the change (all other changes are removal of trailing whitespace).

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19214

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6172d0c0c13055282d05cf2f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-19214-cursor-fix-rst/fundamentals/crud/read-operations/cursor/#conditional-iteration

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
