### PR TITLE
Syntax highlighting fix

### DIFF
--- a/source/fundamentals/builders/updates.txt
+++ b/source/fundamentals/builders/updates.txt
@@ -12,7 +12,7 @@ Updates Builders
 
 .. _updates-builders:
 
-Overview 
+Overview
 --------
 
 In this guide, you can learn how to specify **updates** using
@@ -44,15 +44,15 @@ type, which you can pass to any method that expects an update argument.
 
    The following examples assume this static import.
 
-The examples in this guide use the following document: 
+The examples in this guide use the following document:
 
 .. code-block:: json
 
    {
-       "_id": 1, 
-       "color": "red", 
-       "qty": 5, 
-       "vendor": [ "A", "D", "M" ], 
+       "_id": 1,
+       "color": "red",
+       "qty": 5,
+       "vendor": [ "A", "D", "M" ],
        "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
 
@@ -67,7 +67,7 @@ Set
 Use the `set() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#set(java.lang.String,TItem)>`__
 method to assign the value of a field in an update operation.
 
-The following example sets the value of the ``qty`` field to "11": 
+The following example sets the value of the ``qty`` field to "11":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -81,10 +81,10 @@ The preceding example updates the original document to the following state:
    :copyable: false
 
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 11, 
-      "vendor": [ "A", "D", "M" ], 
+      "_id": 1,
+      "color": "red",
+      "qty": 11,
+      "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
 
@@ -102,14 +102,14 @@ The following example deletes the ``qty`` field:
    :end-before: end unsetUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "vendor": [ "A", "D", "M" ], 
+      "_id": 1,
+      "color": "red",
+      "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
 
@@ -120,7 +120,7 @@ method to assign the value of a field in an update operation on an
 insert of a document.
 
 The following example sets the value of the ``qty`` field to "5"
-if an upsert resulted in the insert of a document: 
+if an upsert resulted in the insert of a document:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -129,15 +129,15 @@ if an upsert resulted in the insert of a document:
    :end-before: end setOnInsertUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
-      "vendor": [ "A", "D", "M" ], 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
+      "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
 
@@ -151,7 +151,7 @@ Use the `inc() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Upd
 method to increment the value of a numeric field in an update operation.
 
 The following example increments the value of the ``qty`` field by
-"3": 
+"3":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -160,14 +160,14 @@ The following example increments the value of the ``qty`` field by
    :end-before: end incUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 8, 
+      "_id": 1,
+      "color": "red",
+      "qty": 8,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -178,7 +178,7 @@ Use the `mul() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Upd
 method to multiply the value of a numeric field in an update operation.
 
 The following example multiplies the value of the ``qty`` field by
-"2": 
+"2":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -187,14 +187,14 @@ The following example multiplies the value of the ``qty`` field by
    :end-before: end mulUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 10, 
+      "_id": 1,
+      "color": "red",
+      "qty": 10,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -211,17 +211,17 @@ The following example renames the ``qty`` field to "quantity":
    :dedent:
    :start-after: begin renameUpdate
    :end-before: end renameUpdate
-   
+
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
       "_id": 1,
-      "color": "red", 
+      "color": "red",
       "vendor": [ "A", "D", "M" ],
-      "lastModified": { "$date": "2021-03-05T05:00:00Z" }, 
+      "lastModified": { "$date": "2021-03-05T05:00:00Z" },
       "quantity": 5
    }
 
@@ -238,15 +238,15 @@ specified in an update operation.
    :end-before: end minUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 2, 
-      "vendor": [ "A", "D", "M" ], 
+      "_id": 1,
+      "color": "red",
+      "qty": 2,
+      "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
 
@@ -257,7 +257,7 @@ method to update the value of a field with the larger number of the two
 specified in an update operation.
 
 The following example sets the value of the ``qty`` field to the
-maximum of its current value and "8": 
+maximum of its current value and "8":
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -266,14 +266,14 @@ maximum of its current value and "8":
    :end-before: end maxUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
-  :copyable: false
-      
+   :copyable: false
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 8, 
+      "_id": 1,
+      "color": "red",
+      "qty": 8,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -294,14 +294,14 @@ the current date as a BSON date:
    :end-before: end currentDateUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
-  :copyable: false
-      
+   :copyable: false
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-22T21:01:20.027Z" }
    }
