### PR TITLE
(DOCSP-20825) Connection Defaults

### DIFF
--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -35,7 +35,7 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies the maximum amount of time, in milliseconds that a
        thread may wait for a connection to become available.
 
-       | **Default**: ``120000`` (2 minutes)
+       | **Default**: ``120000`` (120 seconds)
 
    * - **serverSelectionTimeoutMS**
      - integer
@@ -52,7 +52,7 @@ parameters of the connection URI to specify the behavior of the client.
        response time is less than or equal to the server with the fastest
        response time plus the local threshold, in milliseconds.
 
-       | **Default**: ``15`` (15 milliseconds)
+       | **Default**: ``15``
 
    * - **heartbeatFrequencyMS**
      - integer
@@ -118,8 +118,7 @@ parameters of the connection URI to specify the behavior of the client.
        A value of ``0`` instructs the driver to never time out while waiting
        to send or receive a request.
 
-       | **Default**: ``0`` (never times out)
-
+       | **Default**: ``0``
 
    * - **maxIdleTimeMS**
      - integer
@@ -128,8 +127,7 @@ parameters of the connection URI to specify the behavior of the client.
        connection. A value of ``0`` indicates that there is no upper bound
        on how long the driver can allow a pooled collection to be idle.
 
-       | **Default**: ``0`` (no limit)
-
+       | **Default**: ``0``
 
    * - **maxLifeTimeMS**
      - integer
@@ -138,7 +136,7 @@ parameters of the connection URI to specify the behavior of the client.
        connection. A value of ``0`` indicates that there is no upper bound
        on how long the driver can keep a pooled connection open.
 
-       | **Default**: ``0`` (no limit)
+       | **Default**: ``0``
 
    * - **journal**
      - boolean
@@ -162,8 +160,7 @@ parameters of the connection URI to specify the behavior of the client.
        :manual:`wtimeoutMS option </reference/connection-string/#write-concern-options>`.
        A value of ``0`` instructs the driver to never time out write operations.
 
-       | **Default**: ``0`` (never times out)
-
+       | **Default**: ``0``
 
    * - **readPreference**
      - string
@@ -184,14 +181,14 @@ parameters of the connection URI to specify the behavior of the client.
    * - **maxStalenessSeconds**
      - integer
      - Specifies, in seconds, how stale a secondary can be before the
-       driver stops communicating with that secondary. Not providing
-       a parameter or explicitly setting it to ``-1`` indicates that there
-       should be no staleness check for secondaries. The minimum value is
+       driver stops communicating with that secondary. The minimum value is
        either 90 seconds or the heartbeat frequency plus 10 seconds, whichever
        is greater. For more information, see the server documentation for the
        :manual:`maxStalenessSeconds option </reference/connection-string/#urioption.maxStalenessSeconds>`.
+       Not providing a parameter or explicitly specifying ``-1`` indicates
+       that there should be no staleness check for secondaries.
 
-       | **Default**: ``-1`` (no staleness check)
+       | **Default**: ``-1``
 
    * - **authMechanism**
      - string

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -119,7 +119,7 @@ parameters of the connection URI to specify the behavior of the client.
        A value of ``0`` instructs the driver to never time out while waiting
        to send or receive a request.
 
-       | **Default**: ``0``
+       | **Default**: ``0`` (never times out)
 
 
    * - **maxIdleTimeMS**
@@ -129,7 +129,7 @@ parameters of the connection URI to specify the behavior of the client.
        connection. A value of ``0`` indicates that there is no upper bound
        on how long the driver can allow a pooled collection to be idle.
 
-       | **Default**: ``0``
+       | **Default**: ``0`` (no limit)
 
 
    * - **maxLifeTimeMS**
@@ -139,7 +139,7 @@ parameters of the connection URI to specify the behavior of the client.
        connection. A value of ``0`` indicates that there is no upper bound
        on how long the driver can keep a pooled connection open.
 
-       | **Default**: ``0``
+       | **Default**: ``0`` (no limit)
 
    * - **journal**
      - boolean
@@ -163,7 +163,7 @@ parameters of the connection URI to specify the behavior of the client.
        :manual:`wtimeoutMS option </reference/connection-string/#write-concern-options>`.
        A value of ``0`` instructs the driver to never time out write operations.
 
-       | **Default**: ``0``
+       | **Default**: ``0`` (never times out)
 
 
    * - **readPreference**

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -210,7 +210,7 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies the database that the supplied credentials should be
        validated against. 
        
