### PR TITLE
remove beta tag

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -9,6 +9,6 @@ toc_landing_pages = [
 
 [constants]
 version = 4.4
-full-version = "{+version+}.0-beta2"
+full-version = "{+version+}.0"
 package-name-org = "mongodb-org"
 api = "https://mongodb.github.io/mongo-java-driver/{+version+}"


### PR DESCRIPTION
## Pull Request Info

I forgot to remove the `beta` tag from the `full-version` constant when 4.4 was released.

### Issue JIRA link:
n/a

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=619d1b405314b0809f1a7ad9

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/nl-remove-beta-tag/quick-start/#add-mongodb-as-a-dependency

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
