### PR TITLE
DOCSP-22040 link fix

### DIFF
--- a/source/fundamentals/monitoring.txt
+++ b/source/fundamentals/monitoring.txt
@@ -418,7 +418,8 @@ tracing system other than Zipkin, you must write a command event listener that
 manages `spans <https://docs.spring.io/spring-cloud-sleuth/docs/current-SNAPSHOT/reference/html/getting-started.html#getting-started-terminology>`__
 for your desired distributed tracing system. To see an implementation of such a
 listener, see the
-:github:`TraceMongoCommandListener <spring-cloud/spring-cloud-sleuth/blob/main/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/mongodb/TraceMongoCommandListener.java>`
+:github:`TraceMongoCommandListener
+<spring-cloud/spring-cloud-sleuth/blob/eb01d5952b2e736970efbe3fc7e9784d119eeae9/spring-cloud-sleuth-instrumentation/src/main/java/org/springframework/cloud/sleuth/instrument/mongodb/TraceMongoCommandListener.java>`
 class in the Spring Cloud Sleuth source code.
 
 To learn more about Spring Cloud Sleuth, see


### PR DESCRIPTION
## Pull Request Info

Fixed the link for `TraceMongoCommandListener`.

After the PR is approved, I'll cherry pick to v4.4 and v4.5.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-22040

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=625882af0fdfea9c371287cd

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-22040-LinkFix/fundamentals/monitoring/#include-the-driver-in-your-distributed-tracing-system

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
