### PR TITLE
DOCSP-19656: remove release notes link

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -16,7 +16,6 @@ MongoDB Java Driver
    /issues-and-help
    /compatibility
    /whats-new
-   Release Notes <https://github.com/mongodb/mongo-java-driver/releases>
    View the Source <https://github.com/mongodb/mongo-java-driver>
 
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19656

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=619c2f085314b0809fe4fe21

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-19656-remove-release-notes/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
