### PR TITLE
Docsp 19628 slim

### DIFF
--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -1,4 +1,4 @@
-name: Checker
+name: Link Checker
 on: [push, pull_request]
 jobs:
   build:

--- a/.github/workflows/checker.yml
+++ b/.github/workflows/checker.yml
@@ -1,0 +1,22 @@
+name: Checker
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Check out source code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: Install checker tool
+        run: go install github.com/terakilobyte/checker@latest
+
+      - name: Run checker tool
+        run: git diff --name-only HEAD^..HEAD | tr "\n" "," | xargs checker --changes

--- a/snooty.toml
+++ b/snooty.toml
@@ -8,7 +8,7 @@ toc_landing_pages = [
 ]
 
 [constants]
-version = 4.4
+version = "4.4"
 full-version = "{+version+}.0"
 package-name-org = "mongodb-org"
 api = "https://mongodb.github.io/mongo-java-driver/{+version+}"

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -208,8 +208,8 @@ parameters of the connection URI to specify the behavior of the client.
 
    * - **maxConnecting**
      - integer
-     - Specifies the number of connections the driver concurrently
-       establishes before making them available in the connection pool.
+     - Specifies the number of connections the driver will driver concurrently
+       establish before making them available in the connection pool.
 
 For a complete list of options, see the
 `ConnectionString <{+api+}/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html>`__

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -180,9 +180,9 @@ parameters of the connection URI to specify the behavior of the client.
    * - **zlibCompressionLevel**
      - integer
      - Specifies the degree of compression that `Zlib <https://zlib.net/>`__
-       should use to decrease the size of requests to the connected MongoDB 
-       instance. The level can range from ``-1`` to ``9``, with lower values 
-       compressing faster (but resulting in larger requests) and larger values 
+       should use to decrease the size of requests to the connected MongoDB
+       instance. The level can range from ``-1`` to ``9``, with lower values
+       compressing faster (but resulting in larger requests) and larger values
        compressing slower (but resulting in smaller requests).
 
    * - **retryWrites**
@@ -205,6 +205,11 @@ parameters of the connection URI to specify the behavior of the client.
    * - **directConnection**
      - boolean
      - Specifies that the driver must connect to the host directly.
+   * - **maxConnecting**
+
+     - integer
+     - Specifies the number of connections the driver concurrently
+       establishes before making them available in the connection pool.
 
 For a complete list of options, see the
 `ConnectionString <{+api+}/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html>`__

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -205,8 +205,8 @@ parameters of the connection URI to specify the behavior of the client.
    * - **directConnection**
      - boolean
      - Specifies that the driver must connect to the host directly.
-   * - **maxConnecting**
 
+   * - **maxConnecting**
      - integer
      - Specifies the number of connections the driver concurrently
        establishes before making them available in the connection pool.


### PR DESCRIPTION
## Pull Request Info

Exposes `maxConnecting`. This has been split from the original PR since that content needs to be seen by more eyes since it is prescriptive in connection tuning.

It also adds in a checker with github actions.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19628

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61d71ae241accb36335bad85

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-19628-slim/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
