### PR TITLE
DOCSP-19171: max hosts setting

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "java"
-title = "Java"
+title = "Java Sync"
 toc_landing_pages = [
     "/fundamentals/connection",
     "/fundamentals/crud",

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -52,7 +52,7 @@ settings to modify the driver's behavior:
    * - ``addCommandListener()``
      - Adds a listener for :ref:`command events <command-events-java>`.
 
-   * - ``applicationName​()``
+   * - ``applicationName()``
      - Sets the logical name of the application using the ``MongoClient``.
 
    * - ``applyConnectionString()``
@@ -97,7 +97,7 @@ settings to modify the driver's behavior:
    * - ``credential()``
      - Sets the :ref:`credential <authentication-mechanisms-java>`.
 
-   * - ``readConcern​()``
+   * - ``readConcern()``
      - Sets the :manual:`read concern </reference/read-concern/>`.
 
    * - ``readPreference()``
@@ -106,10 +106,10 @@ settings to modify the driver's behavior:
    * - ``retryReads()``
      - Whether the driver should :manual:`retry reads </core/retryable-reads/>` if a network error occurs.
 
-   * - ``retryWrites​()``
+   * - ``retryWrites()``
      - Whether the driver should :manual:`retry writes </core/retryable-writes/>` if a network error occurs.
 
-   * - ``serverApi​()``
+   * - ``serverApi()``
      - Sets the :ref:`server API <versioned-api-java>` to use when sending commands to the server.
 
    * - ``streamFactoryFactory()``
@@ -118,7 +118,7 @@ settings to modify the driver's behavior:
    * - ``uuidRepresentation()``
      - Sets the UUID representation to use when encoding instances of UUID and decoding BSON binary values with subtype of 3.
 
-   * - ``writeConcern​()``
+   * - ``writeConcern()``
      - Sets the :manual:`write concern </reference/write-concern/>`.
 
 .. _connection-string-example:
@@ -186,22 +186,22 @@ settings to modify the driver's behavior:
    * - Method
      - Description
 
-   * - ``addClusterListener​()``
+   * - ``addClusterListener()``
      - Adds a listener for cluster-related events.
 
-   * - ``applyConnectionString​()``
+   * - ``applyConnectionString()``
      - Uses the settings from a ``ConnectionString`` object.
 
    * - ``applySettings()``
      - Uses the cluster settings specified in a ``ClusterSettings`` object.
 
-   * - ``hosts​()``
+   * - ``hosts()``
      - Sets all the specified locations of a Mongo server.
 
    * - ``localThreshold()``
      - Sets the amount of time that a server’s round trip can take and still be eligible for server selection.
 
-   * - ``mode​()``
+   * - ``mode()``
      - Sets how to connect to a MongoDB server.
 
    * - ``requiredClusterType()``
@@ -234,6 +234,13 @@ settings to modify the driver's behavior:
              MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()
                    .applyConnectionString(new ConnectionString("mongodb+srv://host1.acme.com")))
+
+   * - ``srvMaxHosts()``
+     - | Sets the maximum number of hosts the driver can connect to when using 
+         the DNS seedlist (SRV) connection protocol, identified by the 
+         ``mongodb+srv`` connection string prefix. 
+       |
+       | Throws an exception if you are not using the SRV connection protocol.
 
 Example
 ~~~~~~~
@@ -273,7 +280,7 @@ settings to modify the driver's behavior:
    * - Method
      - Description
 
-   * - ``applyConnectionString​()``
+   * - ``applyConnectionString()``
      - Uses the settings from a ``ConnectionString`` object.
 
    * - ``applySettings()``
@@ -312,7 +319,7 @@ Connection Pool Settings
 ------------------------
 
 Chain the `applyToConnectionPoolSettings() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html#applyToConnectionPoolSettings(com.mongodb.Block)>`__
-method to modify the way the driver manages its' connection pool.
+method to modify the way the driver manages its connection pool.
 
 The following table describes all the methods you can chain to your
 settings to modify the driver's behavior:
@@ -324,10 +331,10 @@ settings to modify the driver's behavior:
    * - Method
      - Description
 
-   * - ``addConnectionPoolListener​()``
+   * - ``addConnectionPoolListener()``
      - Adds a listener for connection pool-related events.
 
-   * - ``applyConnectionString​()``
+   * - ``applyConnectionString()``
      - Uses the settings from a ``ConnectionString`` object.
 
    * - ``applySettings()``
@@ -354,12 +361,6 @@ settings to modify the driver's behavior:
    * - ``minSize()``
      - Sets the minimum amount of connections associated with a connection pool.
 
-   * - ``srvMaxHosts()``
-     - | Sets the maximum number of hosts the driver can connect to when using 
-         the DNS seedlist (SRV) connection protocol, identified by the 
-         ``mongodb+srv`` connection string prefix. 
-       |
-       | Throws an exception if you are not using the SRV connection protocol.
 
 .. note::
 
@@ -408,10 +409,10 @@ settings to modify the driver's behavior:
    * - ``addServerListener()``
      - Adds a listener for server-related events.
 
