### PR TITLE
DOCSP-22293: Records and Codec Provider

### DIFF
--- a/source/fundamentals/data-formats.txt
+++ b/source/fundamentals/data-formats.txt
@@ -8,6 +8,7 @@ Data Formats
 - :doc:`/fundamentals/data-formats/document-data-format-extended-json`
 - :doc:`/fundamentals/data-formats/documents`
 - :doc:`/fundamentals/data-formats/document-data-format-pojo`
+- :doc:`/fundamentals/data-formats/document-data-format-record`
 - :doc:`/fundamentals/data-formats/pojo-customization`
 - :doc:`/fundamentals/data-formats/codecs`
 
@@ -18,6 +19,7 @@ Data Formats
    /fundamentals/data-formats/document-data-format-extended-json
    /fundamentals/data-formats/documents
    /fundamentals/data-formats/document-data-format-pojo
+   /fundamentals/data-formats/document-data-format-record
    /fundamentals/data-formats/pojo-customization
    /fundamentals/data-formats/codecs
 

--- a/source/fundamentals/data-formats/codecs.txt
+++ b/source/fundamentals/data-formats/codecs.txt
@@ -1,3 +1,5 @@
+.. _fundamentals-codecs:
+
 ======
 Codecs
 ======
@@ -32,7 +34,7 @@ sections:
 - :ref:`CodecProvider <codecs-codecprovider>`
 - :ref:`Custom Codec Example <codecs-custom-example>`
 
-If you are customizing encoding and decoding logic for Plain old Java objects
+If you are customizing encoding and decoding logic for plain old Java objects
 (POJOs), read our guide on :doc:`POJO Customization </fundamentals/data-formats/pojo-customization>`.
 
 .. _codecs-codec:

--- a/source/fundamentals/data-formats/document-data-format-pojo.txt
+++ b/source/fundamentals/data-formats/document-data-format-pojo.txt
@@ -224,7 +224,7 @@ When you run this code, your output should look something like this:
    the guide on :doc:`POJO Customization </fundamentals/data-formats/pojo-customization>`.
 
 For more information about the methods and classes mentioned in this section,
-see the following API Documentation:
+see the following API documentation:
 
 - `CodecRegistry <{+api+}/apidocs/bson/org/bson/codecs/configuration/CodecRegistry.html>`__
 - `TDocument <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html>`__

--- a/source/fundamentals/data-formats/document-data-format-pojo.txt
+++ b/source/fundamentals/data-formats/document-data-format-pojo.txt
@@ -1,3 +1,5 @@
+.. _fundamentals-pojos:
+
 ===========================
 Document Data Format: POJOs
 ===========================
@@ -21,7 +23,7 @@ data representation.
 The example in this guide shows how to perform the following:
 
 - Configure the driver to serialize and deserialize POJOs
-- How to read and write to documents using POJOs 
+- How to read and write to documents using POJOs
 
 .. _fundamentals-example-pojo:
 
@@ -120,8 +122,8 @@ To set up the driver to store and retrieve POJOs, we need to specify:
   encode/decode the data between the POJO and MongoDB document, and which
   POJO classes or packages that the codecs should apply to.
 - A ``CodecRegistry`` instance that contains the codecs and other related information.
-- A ``MongoClient``, ``MongoDatabase``, or ``MongoCollection`` instance
-  configured to use the ``CodecRegistry``.
+- A ``MongoDatabase`` or ``MongoCollection`` instance configured to use the
+  ``CodecRegistry``.
 - A ``MongoCollection`` instance created with the POJO document class
   bound to the ``TDocument`` generic type.
 
@@ -130,7 +132,7 @@ requirements:
 
 1. Configure the ``PojoCodecProvider``. In this example, we use the ``automatic(true)``
    setting of the ``PojoCodecProvider.Builder`` to apply the Codecs to
-   any class and its properties. 
+   any class and its properties.
 
    .. code-block:: java
 
@@ -140,7 +142,7 @@ requirements:
 
       Codec providers also contain other objects such as ``ClassModel`` and
       ``Convention`` instances that further define serialization behavior.
-      For more information on codec providers and customization, see our guide
+      For more information on codec providers and customization, see the guide
       on :doc:`POJO Customization </fundamentals/data-formats/pojo-customization>`.
 
 #. Add the ``PojoCodecProvider`` instance to a ``CodecRegistry``. The
