### PR TITLE
DOCSP-19966: fix pojo constructor and annotation description

### DIFF
--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -274,9 +274,9 @@ package:
 
    * - ``BsonCreator``
      - Marks a public constructor or a public static method as the creator for
-       new instances of the class. All parameters in the constructor must
-       be annotated with a ``BsonProperty``. You must use the annotation
-       values that you defined in the corresponding field declarations.
+       new instances of the class. You must annotate all parameters in the
+       constructor with ``BsonProperty`` with values that you defined in
+       the corresponding field declarations.
 
    * - ``BsonDiscriminator``
      - Specifies that a class uses a discriminator. You can set a custom
@@ -294,8 +294,8 @@ package:
 
    * - ``BsonProperty``
      - Specifies a custom document field name when converting the POJO
-       field to BSON. You can include a discriminator if you need one for
-       serializing nested POJOs.
+       field to BSON. You can include a discriminator to serialize POJOs
+       nested within the field.
 
 The following code snippet shows a sample POJO called ``Product`` that uses
 the preceding annotations.

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -274,8 +274,9 @@ package:
 
    * - ``BsonCreator``
      - Marks a public constructor or a public static method as the creator for
-       new instances of the class. You can combine this with the
-       ``BsonProperty`` annotation to link the parameters with properties.
+       new instances of the class. All parameters in the constructor must
+       be annotated with a ``BsonProperty``. You must use the annotation
+       values that you defined in the corresponding field declarations.
 
    * - ``BsonDiscriminator``
      - Specifies that a class uses a discriminator. You can set a custom
@@ -292,9 +293,9 @@ package:
        and/or deserialize a property.
 
    * - ``BsonProperty``
-     - Allows for an alternative document key name when converting the POJO
-       field to BSON. Also allows a field to turn on using a discriminator
-       when storing a POJO value.
+     - Specifies a custom document field name when converting the POJO
+       field to BSON. You can include a discriminator if you need one for
+       serializing nested POJOs.
 
 The following code snippet shows a sample POJO called ``Product`` that uses
 the preceding annotations.
@@ -325,7 +326,7 @@ the preceding annotations.
        private List<Product> relatedItems;
 
        @BsonCreator
-       public ProductPojo(@BsonProperty("modelName") String name) {
+       public Product(@BsonProperty("modelName") String name) {
            this.name = name;
        }
 
@@ -348,7 +349,7 @@ the preceding annotations.
 
 The annotations in the example POJO specify the following behavior:
 
-- Reference the POJO with the specified discriminator key and   value, adding
+- Reference the POJO with the specified discriminator key and value, adding
   the ``cls`` field with the value of "AnnotatedProduct" to the BSON document
   on write operations
 - Convert between the POJO ``name`` field and value and the BSON ``modelName``

--- a/source/includes/mongodb-compatibility-table-java.rst
+++ b/source/includes/mongodb-compatibility-table-java.rst
@@ -1,5 +1,3 @@
-.. include:: /includes/extracts/java-driver-compatibility-matrix-mongodb.rst
-
 .. list-table::
    :header-rows: 1
    :stub-columns: 1


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19966

Fixed constructor name and clarified annotation usage.

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61e70bcabcf82347e52b6b8d

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-19966-annotation-fix/fundamentals/data-formats/pojo-customization/#annotations

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
