### PR TITLE
Fix BSON version

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -10,7 +10,6 @@ toc_landing_pages = [
 [constants]
 version = "4.4"
 full-version = "{+version+}.2"
-bson-version = "{+full-version}"
 package-name-org = "mongodb-org"
 api = "https://mongodb.github.io/mongo-java-driver/{+version+}"
 stable-api = "Stable API"

--- a/source/includes/fundamentals/code-snippets/bson-gradle-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/bson-gradle-versioned.rst
@@ -1,6 +1,6 @@
 .. code-block:: groovy
 
    dependencies {
-      compile 'org.mongodb:bson:{+bson-version+}'
+      compile 'org.mongodb:bson:{+full-version+}'
    }
 

--- a/source/includes/fundamentals/code-snippets/bson-maven-versioned.rst
+++ b/source/includes/fundamentals/code-snippets/bson-maven-versioned.rst
@@ -4,7 +4,7 @@
        <dependency>
            <groupId>org.mongodb</groupId>
            <artifactId>bson</artifactId>
-           <version>{+bson-version+}</version>
+           <version>{+full-version+}</version>
        </dependency>
    </dependencies>
 


### PR DESCRIPTION
## Pull Request Info

BSON version hasn't been updated since 4.1. Confirmed the BSON library version should correspond to the sync/core driver.

### Issue JIRA link:
None

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62044920382d7fe4eeaf1337

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/020921-bson-version/fundamentals/data-formats/document-data-format-bson/#install-the-bson-library

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