@@ -166,11 +168,10 @@ requirements:
 
       CodecRegistry pojoCodecRegistry = fromRegistries(getDefaultCodecRegistry(), fromProviders(pojoCodecProvider));
 
-#. Configure our ``MongoClient``, ``MongoDatabase``, or ``MongoCollection``
-   instance to use the Codecs in the ``CodecRegistry``. You only need to
-   configure one of these. In this example, we set the ``CodecRegistry`` on a
-   ``MongoDatabase`` called ``sample_pojos`` using the ``withCodecRegistry()``
-   method.
+#. Configure the ``MongoDatabase`` or ``MongoCollection`` instance to use the
+   Codecs in the ``CodecRegistry``. You only need to configure one of these.
+   In this example, we set the ``CodecRegistry`` on a ``MongoDatabase`` called
+   ``sample_pojos`` using the ``withCodecRegistry()`` method.
 
    .. code-block:: java
 
@@ -220,7 +221,7 @@ When you run this code, your output should look something like this:
 
    By default, the ``PojoCodecProvider`` omits fields in your POJO that are
    set to ``null``. For more information on how to specify this behavior, see
-   our guide on :doc:`POJO Customization </fundamentals/data-formats/pojo-customization>`.
+   the guide on :doc:`POJO Customization </fundamentals/data-formats/pojo-customization>`.
 
 For more information about the methods and classes mentioned in this section,
 see the following API Documentation:
@@ -245,5 +246,4 @@ by performing the following:
 - Specify the **automatic** conversion behavior for the ``PojoCodecProvider``
   to apply the ``Codecs`` to any class and its properties.
 - Add the ``PojoCodecProvider`` to a ``CodecRegistry``, and specify the
-  registry on an instance of a ``MongoClient``, ``MongoDatabase``, or
-  ``MongoCollection``.
+  registry on an instance of a ``MongoDatabase`` or ``MongoCollection``.

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -100,7 +100,7 @@ After you specify the appropriate codec registry, you can insert a
 
    MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
 
-   // insert the document
+   // insert the record
    collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
 
 Retrieve a Record
@@ -116,10 +116,9 @@ code below:
    .. input::
       :language: java
 
-      // insert the document
-      collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+      MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
 
-      // return all documents in the collection as records
+      // retrieve and print the records
       List<DataStorageRecord> records = new ArrayList<DataStorageRecord>();
       collection.find().into(records);
       records.forEach(System.out::println);
@@ -130,9 +129,8 @@ code below:
       DataStorageRecord[productName=1GB SSD, capacity=8.56]
 
 For more information about the methods and classes mentioned in this section,
-see the following API Documentation:
+see the following API documentation:
 
 - `CodecRegistry <{+api+}/apidocs/bson/org/bson/codecs/configuration/CodecRegistry.html>`__
-- `getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html?is-external=true#getDefaultCodecRegistry()>`__
-- `MongoClientSettings.getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getDefaultCodecRegistry()>`__
+- `getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getDefaultCodecRegistry()>`__
 

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -16,8 +16,8 @@ Overview
 --------
 
 In this guide, you can learn how to store and retrieve data in the {+driver-long+}
-using **Java records**. Java records are a type of Java class that are often
-used to model data and separate business logic from data representation.
+using **Java records**. Java records are a type of Java class often used to
+model data and separate business logic from data representation.
 
 .. tip::
 
@@ -39,7 +39,7 @@ The following sections show how you can perform the following tasks:
 Example Record
 --------------
 
-The code examples in this guide reference the following sample record which
+The code examples in this guide reference the following sample record, which
 describes a data storage device:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/records/DataStorageRecord.java
@@ -50,15 +50,15 @@ describes a data storage device:
 Serialize and Deserialize a Record
 ----------------------------------
 
-To set up the driver to serialize and deserialize a record, you need to
-provide it with logic on how to convert between Java and MongoDB types using
-**codecs**. Codecs define how to encode and decode the data between the
-record and MongoDB document and to which record classes or packages the codecs
-they apply. The driver defines methods for the encoding and decoding logic an
-interface called ``Codec``.
+To set up the driver to serialize and deserialize a record, you must provide
+it with logic on how to convert between Java and MongoDB types using
+**codecs**. Codecs define how to encode and decode data between records and
+MongoDB documents, and to which classes or packages the codecs they apply.
+The driver defines methods for the encoding and decoding logic an interface
+called ``Codec``.
 
