### PR TITLE
Unify-compat-table

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,13 +1,17 @@
 name = "java"
 title = "Java Sync"
+
 toc_landing_pages = [
     "/fundamentals/connection",
     "/fundamentals/crud",
     "/fundamentals/builders",
-    "/usage-examples"
+    "/usage-examples",
 ]
+sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 
 [constants]
+driver = "node"
+driver-long = "MongoDB Java Driver"
 version = "4.4"
 full-version = "{+version+}.2"
 package-name-org = "mongodb-org"

--- a/snooty.toml
+++ b/snooty.toml
@@ -10,7 +10,7 @@ toc_landing_pages = [
 sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 
 [constants]
-driver = "node"
+driver = "java"
 driver-long = "MongoDB Java Driver"
 version = "4.4"
 full-version = "{+version+}.2"

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -1,22 +1,32 @@
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+=============
 Compatibility
--------------
+=============
 
 MongoDB Compatibility
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
-The following compatibility table specifies the recommended versions of the
-MongoDB Java driver for use with a specific version of MongoDB.
+
+:ref:`What information does the MongoDB Compatibility table show? <mongodb-compatibility-table-about-node>`
 
 The first column lists the driver versions.
 
 .. include:: /includes/mongodb-compatibility-table-java.rst
 
 Language Compatibility
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
-The following compatibility table specifies the recommended versions of the
-MongoDB Java driver for use with a specific version of Java.
 
-The first column lists the driver versions.
+:ref:`What information does the Language Compatibility table show? <language-compatibility-table-about-node>`
 
 .. include:: /includes/language-compatibility-table-java.rst
+
+About Compatibility Tables
+--------------------------
+
+.. sharedinclude:: dbx/about-compatibility.rst

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -12,7 +12,7 @@ MongoDB Compatibility
 ---------------------
 
 
-:ref:`What information does the MongoDB Compatibility table show? <mongodb-compatibility-table-about-node>`
+:ref:`What information does the MongoDB Compatibility table show? <mongodb-compatibility-table-about-java>`
 
 The first column lists the driver versions.
 
@@ -22,7 +22,7 @@ Language Compatibility
 ----------------------
 
 
-:ref:`What information does the Language Compatibility table show? <language-compatibility-table-about-node>`
+:ref:`What information does the Language Compatibility table show? <language-compatibility-table-about-java>`
 
 .. include:: /includes/language-compatibility-table-java.rst
 

--- a/source/compatibility.txt
+++ b/source/compatibility.txt
@@ -11,16 +11,23 @@ Compatibility
 MongoDB Compatibility
 ---------------------
 
+The following compatibility table specifies the recommended version(s) of the
+{+driver-long+} for use with a specific version of MongoDB.
+
+The first column lists the driver version(s).
 
 :ref:`What information does the MongoDB Compatibility table show? <mongodb-compatibility-table-about-java>`
 
-The first column lists the driver versions.
 
 .. include:: /includes/mongodb-compatibility-table-java.rst
 
 Language Compatibility
 ----------------------
 
+The following compatibility table specifies the recommended version(s) of the
+{+driver-long+} for use with a specific version of Java.
+
+The first column lists the driver version(s).
 
 :ref:`What information does the Language Compatibility table show? <language-compatibility-table-about-java>`
 


### PR DESCRIPTION
## Pull Request Info

During a meeting it was noticed that the Java compat table page wasn't uniform with other pages.

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=620bcc83382d7fe4ee3c0565

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/unify-compat-table/compatibility/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