-       | **Defaults**: ``admin``
+       | **Default**: ``admin``
 
    * - **authMechanismProperties**
      - string

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -21,21 +21,29 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies the minimum number of connections that must exist at
        any moment in a single connection pool.
 
+       | **Default**: ``0``
+
    * - **maxPoolSize**
      - integer
      - Specifies the maximum number of connections that a connection
        pool may have at a given time.
+
+       | **Default**: ``100``
 
    * - **waitQueueTimeoutMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds that a
        thread may wait for a connection to become available.
 
+       | **Default**: ``120000`` (2 minutes)
+
    * - **serverSelectionTimeoutMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds, the driver
        will wait for server selection to succeed before throwing an
        exception.
+
+       | **Default**: ``30000`` (30 seconds)
 
    * - **localThresholdMS**
      - integer
@@ -44,11 +52,15 @@ parameters of the connection URI to specify the behavior of the client.
        response time is less than or equal to the server with the fastest
        response time plus the local threshold, in milliseconds.
 
+       | **Default**: ``15`` (15 milliseconds)
+
    * - **heartbeatFrequencyMS**
      - integer
      - Specifies the frequency, in milliseconds that the driver will
        wait between attempts to determine the current state of each
        server in the cluster.
+
+       | **Default**: ``10000`` (10 seconds)
 
    * - **replicaSet**
      - string
@@ -56,15 +68,21 @@ parameters of the connection URI to specify the behavior of the client.
        provided includes multiple hosts. When specified, the driver
        attempts to find all members of that set.
 
+       | **Default**: ``null``
+
    * - **ssl**
      - boolean
      - Specifies that all communication with MongoDB instances should
        use TLS/SSL. Superseded by the **tls** option.
 
+       | **Default**: ``false``
+
    * - **tls**
      - boolean
      - Specifies that all communication with MongoDB instances should
        use TLS. Supersedes the **ssl** option.
+
+       | **Default**: ``false``
 
    * - **tlsInsecure**
      - boolean
@@ -74,21 +92,31 @@ parameters of the connection URI to specify the behavior of the client.
        constraints in other ways, use a
        :ref:`custom SSLContext <tls-custom-sslContext>`.
 
+       | **Default**: ``false``
+
+
    * - **tlsAllowInvalidHostnames**
      - boolean
      - Specifies that the driver should allow invalid hostnames in the
        certificate for TLS connections. Supersedes
        **sslInvalidHostNameAllowed**.
 
+       | **Default**: ``false``
+
    * - **connectTimeoutMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver waits for a connection to open before timing out.
 
+       | **Default**: ``10000`` (10 seconds)
+
    * - **socketTimeoutMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver will wait to send or receive a request before timing out.
+
+       | **Default**: ``0``
+
 
    * - **maxIdleTimeMS**
      - integer
@@ -96,16 +124,23 @@ parameters of the connection URI to specify the behavior of the client.
        driver will allow a pooled connection to idle before closing the
        connection.
 
+       | **Default**: ``0``
+
+
    * - **maxLifeTimeMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver will continue to use a pooled connection before closing the
        connection.
 
+       | **Default**: ``0``
+
    * - **journal**
      - boolean
      - Specifies that the driver must wait for the connected MongoDB
        instance to group commit to the journal file on disk for all writes.
+
+       | **Default**: ``false``
 
    * - **w**
      - string or integer
@@ -113,11 +148,16 @@ parameters of the connection URI to specify the behavior of the client.
        the server documentation for the :manual:`w option
        </reference/write-concern/#w-option>`.
 
+       | **Default**: ``1``
+
    * - **wtimeoutMS**
      - integer
      - Specifies a time limit, in milliseconds, for the write concern. For
        more information, see the server documentation for the
        :manual:`wtimeoutMS option </reference/connection-string/#write-concern-options>`.
+
+       | **Default**: ``0``
+
 
    * - **readPreference**
      - string
@@ -125,11 +165,16 @@ parameters of the connection URI to specify the behavior of the client.
        the server documentation for the
        :manual:`readPreference option </reference/connection-string/#urioption.readPreference>`.
 
+       | **Default**: ``"primary"``
+
    * - **readPreferenceTags**
      - string
      - Specifies the read preference tags. For more information on values, see
        the server documentation for the
        :manual:`readPreferenceTags option </reference/connection-string/#urioption.readPreferenceTags>`.
+
+       | **Default**: ``null``
+
 
    * - **maxStalenessSeconds**
      - integer