-In order to identify which codec to use, the driver uses a registry called
-the ``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of
+To identify which codec to use, the driver uses a registry called the
+``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of
 ``Codec`` implementations that identify which object type they can convert.
 
 To specify the scope in which to apply the codecs in the registry, call
@@ -66,10 +66,10 @@ the ``withCodecRegistry`` method on an instance of either a ``MongoDatabase``
 or ``MongoCollection``.
 
 The driver provides the ``DefaultCodecRegistry``, a codec registry that
-includes several ``CodecRegistry`` classes that contain commonly-used
-``Codec`` implementations.
+includes ``CodecRegistry`` classes that contain commonly-used ``Codec`` 
+implementations.
 
-See the code below for an example of how to set the
+See the following code for an example of how to set the
 ``DefaultCodecRegistry`` on the ``MongoDatabase`` instance:
 
 .. code-block:: java
@@ -94,7 +94,7 @@ Insert a Record
 ~~~~~~~~~~~~~~~
 
 After you specify the appropriate codec registry, you can insert a
-``DataStorageRecord`` instance as shown in the code below:
+``DataStorageRecord`` instance as shown in the following code:
 
 .. code-block:: java
 
@@ -108,7 +108,7 @@ Retrieve a Record
 
 After you specify the appropriate codec registry, you can retrieve
 documents as a ``DataStorageRecord`` instances and print them as shown in the
-code below:
+following code:
 
 .. io-code-block::
    :copyable: true

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -65,7 +65,7 @@ You can insert a ``DataStorageRecord`` instance as shown in the following code:
    MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
 
    // insert the record
-   collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+   collection.insertOne(new DataStorageRecord("2TB SSD", 1.71));
 
 Retrieve a Record
 ~~~~~~~~~~~~~~~~~
@@ -89,5 +89,5 @@ as shown in the following code:
    .. output::
       :language: none
 
-      DataStorageRecord[productName=1GB SSD, capacity=8.56]
+      DataStorageRecord[productName=1TB SSD, capacity=1.71]
 

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -35,17 +35,6 @@ In this guide, you can learn how to perform the following tasks:
 
 .. _fundamentals-example-record:
 
-Example Record
---------------
-
-The code examples in this guide reference the following sample record, which
-describes a data storage device:
-
-.. literalinclude:: /includes/fundamentals/code-snippets/records/DataStorageRecord.java
-   :language: java
-   :start-after: start dataStorageRecord
-   :end-before: end dataStorageRecord
-
 Serialize and Deserialize a Record
 ----------------------------------
 
@@ -62,6 +51,17 @@ contains codecs for records and other commonly-used types.
 
    Learn more about how to create and manage codecs from the guide on
    :ref:`<fundamentals-codecs>`.
+
+Example Record
+~~~~~~~~~~~~~~
+
+The code examples in this guide reference the following sample record, which
+describes a data storage device:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/records/DataStorageRecord.java
+   :language: java
+   :start-after: start dataStorageRecord
+   :end-before: end dataStorageRecord
 
 Insert a Record
 ~~~~~~~~~~~~~~~

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -50,10 +50,10 @@ describes a data storage device:
 Serialize and Deserialize a Record
 ----------------------------------
 
-To set up the driver to serialize and deserialize a record, you must provide
-it with logic on how to convert between Java and MongoDB types using
-**codecs**. Codecs define how to encode and decode data between records and
-MongoDB documents, and to which classes or packages the codecs they apply.
+You can provide the driver with instructions on how to serialize and
+deserialize Java and MongoDB types using **codecs**. Codecs define how to
+encode and decode data between records and MongoDB documents, and to which
+classes or packages the codecs apply.
 
 The driver defines methods for the encoding and decoding logic in an interface
 called ``Codec``. It automatically includes the ``DefaultCodecRegistry`` which

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -44,8 +44,8 @@ encode and decode data between records and MongoDB documents, and to which
 classes or packages the codecs apply.
 
 The driver defines methods for the encoding and decoding logic in an interface
-called ``Codec``. It automatically includes the ``DefaultCodecRegistry`` which
-contains codecs for records and other commonly-used types.
+called ``Codec``. By default, the driver includes codecs for several
+commonly-used types.
 
 .. tip::
 

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -59,8 +59,8 @@ called ``Codec``.
 
 .. tip::
 
