### PR TITLE
update log4j to 2.17.1

### DIFF
--- a/source/fundamentals/logging.txt
+++ b/source/fundamentals/logging.txt
@@ -170,7 +170,7 @@ tab corresponding to the logging framework you would like to use in your project
                <dependency>
                  <groupId>org.apache.logging.log4j</groupId>
                  <artifactId>log4j-slf4j-impl</artifactId>
-                 <version>2.17.0</version>
+                 <version>2.17.1</version>
                </dependency>
 
          .. tab:: Gradle
@@ -181,7 +181,7 @@ tab corresponding to the logging framework you would like to use in your project
             .. code-block:: none
    
                dependencies {
-                  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.0'
+                  implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
                }
     
       Once you have included the preceding dependency, log an error using the


### PR DESCRIPTION
## Pull Request Info

Fix version for https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHELOGGINGLOG4J-2327339

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61d46d6241accb3633a9bd6f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/010421-log4j-update/fundamentals/logging/#example---set-up

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [ ] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