@@ -141,20 +186,27 @@ parameters of the connection URI to specify the behavior of the client.
        is greater. For more information, see the server documentation for the
        :manual:`maxStalenessSeconds option </reference/connection-string/#urioption.maxStalenessSeconds>`.
 
+       | **Default**: ``-1``
+
+
    * - **authMechanism**
      - string
      - Specifies the :doc:`authentication mechanism
        </fundamentals/auth>` that the driver should use if a credential
-       was supplied. By default, the client picks the most secure
-       mechanism available based on the server version. For possible
-       values, see the server documentation for the
-       :manual:`authMechanism option
-       </reference/connection-string/#urioption.authMechanism>`.
+       was supplied.
+
+       | **Default**: By default, the client picks the most secure
+         mechanism available based on the server version. For possible
+         values, see the server documentation for the
+         :manual:`authMechanism option
+         </reference/connection-string/#urioption.authMechanism>`.
 
    * - **authSource**
      - string
      - Specifies the database that the supplied credentials should be
-       validated against. Defaults to ``admin``.
+       validated against. 
+       
+       | **Defaults**: ``admin``
 
    * - **authMechanismProperties**
      - string
@@ -164,11 +216,17 @@ parameters of the connection URI to specify the behavior of the client.
        the :manual:`authMechanismProperties option
        </reference/connection-string/#urioption.authMechanismProperties>`.
 
+       | **Default**: ``null``
+
+
    * - **appName**
      - string
      - Specifies the name of the application provided to MongoDB instances
        during the connection handshake. Can be used for server logs and
        profiling.
+
+       | **Default**: ``null``
+
 
    * - **compressors**
      - string
@@ -176,6 +234,9 @@ parameters of the connection URI to specify the behavior of the client.
        will attempt to use to compress requests sent to the connected
        MongoDB instance. Possible values include: ``zlib``, ``snappy``,
        and ``zstd``.
+
+       | **Default**: ``null``
+
 
    * - **zlibCompressionLevel**
      - integer
@@ -185,15 +246,24 @@ parameters of the connection URI to specify the behavior of the client.
        compressing faster (but resulting in larger requests) and larger values
        compressing slower (but resulting in smaller requests).
 
+       | **Default**: ``null``
+
+
    * - **retryWrites**
      - boolean
      - Specifies that the driver must retry supported write operations
-       if they fail due to a network error. Defaults to ``true``.
+       if they fail due to a network error.
+
+       | **Default**: ``true``
+
 
    * - **retryReads**
      - boolean
      - Specifies that the driver must retry supported read operations
-       if they fail due to a network error. Defaults to ``true``.
+       if they fail due to a network error.
+
+       | **Default**: ``true``
+
 
    * - **uuidRepresentation**
      - string
@@ -202,14 +272,21 @@ parameters of the connection URI to specify the behavior of the client.
        for the
        `MongoClientSettings.getUuidRepresentation() method <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getUuidRepresentation()>`__.
 
+       | **Default**: ``UNSPECIFIED``
+
    * - **directConnection**
      - boolean
      - Specifies that the driver must connect to the host directly.
 
+       | **Default**: ``false``
+
+
    * - **maxConnecting**
      - integer
      - Specifies the maximum number of connections a pool may be establishing
-       concurrently. Defaults to ``2``.
+       concurrently.
+       
+       | **Default**: ``2``
 
    * - **srvServiceName**
      - string
@@ -221,8 +298,9 @@ parameters of the connection URI to specify the behavior of the client.
        :manual:`DNS Seed List Connection Format </reference/connection-string/#dns-seed-list-connection-format>`
        in your
        :ref:`connection URI <connection-uri>`
-       to use this option. Defaults to ``"mongodb"``.
-
+       to use this option. 
+       
+       | **Default**: ``"mongodb"``
 
 For a complete list of options, see the
 `ConnectionString <{+api+}/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html>`__

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -106,7 +106,9 @@ parameters of the connection URI to specify the behavior of the client.
    * - **connectTimeoutMS**
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
-       driver waits for a connection to open before timing out.
+       driver waits for a connection to open before timing out. A value of
+       ``0`` instructs the driver to never time out while waiting for a connection
+       to open.
 
        | **Default**: ``10000`` (10 seconds)
 
@@ -114,6 +116,8 @@ parameters of the connection URI to specify the behavior of the client.
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver will wait to send or receive a request before timing out.
+       A value of ``0`` instructs the driver to never time out while waiting
+       to send or receive a request.
 
        | **Default**: ``0``
 
