### PR TITLE
Docsp 17234

### DIFF
--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -66,43 +66,6 @@ using a method in the ``MongoClientSettings.Builder`` class.
                 .build();
          MongoClient client = MongoClients.create(settings);
 
-Configure Netty
-~~~~~~~~~~~~~~~
-
-If you use the driver with `Netty <https://netty.io/>`__ for network IO,
-you have an option to plug an alternative TLS/SSL protocol implementation
-provided by Netty.
-
-.. code-block:: java
-   :copyable: true
-
-   import com.mongodb.MongoClientSettings;
-   import com.mongodb.client.MongoClients;
-   import com.mongodb.client.MongoClient;
-   import com.mongodb.connection.netty.NettyStreamFactoryFactory;
-   import io.netty.handler.ssl.SslContext;
-   import io.netty.handler.ssl.SslContextBuilder;
-   import io.netty.handler.ssl.SslProvider;
-
-To instruct the driver to use `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__,
-use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/apidocs/mongodb-driver-core/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
-method. See the method documentation for details on which `io.netty.handler.ssl.SslProviders <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
-the driver supports and the implications of using them.
-
-.. code-block:: java
-   :copyable: true
-
-   SslContext sslContext = SslContextBuilder.forClient()
-           .sslProvider(SslProvider.OPENSSL)
-           .build();
-   MongoClientSettings settings = MongoClientSettings.builder()
-           .applyToSslSettings(builder -> builder.enabled(true))
-           .streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                   .sslContext(sslContext)
-                   .build())
-           .build();
-   MongoClient client = MongoClients.create(settings);
-
 .. _tls_configure-certificates:
 
 Configure Certificates
@@ -254,13 +217,13 @@ To restrict your application to use only the TLS 1.2 protocol, set the
 
 .. _tls-custom-sslContext:
 
-Customize TLS/SSL Configuration with an SSLContext
---------------------------------------------------
+Customize TLS/SSL Configuration through the Java SE SSLContext
+--------------------------------------------------------------
 
 If your TLS/SSL configuration requires additional customization, you can
 set the ``sslContext`` property of your ``MongoClient`` by
 passing an `SSLContext
-<https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/class-use/SSLContext.html>`__
+<https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html>`__
 object to the builder in the ``applyToSslSettings()`` lambda:
 
 .. code-block:: java
@@ -273,6 +236,44 @@ object to the builder in the ``applyToSslSettings()`` lambda:
                 })
         .build();
    MongoClient client = MongoClients.create(settings);
+
+Customize TLS/SSL Configuration through the Netty SSLContext
+------------------------------------------------------------
+
+If you use the driver with `Netty <https://netty.io/>`__ for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation
+provided by Netty.
+
+.. code-block:: java
+   :copyable: true
+
+   import com.mongodb.MongoClientSettings;
+   import com.mongodb.client.MongoClients;
+   import com.mongodb.client.MongoClient;
+   import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+   import io.netty.handler.ssl.SslContext;
+   import io.netty.handler.ssl.SslContextBuilder;
+   import io.netty.handler.ssl.SslProvider;
+
+To instruct the driver to use `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__,
+use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/apidocs/mongodb-driver-core/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
+method. See the method documentation for details about the different `io.netty.handler.ssl.SslProvider <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
+variants the driver supports and the implications of using them.
+
+.. code-block:: java
+   :copyable: true
+
+   SslContext sslContext = SslContextBuilder.forClient()
+           .sslProvider(SslProvider.OPENSSL)
+           .build();
+   MongoClientSettings settings = MongoClientSettings.builder()
+           .applyToSslSettings(builder -> builder.enabled(true))
+           .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+                   .sslContext(sslContext)
+                   .build())
+           .build();
+   MongoClient client = MongoClients.create(settings);
+
 
 Online Certificate Status Protocol (OCSP)
 -----------------------------------------

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -74,7 +74,7 @@ you have an option to plug an alternative TLS/SSL protocol implementation
 provided by Netty.
 
 .. code-block:: java
