### PR TITLE
DOCSP-23217: Add OptionalPropertyCodecProviderExample for testing

### DIFF
--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -588,52 +588,10 @@ You can use the following implementation of ``PropertyCodecProvider`` to
 retrieve your custom Codec. This implementation uses the
 ``TypeWithTypeParameters`` interface to access the type information.
 
-.. code-block:: java
-
-   public class OptionalPropertyCodecProvider implements PropertyCodecProvider {
-
-       @Override
-       @SuppressWarnings({"rawtypes", "unchecked"})
-       public <T> Codec<T> get(final TypeWithTypeParameters<T> type, final PropertyCodecRegistry registry) {
-           // Check the main type and number of generic parameters
-           if (Optional.class.isAssignableFrom(type.getType()) && type.getTypeParameters().size() == 1) {
-               // Get the codec for the concrete type of the Optional, as its declared in the POJO.
-               Codec<?> valueCodec = registry.get(type.getTypeParameters().get(0));
-               return new OptionalCodec(type.getType(), valueCodec);
-           } else {
-               return null;
-           }
-       }
-
-       private static final class OptionalCodec<T> implements Codec<Optional<T>> {
-           private final Class<Optional<T>> encoderClass;
-           private final Codec<T> codec;
-
-           private OptionalCodec(final Class<Optional<T>> encoderClass, final Codec<T> codec) {
-               this.encoderClass = encoderClass;
-               this.codec = codec;
-           }
-
-           @Override
-           public void encode(final BsonWriter writer, final Optional<T> optionalValue, final EncoderContext encoderContext) {
-               if (optionalValue != null && optionalValue.isPresent()) {
-                   codec.encode(writer, optionalValue.get(), encoderContext);
-               } else {
-                   writer.writeNull();
-               }
-           }
-
-           @Override
-           public Optional<T> decode(final BsonReader reader, final DecoderContext context) {
-               return Optional.of(codec.decode(reader, context));
-           }
-
-           @Override
-           public Class<Optional<T>> getEncoderClass() {
-               return encoderClass;
-           }
-       }
-   }
+.. literalinclude:: /includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyCodecProvider.java
+   :language: java
+   :start-after: start optionalPropertyCodecProvider
+   :end-before: end optionalPropertyCodecProvider
 
 Register your ``OptionalPropertyCodecProvider`` in your ``PojoCodecProvider``
 and the package that contains your POJO as follows:

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/Address.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/Address.java
@@ -1,0 +1,32 @@
+package githubdocs;
+
+public class Address {
+    private String street;
+    private String city;
+    
+    public Address() {}
+    
+    public Address(String street, String city) {
+        this.street = street;
+        this.city = city;
+    }
+    
+    public String getStreet() {
+        return street;
+    }
+    public void setStreet(String street) {
+        this.street = street;
+    }
+    public String getCity() {
+        return city;
+    }
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @Override
+    public String toString() {
+        return "Address [street=" + street + ", city=" + city + "]";
+    }
+    
+}

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/Address.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/Address.java
@@ -1,4 +1,4 @@
-package githubdocs;
+package org.example.pojos;
 
 public class Address {
     private String street;

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/ApplicationUser.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/ApplicationUser.java
@@ -1,4 +1,4 @@
-package githubdocs;
+package org.example.pojos;
 
 import java.util.Optional;
 

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/ApplicationUser.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/ApplicationUser.java
@@ -1,0 +1,43 @@
+package githubdocs;
+
+import java.util.Optional;
+
+
+public class ApplicationUser {
+    
+    private Optional<Address> optionalAddress;
+    private Optional<Subscription> optionalSubscription;
+    private String name;
+    
+    public ApplicationUser() {}
+    public ApplicationUser(String name) {
+        this.name = name;
+    }
+    
+    public Optional<Address> getOptionalAddress() {
+        return optionalAddress;
+    }
+    public void setOptionalAddress(Optional<Address> optionalAddress) {
+        this.optionalAddress = optionalAddress;
+    }
+    public Optional<Subscription> getOptionalSubscription() {
+        return optionalSubscription;
+    }
+    public void setOptionalSubscription(Optional<Subscription> optionalSubscription) {
+        this.optionalSubscription = optionalSubscription;
+    }
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+    @Override
+    public String toString() {
+        return "ApplicationUser [optionalAddress=" + optionalAddress + ", optionalSubscription=" + optionalSubscription
+                + ", name=" + name + "]";
+    }
+
+    
+    
+}

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyCodecProvider.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyCodecProvider.java
@@ -1,0 +1,59 @@
+package githubdocs;
+
+import java.util.Optional;
+
+import org.bson.BsonReader;
+import org.bson.BsonWriter;
+import org.bson.codecs.Codec;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.EncoderContext;
+import org.bson.codecs.pojo.PropertyCodecProvider;
+import org.bson.codecs.pojo.PropertyCodecRegistry;
+import org.bson.codecs.pojo.TypeWithTypeParameters;
+
+// start optionalPropertyCodecProvider
+public class OptionalPropertyCodecProvider implements PropertyCodecProvider {
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public <T> Codec<T> get(final TypeWithTypeParameters<T> type, final PropertyCodecRegistry registry) {
+        // Check the main type and number of generic parameters
+        if (Optional.class.isAssignableFrom(type.getType()) && type.getTypeParameters().size() == 1) {
+            // Get the codec for the concrete type of the Optional, as its declared in the POJO.
+            Codec<?> valueCodec = registry.get(type.getTypeParameters().get(0));
+            return new OptionalCodec(type.getType(), valueCodec);
+        } else {
+            return null;
+        }
+    }
+
+    private static final class OptionalCodec<T> implements Codec<Optional<T>> {
+        private final Class<Optional<T>> encoderClass;
+        private final Codec<T> codec;
+
+        private OptionalCodec(final Class<Optional<T>> encoderClass, final Codec<T> codec) {
+            this.encoderClass = encoderClass;
+            this.codec = codec;
+        }
+
+        @Override
+        public void encode(final BsonWriter writer, final Optional<T> optionalValue, final EncoderContext encoderContext) {
+            if (optionalValue != null && optionalValue.isPresent()) {
+                codec.encode(writer, optionalValue.get(), encoderContext);
+            } else {
+                writer.writeNull();
+            }
+        }
+
+        @Override
+        public Optional<T> decode(final BsonReader reader, final DecoderContext context) {
+            return Optional.of(codec.decode(reader, context));
+        }
+
+        @Override
+        public Class<Optional<T>> getEncoderClass() {
+            return encoderClass;
+        }
+    }
+}
+// end optionalPropertyCodecProvider

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyCodecProvider.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyCodecProvider.java
@@ -1,4 +1,4 @@
-package githubdocs;
+package org.example.pojos;
 
 import java.util.Optional;
 

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyExample.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyExample.java
@@ -1,0 +1,68 @@
+package githubdocs;
+
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+
+import java.util.Optional;
+
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistries;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+
+public class OptionalPropertyExample {
+
+    public static void main(String[] args) {
+        CodecProvider pojoCodecProvider = PojoCodecProvider.builder()
+                .register("githubdocs")
+                .register(new OptionalPropertyCodecProvider()) // comment this out to make the code fail
+                .build();
+
+        CodecRegistry registry = CodecRegistries.fromRegistries(
+                MongoClientSettings.getDefaultCodecRegistry(),
+                fromProviders(pojoCodecProvider));
+
+        String uri = "mongodb://localhost:27017";
+
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
+
+            MongoDatabase database = mongoClient.getDatabase("sample_pojo").withCodecRegistry(registry);
+            MongoCollection<ApplicationUser> collection = database.getCollection("appUser", ApplicationUser.class);
+
+            ApplicationUser appUser = new ApplicationUser("Chris");
+            Address addr = new Address("New York City", "Broadway");
+            appUser.setOptionalAddress(Optional.ofNullable(addr));
+            collection.insertOne(appUser);
+
+            ApplicationUser anotherAppUser = new ApplicationUser("Sirhc");
+            Subscription sub = new Subscription("Monthly", "12-Month Plan");
+            anotherAppUser.setOptionalAddress(Optional.ofNullable(new Address()));
+            anotherAppUser.setOptionalSubscription(Optional.ofNullable(sub));
+            collection.insertOne(anotherAppUser);
+
+            MongoCursor<ApplicationUser> results = collection.find().iterator();
+            while(results.hasNext()) {
+                ApplicationUser result = results.next();
+                StringBuilder sb = new StringBuilder(result.getName() + ": ");
+                
+                if (result.getOptionalSubscription() != null && result.getOptionalSubscription().isPresent()) {
+                    sb.append(result.getOptionalSubscription().get().toString());
+                }
+                if (result.getOptionalAddress() != null && result.getOptionalAddress().isPresent()) {
+                    sb.append(result.getOptionalAddress().get().toString());
+                }
+                
+                System.out.println(sb);
+            }
+        }
+
+
+    }
+
+}

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyExample.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/OptionalPropertyExample.java
@@ -1,4 +1,4 @@
-package githubdocs;
+package org.example.pojos;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/Subscription.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/Subscription.java
@@ -1,4 +1,4 @@
-package githubdocs;
+package org.example.pojos;
 
 public class Subscription {
     private String type;

--- a/source/includes/fundamentals/code-snippets/optional-codec-provider/Subscription.java
+++ b/source/includes/fundamentals/code-snippets/optional-codec-provider/Subscription.java
@@ -1,0 +1,32 @@
+package githubdocs;
+
+public class Subscription {
+    private String type;
+    private String subName;
+    
+    public Subscription() {}
+    
+    public Subscription(String type, String subName) {
+        this.type = type;
+        this.subName = subName;
+    }
+    
+    public String getType() {
+        return type;
+    }
+    public void setType(String type) {
+        this.type = type;
+    }
+    public String getSubName() {
+        return subName;
+    }
+    public void setSubName(String subName) {
+        this.subName = subName;
+    }
+
+    @Override
+    public String toString() {
+        return "Subscription [type=" + type + ", subName=" + subName + "]";
+    }
+    
+}


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

The code appears to be working in the current driver version, but for ease of testing, I created an example app to allow user testing of the functionality and sourced the Codec code in the docs.

JIRA - https://jira.mongodb.org/browse/DOCSP-23217
Staging -
[Scroll down from this section header to verify the OptionalPropertyCodecProvider code snippet shows up as intended](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-23217-add-codecprovider-example/fundamentals/data-formats/pojo-customization/#generics-support)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
