### PR TITLE
081622: update builder link and link description

### DIFF
--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -549,8 +549,8 @@ on a specified span of documents in a collection.
 
 .. tip:: Window Functions
 
-   The driver includes the `WindowedComputations <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/WindowedComputations.html>`__
-   class with static factory methods for each of the supported window operators.
+   The driver includes the `Windows <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Windows.html>`__
+   class with static factory methods for building windowed computations.
 
 The following example creates a pipeline stage that computes the
 accumulated rainfall and the average temperature over the past month for


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Original link and description were correct for 4.6. New link and description for 4.7.

JIRA - None
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/081622-fix-broken-link/fundamentals/builders/aggregates/#setwindowfields

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
