### PR TITLE
(DOCSP-24130) libmongocrypt patch

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -18,9 +18,9 @@ sharedinclude_root = "https://raw.githubusercontent.com/10gen/docs-shared/main/"
 driver = "java"
 driver-long = "MongoDB Java Driver"
 version = "4.7"
-full-version = "{+version+}.0"
+full-version = "{+version+}.1"
 
 package-name-org = "mongodb-org"
 api = "https://mongodb.github.io/mongo-java-driver/{+version+}"
 stable-api = "Stable API"
-mongocrypt-version = "1.5.1.1"                                  # ensure compatibilty with driver version
+mongocrypt-version = "1.5.2"                                  # ensure compatibilty with driver version

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -12,6 +12,7 @@ What's New
 
 Learn what's new in:
 
+* :ref:`Version 4.7.1 <version-4.7.1>`
 * :ref:`Version 4.7 <version-4.7>`
 * :ref:`Version 4.6 <version-4.6>`
 * :ref:`Version 4.5 <version-4.5>`
@@ -20,6 +21,28 @@ Learn what's new in:
 * :ref:`Version 4.2 <version-4.2>`
 * :ref:`Version 4.1 <version-4.1>`
 * :ref:`Version 4.0 <version-4.0>`
+
+.. _version-4.7.1:
+
+What's New in 4.7.1
+-------------------
+
+The 4.7.1 driver patches a potential data corruption bug in
+Client-Side Field Level Encryption (CSFLE) and Queryable Encryption (QE)
+that occurs when rotating :ref:`Data Encryption Keys <csfle-key-architecture>`
+(DEKs) encrypted with a :ref:`Customer Master Key <csfle-key-architecture>` (CMK)
+hosted on Google Cloud Key Management Service (GCP KMS) or Azure
+Key Vault.
+
+To avoid potential data corruption when rotating DEKs encrypted with a CMK
+hosted on GCP KMS or Azure Key Vault, upgrade to version 4.7.1 or later of the
+driver before using the ``RewrapManyDataKey`` method.
+
+.. important:: Back-Up your Key Vault Collection
+
+   Always back-up your :ref:`Key Vault Collection <csfle-reference-key-vault>`
+   before you rotate your DEKs. If you lose your DEKs, you lose access to all
+   of the data encrypted with those keys.
 
 .. _version-4.7:
 


### PR DESCRIPTION
# Pull Request Info

Update `mongo-crypt` version and add note about 4.7.1 patch release.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-24130
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