-   :copyable: True
+   :copyable: true
 
    import com.mongodb.MongoClientSettings;
    import com.mongodb.client.MongoClients;
@@ -86,11 +86,11 @@ provided by Netty.
 
 To instruct the driver to use `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__,
 use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/apidocs/mongodb-driver-core/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
-method. See the documentation of this method for details on which `io.netty.handler.ssl.SslProviders <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
-the driver supports and implications of using them.
+method. See the method documentation for details on which `io.netty.handler.ssl.SslProviders <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
+the driver supports and the implications of using them.
 
 .. code-block:: java
-   :copyable: True
+   :copyable: true
 
    SslContext sslContext = SslContextBuilder.forClient()
            .sslProvider(SslProvider.OPENSSL)

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -66,6 +66,43 @@ using a method in the ``MongoClientSettings.Builder`` class.
                 .build();
          MongoClient client = MongoClients.create(settings);
 
+Configure Netty
+~~~~~~~~~~~~~~~
+
+If you use the driver with `Netty <https://netty.io/>`__ for network IO,
+you have an option to plug an alternative TLS/SSL protocol implementation
+provided by Netty.
+
+.. code-block:: java
+   :copyable: True
+
+   import com.mongodb.MongoClientSettings;
+   import com.mongodb.client.MongoClients;
+   import com.mongodb.client.MongoClient;
+   import com.mongodb.connection.netty.NettyStreamFactoryFactory;
+   import io.netty.handler.ssl.SslContext;
+   import io.netty.handler.ssl.SslContextBuilder;
+   import io.netty.handler.ssl.SslProvider;
+
+To instruct the driver to use `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__,
+use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
+method. See the documentation of this method for details on which `io.netty.handler.ssl.SslProviders <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
+the driver supports and implications of using them.
+
+.. code-block:: java
+   :copyable: True
+
+   SslContext sslContext = SslContextBuilder.forClient()
+           .sslProvider(SslProvider.OPENSSL)
+           .build();
+   MongoClientSettings settings = MongoClientSettings.builder()
+           .applyToSslSettings(builder -> builder.enabled(true))
+           .streamFactoryFactory(NettyStreamFactoryFactory.builder()
+                   .sslContext(sslContext)
+                   .build())
+           .build();
+   MongoClient client = MongoClients.create(settings);
+
 .. _tls_configure-certificates:
 
 Configure Certificates

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -85,7 +85,7 @@ provided by Netty.
    import io.netty.handler.ssl.SslProvider;
 
 To instruct the driver to use `io.netty.handler.ssl.SslContext <https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html>`__,
-use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
+use the `NettyStreamFactoryFactory.Builder.sslContext <{+api+}/apidocs/mongodb-driver-core/com/mongodb/connection/netty/NettyStreamFactoryFactory.Builder.html#sslContext(io.netty.handler.ssl.SslContext)>`__
 method. See the documentation of this method for details on which `io.netty.handler.ssl.SslProviders <https://netty.io/4.1/api/io/netty/handler/ssl/SslProvider.html>`__
 the driver supports and implications of using them.
 

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -237,7 +237,7 @@ object to the builder in the ``applyToSslSettings()`` lambda:
         .build();
    MongoClient client = MongoClients.create(settings);
 
-Customize TLS/SSL Configuration through the Netty SSLContext
+Customize TLS/SSL Configuration through the Netty SslContext
 ------------------------------------------------------------
 
 If you use the driver with `Netty <https://netty.io/>`__ for network IO,


### PR DESCRIPTION
## Pull Request Info
This documents how to use Netty for TLS/SSL. 🔥 The API docs link will not work on master as the 4.4 API docs aren't published, but it will work on 4.3.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17234

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6184028fc13055282dab7e2d

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-17234/fundamentals/connection/tls/#configure-netty

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