-   Learn more about how to create and manage custom codecs from the guide on
-   :ref:<fundamentals-codecs>`.
+   Learn more about how to create and manage codecs from the guide on
+   :ref:`<fundamentals-codecs>`.
 
 To identify which codec to use, the driver uses a registry called the
 ``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -111,10 +111,10 @@ documents as a ``DataStorageRecord`` instances and print them as shown in the
 code below:
 
 .. io-code-block::
+   :copyable: true
 
    .. input::
       :language: java
-      :copyable: true
 
       // insert the document
       collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
@@ -126,7 +126,6 @@ code below:
 
    .. output::
       :language: none
-      :copyable: false
 
       DataStorageRecord[productName=1GB SSD, capacity=8.56]
 

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -28,11 +28,10 @@ model data and separate business logic from data representation.
    objects instead. See the :ref:`<fundamentals-pojos>` guide for
    implementation details.
 
-The following sections show how you can perform the following tasks:
+In this guide, you can learn how to perform the following tasks:
 
-- Configure the driver to serialize and deserialize a record.
-- Read data from MongoDB into records.
 - Write data from records into MongoDB.
+- Retrieve documents from MongoDB as records.
 
 .. _fundamentals-example-record:
 

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -21,8 +21,8 @@ model data and separate business logic from data representation.
 
 .. tip::
 
-   You can declare Java records in Java 14 or later. Learn more about the
-   functionality and restrictions of records from `Java 14 Language Updates: Records <https://docs.oracle.com/en/java/javase/14/language/records.html>`__.
+   You can declare Java records in Java 16 or later. Learn more about the
+   functionality and restrictions of records from `Java 17 Language Updates: Record Classes <https://docs.oracle.com/en/java/javase/17/language/records.html>`__.
 
    If you are using an earlier version of Java, you can use plain old Java
    objects instead. See the :ref:`<fundamentals-pojos>` guide for
@@ -38,19 +38,11 @@ In this guide, you can learn how to perform the following tasks:
 Serialize and Deserialize a Record
 ----------------------------------
 
