### PR TITLE
DOCSP-22817: add walltime to changedocument output

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,7 +1,6 @@
 name = "java"
 title = "Java Sync"
 intersphinx = [
-    "https://www.mongodb.com/docs/upcoming/objects.inv",
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/drivers/objects.inv"
 ]

--- a/snooty.toml
+++ b/snooty.toml
@@ -1,7 +1,10 @@
 name = "java"
 title = "Java Sync"
-intersphinx = ["https://mongodb.com/docs/manual/objects.inv",
-               "https://mongodb.com/docs/drivers/objects.inv"]
+intersphinx = [
+    "https://www.mongodb.com/docs/upcoming/objects.inv",
+    "https://www.mongodb.com/docs/manual/objects.inv",
+    "https://www.mongodb.com/docs/drivers/objects.inv"
+]
 
 toc_landing_pages = [
     "/fundamentals/connection",

--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -418,8 +418,8 @@ the ``vendors`` collection:
 
 See the MongoDB server manual sections for more information:
 
-- :ref:`Clustered Indexes <db.createCollection.clusteredIndex>`
-- :ref:`Clustered Collections <clustered-collections>`
+- :v6.0:`Clustered Index </reference/method/db.createCollection/#std-label-db.createCollection.clusteredIndex>`
+- :v6.0:`Clustered Collections </core/clustered-collections>`
 
 Remove an Index
 ---------------

--- a/source/usage-examples/watch.txt
+++ b/source/usage-examples/watch.txt
@@ -9,9 +9,13 @@ Watch for Changes
 You can keep track of changes to data in MongoDB, such as changes to a
 collection, database, or deployment, by opening a **change stream**. A change
 stream allows applications to watch for changes to data and react to them.
-The change stream returns **change event** documents when changes occur.
-You can open a change stream by calling the ``watch()`` method on
-a ``MongoCollection``, ``MongoDatabase``, or ``MongoClient`` object:
+
+The change stream returns **change event** documents when changes occur. A
+change event contains information about the updated data.
+
+Open a change stream by calling the ``watch()`` method on a 
+``MongoCollection``, ``MongoDatabase``, or ``MongoClient`` object as shown in 
+the following code example:
 
 .. code-block:: java
 
@@ -134,7 +138,7 @@ pipeline filters out the ``delete`` operation:
 
    Received a change to the collection: ChangeStreamDocument{
      operationType=OperationType{value='insert'},
-     resumeToken={"_data": "825EC..."},
+     resumeToken={"_data": "825E..."},
      namespace=sample_mflix.movies,
      destinationNamespace=null,
      fullDocument=Document{{_id=5ec3..., test=sample movie document}},
@@ -142,11 +146,12 @@ pipeline filters out the ``delete`` operation:
      clusterTime=Timestamp{...},
      updateDescription=null,
      txnNumber=null,
-     lsid=null
+     lsid=null,
+     wallTime=BsonDateTime{value=1657...}
    }
    Received a change to the collection: ChangeStreamDocument{
      operationType=OperationType{value='update'},
-     resumeToken={"_data": "825EC..."},
+     resumeToken={"_data": "825E..."},
      namespace=sample_mflix.movies,
      destinationNamespace=null,
      fullDocument=Document{{_id=5ec3..., test=sample movie document, field2=sample movie document update}},
@@ -154,7 +159,8 @@ pipeline filters out the ``delete`` operation:
      clusterTime=Timestamp{...},
      updateDescription=UpdateDescription{removedFields=[], updatedFields={"field2": "sample movie document update"}},
      txnNumber=null,
-     lsid=null
+     lsid=null,
+     wallTime=BsonDateTime{value=1657...}
    }
 
 You should also see output from the ``WatchCompanion`` application that


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-22817
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-22817-walltime/usage-examples/watch/#example

For the change listed in the JIRA ticket A/C, see the output after: 
"Only the insert and update operations are printed, since the aggregation pipeline filters out the delete operation:"
 
For the link fixes to autobuilder errors present in the current master branch, see "Clustered Index" and "Clustered Collections":
https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-22817-walltime/fundamentals/indexes/#clustered-indexes




## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
