### PR TITLE
Backport: typo fix

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -87,7 +87,7 @@ Version 4.0 Breaking Changes
 - The default BSON representation of ``java.util.UUID`` value was changed
   from ``JAVA_LEGACY`` to ``UNSPECIFIED``. Applications that store or retrieve
   UUID values must explicitly specify which representation to use. You can
-  specify the representation in the ``uidRepresentation`` property of
+  specify the representation in the ``uuidRepresentation`` property of
   ``MongoClientSettings``.
 - The connection pool no longer restricts the number of wait queue threads
   or asynchronous tasks that require a connection to MongoDB. The


### PR DESCRIPTION
(cherry picked from commit 9830df3ff0dcf0e3560b4a93e0036447e7c3b610)

# Pull Request Info

https://github.com/mongodb/docs-java/pull/249

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=62f12944230aeb802e5e17bc

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