-You can provide the driver with instructions on how to serialize and
-deserialize Java and MongoDB types using **codecs**. Codecs define how to
-encode and decode data between records and MongoDB documents, and to which
-classes or packages the codecs apply.
-
-The driver defines methods for the encoding and decoding logic in an interface
-called ``Codec``. By default, the driver includes codecs for several
-commonly-used types.
-
-.. tip::
-
-   Learn more about how to create and manage codecs from the guide on
-   :ref:`<fundamentals-codecs>`.
+The driver natively supports encoding and decoding Java records for
+MongoDB read and write operations using the **default codec registry**. The
+default codec registry is a collection of classes called **codecs** that
+define how to convert encode and decode Java types.  Learn more about
+codecs and the default codec registry in the guide on :ref:`<fundamentals-codecs>`.
 
 Example Record
 ~~~~~~~~~~~~~~

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -1,0 +1,139 @@
+.. _fundamentals-records:
+
+=============================
+Document Data Format: Records
+=============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+In this guide, you can learn how to store and retrieve data in the {+driver-long+}
+using **Java records**. Java records are a type of Java class that are often
+used to model data and separate business logic from data representation.
+
+.. tip::
+
+   You can declare Java records in Java 14 or later. Learn more about the
+   functionality and restrictions of records from `Java 14 Language Updates: Records <https://docs.oracle.com/en/java/javase/14/language/records.html>`__.
+
+   If you are using an earlier version of Java, you can use plain old Java
+   objects instead. See the :ref:`<fundamentals-pojos>` guide for
+   implementation details.
+
+The following sections show how you can perform the following tasks:
+
+- Configure the driver to serialize and deserialize a record.
+- Read data from MongoDB into records.
+- Write data from records into MongoDB.
+
+.. _fundamentals-example-record:
+
+Example Record
+--------------
+
+The code examples in this guide reference the following sample record which
+describes a data storage device:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/records/DataStorageRecord.java
+   :language: java
+   :start-after: start dataStorageRecord
+   :end-before: end dataStorageRecord
+
+Serialize and Deserialize a Record
+----------------------------------
+
+To set up the driver to serialize and deserialize a record, you need to
+provide it with logic on how to convert between Java and MongoDB types using
+**codecs**. Codecs define how to encode and decode the data between the
+record and MongoDB document and to which record classes or packages the codecs
+they apply. The driver defines methods for the encoding and decoding logic an
+interface called ``Codec``.
+
+In order to identify which codec to use, the driver uses a registry called
+the ``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of
+``Codec`` implementations that identify which object type they can convert.
+
+To specify the scope in which to apply the codecs in the registry, call
+the ``withCodecRegistry`` method on an instance of either a ``MongoDatabase``
+or ``MongoCollection``.
+
+The driver provides the ``DefaultCodecRegistry``, a codec registry that
+includes several ``CodecRegistry`` classes that contain commonly-used
+``Codec`` implementations.
+
+See the code below for an example of how to set the
+``DefaultCodecRegistry`` on the ``MongoDatabase`` instance:
+
+.. code-block:: java
+   :emphasize-lines: 7,8
+
+   import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
+   import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+   // ...
+
+   try (MongoClient mongoClient = MongoClients.create(uri)) {
+       CodecRegistry codecRegistry = fromRegistries(getDefaultCodecRegistry());
+       MongoDatabase database = mongoClient.getDatabase("sample_data").withCodecRegistry(codecRegistry);
+
+       // ...
+   }
+
+The ``DefaultCodecRegistry`` includes a codec that handles record types and
+the fields in a ``DataStorageRecord``.
+
+Insert a Record
+~~~~~~~~~~~~~~~
+
+After you specify the appropriate codec registry, you can insert a
+``DataStorageRecord`` instance as shown in the code below:
+
+.. code-block:: java
+
+   MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
+
+   // insert the document
+   collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+
+Retrieve a Record
+~~~~~~~~~~~~~~~~~
+
+After you specify the appropriate codec registry, you can retrieve
+documents as a ``DataStorageRecord`` instances and print them as shown in the
+code below:
+
+.. io-code-block::
+
+   .. input::
+      :language: java
+      :copyable: true
+
+      // insert the document
+      collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+
+      // return all documents in the collection as records
+      List<DataStorageRecord> records = new ArrayList<DataStorageRecord>();
+      collection.find().into(records);
+      records.forEach(System.out::println);
+
+   .. output::
+      :language: none
+      :copyable: false
+
+      DataStorageRecord[productName=1GB SSD, capacity=8.56]
+
+For more information about the methods and classes mentioned in this section,
+see the following API Documentation:
+
+- `CodecRegistry <{+api+}/apidocs/bson/org/bson/codecs/configuration/CodecRegistry.html>`__
+- `getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html?is-external=true#getDefaultCodecRegistry()>`__
+- `MongoClientSettings.getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getDefaultCodecRegistry()>`__
+

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -112,7 +112,7 @@ Retrieve a Record
 ~~~~~~~~~~~~~~~~~
 
 After you specify the appropriate codec registry, you can retrieve
-documents as a ``DataStorageRecord`` instances and print them as shown in the
+documents as ``DataStorageRecord`` instances and print them as shown in the
 following code:
 
 .. io-code-block::

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -54,8 +54,13 @@ To set up the driver to serialize and deserialize a record, you must provide
 it with logic on how to convert between Java and MongoDB types using
 **codecs**. Codecs define how to encode and decode data between records and
 MongoDB documents, and to which classes or packages the codecs they apply.
-The driver defines methods for the encoding and decoding logic an interface
+The driver defines methods for the encoding and decoding logic in an interface
 called ``Codec``.