-   * - ``addServerMonitorListener​()``
+   * - ``addServerMonitorListener()``
      - Adds a listener for server monitor-related events.
 
-   * - ``applyConnectionString​()``
+   * - ``applyConnectionString()``
      - Uses the settings from a ``ConnectionString`` object.
 
    * - ``applySettings()``
@@ -457,7 +458,7 @@ settings to modify the driver's behavior:
    * - Method
      - Description
 
-   * - ``applyConnectionString​()``
+   * - ``applyConnectionString()``
      - Uses the settings from a ``ConnectionString`` object.
 
    * - ``applySettings()``

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -355,10 +355,11 @@ settings to modify the driver's behavior:
      - Sets the minimum amount of connections associated with a connection pool.
 
    * - ``srvMaxHosts()``
-     - Sets the maximum number of connections the driver maintains to
-       ``mongos`` servers when using the DNS seedlist (SRV) connection
-       protocol, identified by the ``mongodb+srv`` connection string prefix.
-       Throws an exception if you are not using the SRV connection protocol.
+     - | Sets the maximum number of hosts the driver can connect to when using 
+         the DNS seedlist (SRV) connection protocol, identified by the 
+         ``mongodb+srv`` connection string prefix. 
+       |
+       | Throws an exception if you are not using the SRV connection protocol.
 
 .. note::
 

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -29,7 +29,7 @@ The following sections describe commonly used settings:
 MongoClient Settings
 --------------------
 
-You can control the behavior of your ``MongoClient`` by creating and passing in a 
+You can control the behavior of your ``MongoClient`` by creating and passing in a
 `MongoClientSettings <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html>`__
 object to the `MongoClients.create() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoClients.html#create(com.mongodb.MongoClientSettings)>`__
 method.
@@ -74,7 +74,7 @@ settings to modify the driver's behavior:
      - Applies the ``SslSettings.Builder`` block and then sets the :ref:`TLS/SSL settings <mcs-ssl-settings>`.
 
    * - ``autoEncryptionSettings()``
-     - | Sets the :ref:`auto-encryption settings <auto-encryption-decryption-java>`. 
+     - | Sets the :ref:`auto-encryption settings <auto-encryption-decryption-java>`.
        |
        | If you omit ``keyVaultClient`` or set
        | ``bypassAutomaticEncryption`` to false in your
@@ -218,19 +218,19 @@ settings to modify the driver's behavior:
 
    * - ``srvHost()``
      - Sets the host name to use to look up an SRV DNS record to find the MongoDB hosts.
-     
+
        .. note::
-        
+
           When setting ``srvHost``, the driver does not process any
-          associated TXT records associated with the host. 
+          associated TXT records associated with the host.
 
           If you want to enable the processing of TXT records, you must
-          specify the SRV host in the connection string using the 
+          specify the SRV host in the connection string using the
           ``applyConnectionString()`` method.
 
           .. code-block:: java
              :emphasize-lines: 3
-        
+
              MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()
                    .applyConnectionString(new ConnectionString("mongodb+srv://host1.acme.com")))
@@ -354,6 +354,12 @@ settings to modify the driver's behavior:
    * - ``minSize()``
      - Sets the minimum amount of connections associated with a connection pool.
 
+   * - ``srvMaxHosts()``
+     - Sets the maximum number of connections the driver maintains to
+       ``mongos`` servers when using the DNS seedlist (SRV) connection
+       protocol, identified by the ``mongodb+srv`` connection string prefix.
+       Throws an exception if you are not using the SRV connection protocol.
+
 .. note::
 
    This ``maxSize`` and ``minSize`` settings apply to each server
@@ -421,7 +427,7 @@ Example
 
 This example specifies the following driver behavior in a MongoDB server:
 
-- The minimum interval for server monitoring checks to be at least ``700 MILLISECONDS`` 
+- The minimum interval for server monitoring checks to be at least ``700 MILLISECONDS``
 - The cluster monitor to attempt reaching a server every ``15 SECONDS``
 
 .. literalinclude:: /includes/fundamentals/code-snippets/mcs.java


### PR DESCRIPTION
## Pull Request Info

Changes of note:
- Renamed Java -> Java Sync in snooty.toml for proper breadcrumb display (differentiate it from Java RS)
- Added setting (ticket task) [srvMaxHosts](https://github.com/mongodb/docs-java/pull/174/files#diff-b33e95fb0e2b3cd27f170a41ded73770cdd15a0beabcaa7cfc938e7827b8f1ebR238-R244)
- Removed zero-width space characters and trailing spaces in source/fundamentals/connection/mongoclientsettings.txt 
- Removed stray single-quotation mark https://github.com/mongodb/docs-java/pull/174/files#diff-b33e95fb0e2b3cd27f170a41ded73770cdd15a0beabcaa7cfc938e7827b8f1ebL315

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19171

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6181b2acc13055282d15a5cc

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-19171-mongos-max-hosts/fundamentals/connection/mongoclientsettings/#cluster-settings

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
