### PR TITLE
update recommended log4j version

### DIFF
--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -170,7 +170,7 @@ tab corresponding to the logging framework you would like to use in your project
                <dependency>
                  <groupId>org.apache.logging.log4j</groupId>
                  <artifactId>log4j-slf4j-impl</artifactId>
-                 <version>2.14.1</version>
+                 <version>2.15.0</version>
                </dependency>
 
          .. tab:: Gradle
@@ -181,7 +181,7 @@ tab corresponding to the logging framework you would like to use in your project
             .. code-block:: none
    
                dependencies {
-                  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+                  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.15.0'
                }
     
       Once you have included the preceding dependency, log an error using the


### PR DESCRIPTION
## Pull Request Info

Update version of log4j recommended in the docs to a version patched for https://nvd.nist.gov/vuln/detail/CVE-2021-44228

Recommended this version: https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl/2.15.0

### Issue JIRA link:
None

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61b38133c52f2a460f5c11df

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/java/docsworker-xlarge/NNNNNNNNNNN/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