+
+.. tip::
+
+   Learn more about how to create and manage custom codecs from the guide on
+   :ref:<fundamentals-codecs>`.
 
 To identify which codec to use, the driver uses a registry called the
 ``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of
@@ -66,7 +71,7 @@ the ``withCodecRegistry`` method on an instance of either a ``MongoDatabase``
 or ``MongoCollection``.
 
 The driver provides the ``DefaultCodecRegistry``, a codec registry that
-includes ``CodecRegistry`` classes that contain commonly-used ``Codec`` 
+includes ``CodecRegistry`` classes that contain commonly-used ``Codec``
 implementations.
 
 See the following code for an example of how to set the

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -28,11 +28,6 @@ model data and separate business logic from data representation.
    objects instead. See the :ref:`<fundamentals-pojos>` guide for
    implementation details.
 
-In this guide, you can learn how to perform the following tasks:
-
-- Write data from records into MongoDB.
-- Retrieve documents from MongoDB as records.
-
 .. _fundamentals-example-record:
 
 Serialize and Deserialize a Record

--- a/source/fundamentals/data-formats/document-data-format-record.txt
+++ b/source/fundamentals/data-formats/document-data-format-record.txt
@@ -54,52 +54,20 @@ To set up the driver to serialize and deserialize a record, you must provide
 it with logic on how to convert between Java and MongoDB types using
 **codecs**. Codecs define how to encode and decode data between records and
 MongoDB documents, and to which classes or packages the codecs they apply.
+
 The driver defines methods for the encoding and decoding logic in an interface
-called ``Codec``.
+called ``Codec``. It automatically includes the ``DefaultCodecRegistry`` which
+contains codecs for records and other commonly-used types.
 
 .. tip::
 
    Learn more about how to create and manage codecs from the guide on
    :ref:`<fundamentals-codecs>`.
 
-To identify which codec to use, the driver uses a registry called the
-``CodecRegistry``. The ``CodecRegistry`` is an immutable collection of
-``Codec`` implementations that identify which object type they can convert.
-
-To specify the scope in which to apply the codecs in the registry, call
-the ``withCodecRegistry`` method on an instance of either a ``MongoDatabase``
-or ``MongoCollection``.
-
-The driver provides the ``DefaultCodecRegistry``, a codec registry that
-includes ``CodecRegistry`` classes that contain commonly-used ``Codec``
-implementations.
-
-See the following code for an example of how to set the
-``DefaultCodecRegistry`` on the ``MongoDatabase`` instance:
-
-.. code-block:: java
-   :emphasize-lines: 7,8
-
-   import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
-   import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-
-   // ...
-
-   try (MongoClient mongoClient = MongoClients.create(uri)) {
-       CodecRegistry codecRegistry = fromRegistries(getDefaultCodecRegistry());
-       MongoDatabase database = mongoClient.getDatabase("sample_data").withCodecRegistry(codecRegistry);
-
-       // ...
-   }
-
-The ``DefaultCodecRegistry`` includes a codec that handles record types and
-the fields in a ``DataStorageRecord``.
-
 Insert a Record
 ~~~~~~~~~~~~~~~
 
-After you specify the appropriate codec registry, you can insert a
-``DataStorageRecord`` instance as shown in the following code:
+You can insert a ``DataStorageRecord`` instance as shown in the following code:
 
 .. code-block:: java
 
@@ -111,9 +79,8 @@ After you specify the appropriate codec registry, you can insert a
 Retrieve a Record
 ~~~~~~~~~~~~~~~~~
 
-After you specify the appropriate codec registry, you can retrieve
-documents as ``DataStorageRecord`` instances and print them as shown in the
-following code:
+You can retrieve documents as ``DataStorageRecord`` instances and print them
+as shown in the following code:
 
 .. io-code-block::
    :copyable: true
@@ -132,10 +99,4 @@ following code:
       :language: none
 
       DataStorageRecord[productName=1GB SSD, capacity=8.56]
-
-For more information about the methods and classes mentioned in this section,
-see the following API documentation:
-
-- `CodecRegistry <{+api+}/apidocs/bson/org/bson/codecs/configuration/CodecRegistry.html>`__
-- `getDefaultCodecRegistry() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.html#getDefaultCodecRegistry()>`__
 

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -1,3 +1,5 @@
+.. _fundamentals-pojo-customization:
+
 ==================
 POJO Customization
 ==================

--- a/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
+++ b/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
@@ -1,0 +1,37 @@
+package fundamentals.codecs.records;
+
+import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bson.codecs.configuration.CodecRegistry;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+
+public class CodecRecordExample {
+    public static void main(String args[]) {
+        CodecRegistry codecRegistry = fromRegistries(getDefaultCodecRegistry());
+
+        // Replace the uri string with your MongoDB deployment's connection string
+        String uri = "<connection uri>";
+        try (MongoClient mongoClient = MongoClients.create(uri)) {
+
+            MongoDatabase database = mongoClient.getDatabase("sample_data").withCodecRegistry(codecRegistry);
+            MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
+
+            // insert the document
+            collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+
+            // return all documents in the collection as records
+            List<DataStorageRecord> records = new ArrayList<DataStorageRecord>();
+            collection.find().into(records);
+            records.forEach(System.out::println);
+        }
+    }
+}