@@ -310,7 +310,7 @@ Current Timestamp
 ~~~~~~~~~~~~~~~~~
 Use the `currentTimestamp() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#currentTimestamp(java.lang.String)>`__
 method to assign the value of a field in an update operation to the
-current date as a :manual:`timestamp </reference/bson-types/#timestamps>`. 
+current date as a :manual:`timestamp </reference/bson-types/#timestamps>`.
 
 The following example sets the value of the ``lastModified`` field to
 the current date as a BSON timestamp:
@@ -322,14 +322,14 @@ the current date as a BSON timestamp:
    :end-before: end currentTimestampUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
-  :copyable: false
-      
+   :copyable: false
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$timestamp": { "t": 1616446880, "i": 5 } }
    }
@@ -340,22 +340,22 @@ Use the `bitwiseOr() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/mod
 `bitwiseAnd() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#bitwiseAnd(java.lang.String,int)>`__,
 and `bitwiseXor() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#bitwiseXor(java.lang.String,int)>`__
 methods to perform a bitwise update of the integer value of a field in
-an update operation. 
+an update operation.
 
 The following example performs a bitwise ``AND`` between the number
-"10" and the integer value of the ``qty`` field: 
+"10" and the integer value of the ``qty`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
    :dedent:
    :start-after: begin bitwiseOrUpdate
    :end-before: end bitwiseOrUpdate
-   
+
 The bitwise operation results in 15:
 
 .. code-block:: none
    :copyable: false
-   
+
    0101
    1010
    ----
@@ -365,10 +365,10 @@ The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
+      "_id": 1,
+      "color": "red",
       "qty": 15,
       "vendor": [ "A", "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
@@ -383,10 +383,10 @@ Add to Set
 ~~~~~~~~~~
 Use the `addToSet() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#addToSet(java.lang.String,TItem)>`__
 method to append a value to an array if the value is not already present
-in an update operation. 
+in an update operation.
 
 The following example adds the value "C" to the array value of
-the ``vendor`` field: 
+the ``vendor`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -395,14 +395,14 @@ the ``vendor`` field:
    :end-before: end addToSetUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "A", "D", "M", "C" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -412,10 +412,10 @@ Pop
 Use the `popFirst() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#popFirst(java.lang.String)>`__
 method to remove the first element of an array and the
 `popLast() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#popLast(java.lang.String)>`__
-method to remove the last element of an array in an update operation. 
+method to remove the last element of an array in an update operation.
 
 The following example pops the first element off of the array value
-of the ``vendor`` field:  
+of the ``vendor`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -424,14 +424,14 @@ of the ``vendor`` field:
    :end-before: end popFirstUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "D", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -440,9 +440,9 @@ Pull All
 ~~~~~~~~
 Use the `pullAll() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#pullAll(java.lang.String,java.util.List)>`__
 method to remove all instances of values from an existing array in
-an update operation. 
+an update operation.
 
-The following example removes vendor "A" and "M" from the ``vendor`` array: 
+The following example removes vendor "A" and "M" from the ``vendor`` array:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -451,14 +451,14 @@ The following example removes vendor "A" and "M" from the ``vendor`` array:
    :end-before: end pullAllUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
-  :copyable: false
-      
+   :copyable: false
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "D" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -467,10 +467,10 @@ Pull
 ~~~~
 Use the `pull() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Updates.html#pull(java.lang.String,TItem)>`__
 method to remove all instances of a value from an existing array in
-an update operation. 
+an update operation.
 
 The following example removes the value "D" from the ``vendor``
-array: 
+array:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/Updates.java
    :language: java
@@ -479,14 +479,14 @@ array:
    :end-before: end pullUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
-  :copyable: false
-      
+   :copyable: false
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "A", "M" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -508,11 +508,11 @@ The preceding example updates the original document to the following state:
 
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "red", 
-      "qty": 5, 
+      "_id": 1,
+      "color": "red",
+      "qty": 5,
       "vendor": [ "A", "D", "M", "C" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }
@@ -523,7 +523,7 @@ Combining Multiple Update Operators
 -----------------------------------
 An application can update multiple fields of a single document by
 combining two or more of the update operators described in the preceding
-sections. 
+sections.
 
 The following example increments the value of the ``qty`` field by "6", sets
 the value of the ``color`` field to "purple", and pushes "R" to
@@ -536,14 +536,14 @@ the ``vendor`` field:
    :end-before: end combineUpdate
 
 The preceding example updates the original document to the following state:
-   
+
 .. code-block:: json
    :copyable: false
-      
+
    {
-      "_id": 1, 
-      "color": "purple", 
-      "qty": 11, 
+      "_id": 1,
+      "color": "purple",
+      "qty": 11,
       "vendor": [ "A", "D", "M", "R" ],
       "lastModified": { "$date": "2021-03-05T05:00:00Z" }
    }

--- a/source/fundamentals/collations.txt
+++ b/source/fundamentals/collations.txt
@@ -321,11 +321,11 @@ you start with the following collection of documents:
 
 .. code-block:: json
 
-  { "_id" : 1, "first_name" : "Klara" }
-  { "_id" : 2, "first_name" : "Gunter" }
-  { "_id" : 3, "first_name" : "Günter" }
-  { "_id" : 4, "first_name" : "Jürgen" }
-  { "_id" : 5, "first_name" : "Hannah" }
+   { "_id" : 1, "first_name" : "Klara" }
+   { "_id" : 2, "first_name" : "Gunter" }
+   { "_id" : 3, "first_name" : "Günter" }
+   { "_id" : 4, "first_name" : "Jürgen" }
+   { "_id" : 5, "first_name" : "Hannah" }
 
 In the following examples, we specify the "de@collation=phonebook" locale and
 variant collation. The "de" part of the collation specifies the German
@@ -410,11 +410,11 @@ returns the following update document:
 .. code-block:: none
    :copyable: false
 
-  {
-    lastErrorObject: { updatedExisting: true, n: 1 },
-    value: { _id: 3, first_name: 'Günter' },
-    ok: 1
-  }
+   {
+     lastErrorObject: { updatedExisting: true, n: 1 },
+     value: { _id: 3, first_name: 'Günter' },
+     ok: 1
+   }
 
 For more information about the methods and classes mentioned in this section,
 see the following API Documentation:
@@ -441,9 +441,9 @@ contains the following documents:
 
 .. code-block:: json
 
-  { "_id" : 1, "a" : "16 apples" }
-  { "_id" : 2, "a" : "84 oranges" }
-  { "_id" : 3, "a" : "179 bananas" }
+   { "_id" : 1, "a" : "16 apples" }
+   { "_id" : 2, "a" : "84 oranges" }
+   { "_id" : 3, "a" : "179 bananas" }
 
 In the collation, we set the ``locale`` option to "en" and the
 ``numericOrdering`` option to "true" in order to sort strings based on their

--- a/source/fundamentals/crud/read-operations/limit.txt
+++ b/source/fundamentals/crud/read-operations/limit.txt
@@ -64,25 +64,25 @@ longest books. It first matches all the documents with the query, then sorts on 
 books with shorter lengths. Lastly, it limits the return value to ``3`` documents:
 
 .. code-block:: java
-  :emphasize-lines: 6
+   :emphasize-lines: 6
 
-    import com.mongodb.client.model.Sorts;
+   import com.mongodb.client.model.Sorts;
 
-    // define a cursor that will return the first 3 sorted items
-    MongoCursor<Document> cursor = collection.find()
-        .sort(descending("length"))
-        .limit(3)
-        .iterator();
-    // print out items
-    try {
-        while (cursor.hasNext()) {
-            System.out.println(cursor.next());
-        }
-    }
-    // close the cursor
-    finally {
-        cursor.close();
-    }
+   // define a cursor that will return the first 3 sorted items
+   MongoCursor<Document> cursor = collection.find()
+       .sort(descending("length"))
+       .limit(3)
+       .iterator();
+   // print out items
+   try {
+       while (cursor.hasNext()) {
+           System.out.println(cursor.next());
+       }
+   }
+   // close the cursor
+   finally {
+       cursor.close();
+   }
 
 The preceding code example prints out the following three documents, sorted by
 length:
@@ -113,13 +113,13 @@ To see the next three longest books, append the ``skip()`` method to your
 how many documents the find operation returns:
 
 .. code-block:: java
-  :emphasize-lines: 3, 4
+   :emphasize-lines: 3, 4
 
-    MongoCursor<Document> cursor = collection.find()
-        .sort(ascending("length"))
-        .limit(3)
-        .skip(3)
-        .iterator();
+   MongoCursor<Document> cursor = collection.find()
+       .sort(ascending("length"))
+       .limit(3)
+       .skip(3)
+       .iterator();
 
 This operation returns the documents that describe the fourth through sixth
 longest books:
@@ -127,9 +127,9 @@ longest books:
 .. code-block:: java
    :copyable: false
 
-    Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
-    Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
-    Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
+   Document{{_id=3, title=Atlas Shrugged, author=Rand, length=1088}}
+   Document{{_id=5, title=Cryptonomicon, author=Stephenson, length=918}}
+   Document{{_id=1, title=The Brothers Karamazov, author=Dostoyevsky, length=824}}
 
 You can combine ``skip()`` and ``limit()`` in this way to implement paging for your
 collection, returning only small subsets of the collection at one time.
@@ -146,10 +146,10 @@ collection, returning only small subsets of the collection at one time.
   .. code-block:: java
      :copyable: false
 
-      { type: "computer", data: "1", serial_no: 235235 }
-      { type: "computer", data: "2", serial_no: 235237 }
-      { type: "computer", data: "3", serial_no: 235239 }
-      { type: "computer", data: "4", serial_no: 235241 }
+     { type: "computer", data: "1", serial_no: 235235 }
+     { type: "computer", data: "2", serial_no: 235237 }
+     { type: "computer", data: "3", serial_no: 235239 }
+     { type: "computer", data: "4", serial_no: 235241 }
 
   If you sorted by ``type`` alone, ``sort()`` does not guarantee the same order
   upon return. Appending ``skip()`` and ``limit()`` to the ``sort()``

