### PR TITLE
add ref to java quickstart

### DIFF
--- a/source/quick-start.txt
+++ b/source/quick-start.txt
@@ -1,3 +1,5 @@
+.. _java-sync-quickstart:
+
 ===========
 Quick Start
 ===========


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=621d47d59c4c7f6bfb4d98b3

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/add-ref/quick-start/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