--- a/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
+++ b/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
@@ -1,12 +1,7 @@
 package fundamentals.codecs.records;
 
-import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
-import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-
 import java.util.ArrayList;
 import java.util.List;
-
-import org.bson.codecs.configuration.CodecRegistry;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
@@ -16,13 +11,11 @@ import com.mongodb.client.MongoDatabase;
 
 public class CodecRecordExample {
     public static void main(String args[]) {
-        CodecRegistry codecRegistry = fromRegistries(getDefaultCodecRegistry());
-
         // Replace the uri string with your MongoDB deployment's connection string
         String uri = "<connection uri>";
         try (MongoClient mongoClient = MongoClients.create(uri)) {
 
-            MongoDatabase database = mongoClient.getDatabase("sample_data").withCodecRegistry(codecRegistry);
+            MongoDatabase database = mongoClient.getDatabase("sample_data");
             MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
 
             // insert the document

--- a/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
+++ b/source/includes/fundamentals/code-snippets/records/CodecRecordExample.java
@@ -19,7 +19,7 @@ public class CodecRecordExample {
             MongoCollection<DataStorageRecord> collection = database.getCollection("data_storage_devices", DataStorageRecord.class);
 
             // insert the document
-            collection.insertOne(new DataStorageRecord("1GB SSD", 8.56));
+            collection.insertOne(new DataStorageRecord("2TB SSD", 1.71));
 
             // return all documents in the collection as records
             List<DataStorageRecord> records = new ArrayList<DataStorageRecord>();

--- a/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
+++ b/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
@@ -3,7 +3,6 @@ package fundamentals.codecs.records;
 // start dataStorageRecord
 public record DataStorageRecord(
         String productName,
-        Double capacity
+        double capacity
 ) {}
 // end dataStorageRecord
-

--- a/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
+++ b/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
@@ -6,3 +6,4 @@ public record DataStorageRecord(
         Double capacity
 ) {}
 // end dataStorageRecord
+

--- a/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
+++ b/source/includes/fundamentals/code-snippets/records/DataStorageRecord.java
@@ -1,0 +1,8 @@
+package fundamentals.codecs.records;
+
+// start dataStorageRecord
+public record DataStorageRecord(
+        String productName,
+        Double capacity
+) {}
+// end dataStorageRecord

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -32,7 +32,7 @@ Client-Side Field Level Encryption and Queryable Encryption.
 The bug can cause data corruption when rotating :ref:`Data Encryption Keys <csfle-key-architecture>`
 (DEKs) encrypted with a :ref:`Customer Master Key <csfle-key-architecture>`
 hosted on Google Cloud Key Management Service or Azure
-Key Vault. The bug was present in version 4.7.0 of the driver 
+Key Vault. The bug was present in version 4.7.0 of the driver
 in the ``RewrapManyDataKey`` method and causes the
 loss of your DEKs.
 
@@ -117,7 +117,8 @@ New features of the 4.6 Java driver release include:
   and the `DnsClientProvider <https://mongodb.github.io/mongo-java-driver/4.6/apidocs/mongodb-driver-core/com/mongodb/spi/dns/DnsClientProvider.html>`__
   interface API documentation for more information.
 - Added driver support for encoding and decoding between `Java records <https://docs.oracle.com/en/java/javase/17/language/records.html>`__
-  and BSON documents, which is enabled by default.
+  and BSON documents, which is enabled by default. See :ref:`<fundamentals-records>`
+  for more information.
 
 .. _version-4.5:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

### Changes not directly related to the A/C:
- Removed inaccurate information about withCodecRegistry method existing on MongoClient
- Added ref targets
- Set lowercase "p" in "plain old Java objects"

- JIRA - https://jira.mongodb.org/browse/DOCSP-22293

### Notes to reviewer:
- Given the similarities of the Records Page and the [POJOs page](https://www.mongodb.com/docs/drivers/java/sync/current/fundamentals/data-formats/document-data-format-pojo/), I plan to ticket future work to determine the best way to organize the information to reduce duplication. This page doesn't contain as much detail as the POJOs page, but directs to other pages that should help the reader locate the omitted info.
- Link checker failure is a false positive, created a [JIRA ticket](https://jira.mongodb.org/browse/DOCSP-25158)

### Staging
[Data Format: Records Page](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-22293-java-record-codec-provider/fundamentals/data-formats/document-data-format-record/)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
