### PR TITLE
DOCSP-23045: add setWindowFields API change to release notes

### DIFF
--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -397,7 +397,7 @@ Refer to the :manual:`Unique Indexes page </core/index-unique>` in the MongoDB s
 
 .. driver-content-end
 
-.. _java-clustered-idexes:
+.. _java-clustered-indexes:
 
 Clustered Indexes
 ~~~~~~~~~~~~~~~~~

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -50,6 +50,19 @@ changes between the current and upgrade versions. For example, if you
 are upgrading the driver from v4.0 to v4.5, address all breaking changes from
 the version after v4.0 including any listed under v4.5.
 
+.. _java-breaking-changes-v4.7:
+
+Version 4.7 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The ``setWindowFields`` builder API is no longer beta. The new builder
+  breaks binary and source compatibility. See the
+  `Aggregates API documentation https://mongodb.github.io/mongo-java-driver/4.7/apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html>`__
+  for information the new ``setWindowFields()`` method signatures.
+
+  If your application uses this builder in a version prior to v4.7, update
+  your source code to use the new method signature and rebuild your binary.
+
 .. _java-breaking-changes-v4.2:
 
 Version 4.2 Breaking Changes

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -43,7 +43,7 @@ New features of the 4.7 driver release include:
   - Added ``showExpandedEvents`` support for change streams.
   - Added ``wallTime`` support to the ``ChangeStreamDocument`` class.
 
-- Added :ref:`clustered index <java-clustered-idexes>` creation support.
+- Added :ref:`clustered index <java-clustered-indexes>` creation support.
 - Support for new features related to :ref:`qe-manual-feature-qe`,
   including support for automatic encryption (MongoDB v6.0 Enterprise or later
   is required) and manual encryption.
@@ -60,10 +60,9 @@ New features of the 4.7 driver release include:
   :pipeline:`$densify`, and :pipeline:`$fill`.
 
 - The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
-  is no longer a `@Beta <{+api+}/apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`__
-  feature. Changes in the API break both binary and source compatibility. If
-  you used the beta API with a previous version of the driver, update your
-  source and rebuild your binaries.
+  is no longer a beta feature. Changes in the API break both binary and source
+  compatibility. If you used the beta API with a previous version of the
+  driver, update your source and rebuild your binaries.
 
 - Added the ``BsonExtraElements`` annotation that can be used with POJO encoding
   and decoding. ``BsonExtraElements`` enables decoding objects that may receive

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -60,10 +60,10 @@ New features of the 4.7 driver release include:
   :pipeline:`$densify`, and :pipeline:`$fill`.
 
 - The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
-  is no longer a :ref:`@Beta feature <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`.
-  Changes in the API break both binary and source compatibility. If you
-  used the beta API with a previous version of the driver, you may need to
-  update your source and rebuild your binaries.
+  is no longer a :api:`@Beta </apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`
+  feature. Changes in the API break both binary and source compatibility. If
+  you used the beta API with a previous version of the driver, update your
+  source and rebuild your binaries.
 
 - Added the ``BsonExtraElements`` annotation that can be used with POJO encoding
   and decoding. ``BsonExtraElements`` enables decoding objects that may receive

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -58,6 +58,13 @@ New features of the 4.7 driver release include:
 - Added builder API methods for additional aggregation stages
   including :pipeline:`$search`/:pipeline:`$searchMeta` (Atlas only),
   :pipeline:`$densify`, and :pipeline:`$fill`.
+
+- The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
+  is no longer a :ref:`@Beta feature <https://mongodb.github.io/mongo-java-driver/4.3/apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`.
+  Changes in the API break both binary and source compatibility. If you
+  used the beta API with a previous version of the driver, you may need to
+  update your source and rebuild your binaries.
+
 - Added the ``BsonExtraElements`` annotation that can be used with POJO encoding
   and decoding. ``BsonExtraElements`` enables decoding objects that may receive
   new fields in the future without requiring developers to explicitly map

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -59,21 +59,20 @@ New features of the 4.7 driver release include:
   including :pipeline:`$search`/:pipeline:`$searchMeta` (Atlas only),
   :pipeline:`$densify`, and :pipeline:`$fill`.
 
-- The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
-  is no longer a beta feature. Changes in the API break both binary and source
-  compatibility. If you used the beta API with a previous version of the
-  driver, update your source and rebuild your binaries.
-
 - Added the ``BsonExtraElements`` annotation that can be used with POJO encoding
   and decoding. ``BsonExtraElements`` enables decoding objects that may receive
   new fields in the future without requiring developers to explicitly map
   those new fields.
+
 - Performance optimizations including:
 
   - Lock-free implementations of the server session pool and the buffer pool.
   - A new cleanup implementation of ``DBCursor`` that uses Java's
     Cleaner API instead of finalization, available in Java 9 or later.
 
+- The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
+  is no longer a beta feature. Changes in the API break both binary and source
+  compatibility. See :ref:`<java-breaking-changes-v4.7>` for more information.
 
 .. _version-4.6:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -60,7 +60,7 @@ New features of the 4.7 driver release include:
   :pipeline:`$densify`, and :pipeline:`$fill`.
 
 - The :ref:`setWindowFields <builders-aggregates-setWindowFields>` builder API
-  is no longer a :api:`@Beta </apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`
+  is no longer a `@Beta <{+api+}/apidocs/mongodb-driver-core/com/mongodb/annotations/Beta.html>`__
   feature. Changes in the API break both binary and source compatibility. If
   you used the beta API with a previous version of the driver, update your
   source and rebuild your binaries.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-23045
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-23045-setwindowfields-api-update/whats-new/#what-s-new-in-4.7

The link checker is failing on a link that loads when accessed through a browser.


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