@@ -122,7 +126,8 @@ parameters of the connection URI to specify the behavior of the client.
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver will allow a pooled connection to idle before closing the
-       connection.
+       connection. A value of ``0`` indicates that there is no upper bound
+       on how long the driver can allow a pooled collection to be idle.
 
        | **Default**: ``0``
 
@@ -131,7 +136,8 @@ parameters of the connection URI to specify the behavior of the client.
      - integer
      - Specifies the maximum amount of time, in milliseconds, the Java
        driver will continue to use a pooled connection before closing the
-       connection.
+       connection. A value of ``0`` indicates that there is no upper bound
+       on how long the driver can keep a pooled connection open.
 
        | **Default**: ``0``
 
@@ -155,6 +161,7 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies a time limit, in milliseconds, for the write concern. For
        more information, see the server documentation for the
        :manual:`wtimeoutMS option </reference/connection-string/#write-concern-options>`.
+       A value of ``0`` instructs the driver to never time out write operations.
 
        | **Default**: ``0``
 
@@ -165,7 +172,7 @@ parameters of the connection URI to specify the behavior of the client.
        the server documentation for the
        :manual:`readPreference option </reference/connection-string/#urioption.readPreference>`.
 
-       | **Default**: ``"primary"``
+       | **Default**: ``primary``
 
    * - **readPreferenceTags**
      - string
@@ -272,7 +279,7 @@ parameters of the connection URI to specify the behavior of the client.
        for the
        `MongoClientSettings.getUuidRepresentation() method <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getUuidRepresentation()>`__.
 
-       | **Default**: ``UNSPECIFIED``
+       | **Default**: ``unspecified``
 
    * - **directConnection**
      - boolean
@@ -300,7 +307,7 @@ parameters of the connection URI to specify the behavior of the client.
        :ref:`connection URI <connection-uri>`
        to use this option. 
        
-       | **Default**: ``"mongodb"``
+       | **Default**: ``mongodb``
 
 For a complete list of options, see the
 `ConnectionString <{+api+}/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html>`__

--- a/source/fundamentals/connection/connection-options.txt
+++ b/source/fundamentals/connection/connection-options.txt
@@ -94,7 +94,6 @@ parameters of the connection URI to specify the behavior of the client.
 
        | **Default**: ``false``
 
-
    * - **tlsAllowInvalidHostnames**
      - boolean
      - Specifies that the driver should allow invalid hostnames in the
@@ -182,7 +181,6 @@ parameters of the connection URI to specify the behavior of the client.
 
        | **Default**: ``null``
 
-
    * - **maxStalenessSeconds**
      - integer
      - Specifies, in seconds, how stale a secondary can be before the
@@ -193,8 +191,7 @@ parameters of the connection URI to specify the behavior of the client.
        is greater. For more information, see the server documentation for the
        :manual:`maxStalenessSeconds option </reference/connection-string/#urioption.maxStalenessSeconds>`.
 
-       | **Default**: ``-1``
-
+       | **Default**: ``-1`` (no staleness check)
 
    * - **authMechanism**
      - string
@@ -225,7 +222,6 @@ parameters of the connection URI to specify the behavior of the client.
 
        | **Default**: ``null``
 
-
    * - **appName**
      - string
      - Specifies the name of the application provided to MongoDB instances
@@ -233,7 +229,6 @@ parameters of the connection URI to specify the behavior of the client.
        profiling.
 
        | **Default**: ``null``
-
 
    * - **compressors**
      - string
@@ -244,7 +239,6 @@ parameters of the connection URI to specify the behavior of the client.
 
        | **Default**: ``null``
 
-
    * - **zlibCompressionLevel**
      - integer
      - Specifies the degree of compression that `Zlib <https://zlib.net/>`__
@@ -254,7 +248,6 @@ parameters of the connection URI to specify the behavior of the client.
        compressing slower (but resulting in smaller requests).
 
        | **Default**: ``null``
-
 
    * - **retryWrites**
      - boolean
@@ -271,7 +264,6 @@ parameters of the connection URI to specify the behavior of the client.
 
        | **Default**: ``true``
 
-
    * - **uuidRepresentation**
      - string
      - Specifies the UUID representation to use for read and write
@@ -286,7 +278,6 @@ parameters of the connection URI to specify the behavior of the client.
      - Specifies that the driver must connect to the host directly.
 
        | **Default**: ``false``
-
 
    * - **maxConnecting**
      - integer


### PR DESCRIPTION
## Pull Request Info

Add default values for all connection options

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-20825

### Snooty build log:

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=622692521a622fb274228ad9

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-20825-Connection-Defaults/fundamentals/connection/connection-options/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