--- a/source/fundamentals/data-formats/documents.txt
+++ b/source/fundamentals/data-formats/documents.txt
@@ -126,12 +126,12 @@ using the ``getCollection()`` method and call the :doc:`insertOne
 
 .. code-block:: java
 
-  // MongoClient mongoClient = <code to instantiate your client>;
+   // MongoClient mongoClient = <code to instantiate your client>;
 
-  MongoDatabase database = mongoClient.getDatabase("fundamentals_data");
-  MongoCollection<Document> collection = database.getCollection("authors");
+   MongoDatabase database = mongoClient.getDatabase("fundamentals_data");
+   MongoCollection<Document> collection = database.getCollection("authors");
 
-  InsertOneResult result = collection.insertOne(author);
+   InsertOneResult result = collection.insertOne(author);
 
 Once you perform a successful insert, you can retrieve the sample document
 data from the collection using the following code:
@@ -235,7 +235,7 @@ different field types:
 
 To insert this document into a collection, instantiate a collection
 using the ``getCollection()`` method specifying the ``BsonDocument``
-class as the ``documentClass`` parameter. Then, call the 
+class as the ``documentClass`` parameter. Then, call the
 :doc:`insertOne </usage-examples/insertOne>` operation as follows:
 
 .. code-block:: java
@@ -307,10 +307,10 @@ You can customize the format of JSON in ``JsonObject`` by specifying a
 ``JsonObjectCodec`` and passing it a ``JsonWriterSettings``
 object. For more information on JSON formats, see
 our :doc:`Extended JSON guide </fundamentals/data-formats/document-data-format-extended-json/>`.
-For more information on specifying codecs, see our 
+For more information on specifying codecs, see our
 :doc:`Codecs guide </fundamentals/data-formats/codecs>`.
 
-In the following code snippet, we show how to instantiate a sample ``JsonObject`` 
+In the following code snippet, we show how to instantiate a sample ``JsonObject``
 instance wrapping an Extended JSON string containing different types of key value pairs:
 
 .. code-block:: java
@@ -326,7 +326,7 @@ instance wrapping an Extended JSON string containing different types of key valu
 
 To insert this document into a collection, instantiate a collection
 using the ``getCollection()`` method specifying the ``JsonObject`` class
-as the ``documentClass`` parameter. Then, call the 
+as the ``documentClass`` parameter. Then, call the
 :doc:`insertOne </usage-examples/insertOne>` operation as follows:
 
 .. code-block:: java
@@ -338,7 +338,7 @@ as the ``documentClass`` parameter. Then, call the
 
    InsertOneResult result = collection.insertOne(author);
 
-Once you perform a successful insert, you can retrieve the sample JSON data from the 
+Once you perform a successful insert, you can retrieve the sample JSON data from the
 collection. While you can use any class that extends ``Bson`` to specify your query,
 here is how to query your data using a ``JsonObject``:
 
@@ -360,23 +360,23 @@ The output should look something like this:
    query result in extended json format: {"_id": {"$oid": "6035210f35bd203721c3eab8"}, "name": "Gabriel García Márquez", "dateOfDeath": {"$date": "2014-04-17T04:00:00Z"}, "novels": [{"title": "One Hundred Years of Solitude", "yearPublished": 1967}, {"title": "Chronicle of a Death Foretold", "yearPublished": 1981}, {"title": "Love in the Time of Cholera", "yearPublished": 1985}]}
 
 .. tip::
-   
+
    If you would like to work with other formats of JSON strings
    in your application, you can use the ``JsonObjectCodec`` class
    along with ``JsonWriterSettings`` to specify your desired JSON
    format.
-   
+
    The following code example reads and writes
-   to our MongoDB instance using 
+   to our MongoDB instance using
    :manual:`Relaxed mode JSON </reference/mongodb-extended-json/>`
    strings and outputs ``ObjectId`` instances as hex strings:
 
    .. code-block:: java
-  
+
       import static org.bson.codecs.configuration.CodecRegistries.fromCodecs;
- 
+
       // MongoClient mongoClient = <code to instantiate your client>;
-      
+
       MongoDatabase database = mongoClient.getDatabase("fundamentals_data");
       MongoCollection<JsonObject> collection = database.getCollection("authors", JsonObject.class)
               .withCodecRegistry(
@@ -400,9 +400,9 @@ The output should look something like this:
       if (jsonResult != null) {
           System.out.println("query result in relaxed json format: " + jsonResult.getJson());
       }
- 
+
    The output of this code should look something like this:
- 
+
    .. code-block:: none
       :copyable: false
 
@@ -448,7 +448,7 @@ different field types:
 
 To insert this document into a collection, instantiate a collection using
 the ``getCollection()`` method specifying the ``BasicDBObject`` class as
-the ``documentClass`` parameter. Then, call the 
+the ``documentClass`` parameter. Then, call the
 :doc:`insertOne </usage-examples/insertOne>` operation as follows:
 
 .. code-block:: java
@@ -489,7 +489,7 @@ data from the collection using the following code:
    The preceding code sample uses helper methods that check the returned type
    and throw an exception if it is unable to cast the field value.
    You can call the ``get()`` method to retrieve values as type
-   ``Object`` and to skip type checking. 
+   ``Object`` and to skip type checking.
 
 The output should look something like this:
 

--- a/source/fundamentals/data-formats/pojo-customization.txt
+++ b/source/fundamentals/data-formats/pojo-customization.txt
@@ -472,15 +472,15 @@ annotations and example documents that contain the discriminator fields:
 .. code-block:: java
    :emphasize-lines: 1,6
 
-  @BsonDiscriminator(value="AnonymousUser", key="_cls")
-  public class AnonymousUser {
-      // class code
-  }
+   @BsonDiscriminator(value="AnonymousUser", key="_cls")
+   public class AnonymousUser {
+       // class code
+   }
 
-  @BsonDiscriminator(value="RegisteredUser", key="_cls")
-  public class RegisteredUser {
-      // class code
-  }
+   @BsonDiscriminator(value="RegisteredUser", key="_cls")
+   public class RegisteredUser {
+       // class code
+   }
 
 The following shows sample documents created from the preceding POJOs in a
 single MongoDB collection:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

No JIRA ticket

This PR fixes the code-block rST indentation which silently failed to apply syntax highlighting for the specified language. While it's beyond expectations to review each file, to verify the syntax highlighting is applied, you'll need to individually inspect each code block with Chrome Tools for the "java" (or other) style in the code component:

![Screen Shot 2022-11-09 at 6 57 59 PM](https://user-images.githubusercontent.com/52428683/200967498-166afd3e-b097-4c5c-9a59-de999a06153d.png)


Staging:

[Builders: Updates](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/110922-test-highlight-fix/fundamentals/builders/updates/)

[Collations](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/110922-test-highlight-fix/fundamentals/collations/)

[Read Operations: Limit](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/110922-test-highlight-fix/fundamentals/crud/read-operations/limit/)

[POJO Customization](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/110922-test-highlight-fix/fundamentals/data-formats/pojo-customization/)

[Documents](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/110922-test-highlight-fix/fundamentals/data-formats/documents/)




## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
