### PR TITLE
DOCSP-24606: add info about v4.8 server breaking change and upgrading

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -19,6 +19,7 @@ driver = "java"
 driver-long = "MongoDB Java Driver"
 version = "4.8"
 full-version = "{+version+}.0-beta0"
+mdb-server = "MongoDB server"
 
 package-name-org = "mongodb-org"
 api = "https://mongodb.github.io/mongo-java-driver/{+version+}"

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -76,6 +76,14 @@ changes between the current and upgrade versions. For example, if you
 are upgrading the driver from v4.0 to v4.5, address all breaking changes from
 the version after v4.0 including any listed under v4.5.
 
+.. _java-breaking-changes-v4.8:
+
+Version 4.8 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The driver ends support for connecting to MongoDB Server versions v3.4 and
+  earlier. To learn more about this change, see the :ref:`<java-server-release-change-v4.8>`
+  section.
 
 .. _java-breaking-changes-v4.7:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -27,39 +27,15 @@ Before you upgrade, perform the following actions:
   page for this information.
 - Address any breaking changes between the current version of the driver
   your application is using and your planned upgrade version in the
-  section on :ref:`Breaking Changes <java-breaking-changes>` below.
+  section on :ref:`Breaking Changes <java-breaking-changes>` below. To learn
+  more about the MongoDB server release compatibility changes, see the
+  section on :ref:`<java-server-release-changes>`.
 
 .. tip::
 
    To minimize the amount of changes your application may require when
    upgrading driver versions in the future, use the
    :ref:`{+stable-api+} <stable-api-java>`.
-
-.. _java-server-release-changes:
-
-Server Release Compatibility Changes
-------------------------------------
-
-A server release compatibility change is a modification
-to the {+driver-long+} that discontinues support for a set of
-MongoDB server versions.
-
-To learn more about end-of-life MongoDB products,
-see the `Legacy Support Policy <https://www.mongodb.com/support-policy/legacy>`__.
-
-.. _java-server-release-change-v4.8:
-
-Version 4.8 Server Release Support Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-- The v4.8 driver drops support for MongoDB v3.4 and earlier.
-  To use the v4.8 driver, your MongoDB server must be v3.6 or later. To learn
-  how to upgrade your MongoDB server to v3.6, follow the link corresponding
-  to your MongoDB configuration:
-
-  - :ref:`<3.6-upgrade-replica-set>`
-  - :ref:`<3.6-upgrade-standalone>`
-  - :ref:`<3.6-upgrade-sharded-cluster>`
 
 .. _java-breaking-changes:
 
@@ -156,3 +132,31 @@ Version 4.0 Breaking Changes
   any classes that link to the driver against this version or later to ensure
   that they continue to work.
 
+.. _java-server-release-changes:
+
+Server Release Compatibility Changes
+------------------------------------
+
+A server release compatibility change is a modification
+to the {+driver-long+} that discontinues support for a set of
+MongoDB server versions.
+
+The driver discontinues support for a MongoDB server version after it reaches
+end-of-life (EOL).
+
+To learn more about the MongoDB support for EOL products,
+see the `Legacy Support Policy <https://www.mongodb.com/support-policy/legacy>`__.
+
+.. _java-server-release-change-v4.8:
+
+Version 4.8 Server Release Support Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The v4.8 driver drops support for MongoDB server v3.4 and earlier.
+  To use the v4.8 driver, your MongoDB server must be v3.6 or later. To learn
+  how to upgrade your MongoDB server to v3.6, follow the link that corresponds 
+  to your MongoDB deployment configuration:
+
+  - :ref:`<3.6-upgrade-replica-set>`
+  - :ref:`<3.6-upgrade-standalone>`
+  - :ref:`<3.6-upgrade-sharded-cluster>`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -21,15 +21,15 @@ application to upgrade your driver to a new version.
 
 Before you upgrade, perform the following actions:
 
-- Ensure the new version is compatible with the MongoDB server versions
+- Ensure the new version is compatible with the {+mdb-server} versions
   your application connects to and the Java Runtime Environment (JRE) your
   application runs on. See the :ref:`Java Compatibility <java-compatibility-tables>`
   page for this information.
 - Address any breaking changes between the current version of the driver
   your application is using and your planned upgrade version in the
-  section on :ref:`Breaking Changes <java-breaking-changes>` below. To learn
-  more about the MongoDB server release compatibility changes, see the
-  section on :ref:`<java-server-release-changes>`.
+  :ref:`Breaking Changes <java-breaking-changes>` section. To learn
+  more about the {+mdb-server+} release compatibility changes, see the
+  :ref:`<java-server-release-changes>` section.
 
 .. tip::
 
@@ -57,7 +57,7 @@ the version after v4.0 including any listed under v4.5.
 Version 4.8 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- The driver ends support for connecting to MongoDB Server versions v3.4 and
+- The driver ends support for connecting to {+mdb-server+} versions v3.4 and
   earlier. To learn more about this change, see the :ref:`<java-server-release-change-v4.8>`
   section.
 
@@ -139,9 +139,9 @@ Server Release Compatibility Changes
 
 A server release compatibility change is a modification
 to the {+driver-long+} that discontinues support for a set of
-MongoDB server versions.
+{+mdb-server+} versions.
 
-The driver discontinues support for a MongoDB server version after it reaches
+The driver discontinues support for a {+mdb-server+} version after it reaches
 end-of-life (EOL).
 
 To learn more about the MongoDB support for EOL products,
@@ -152,9 +152,9 @@ see the `Legacy Support Policy <https://www.mongodb.com/support-policy/legacy>`_
 Version 4.8 Server Release Support Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- The v4.8 driver drops support for MongoDB server v3.4 and earlier.
-  To use the v4.8 driver, your MongoDB server must be v3.6 or later. To learn
-  how to upgrade your MongoDB server to v3.6, follow the link that corresponds 
+- The v4.8 driver drops support for {+mdb-server+} v3.4 and earlier.
+  To use the v4.8 driver, your {+mdb-server+} must be v3.6 or later. To learn
+  how to upgrade your {+mdb-server+} to v3.6, follow the link that corresponds 
   to your MongoDB deployment configuration:
 
   - :ref:`<3.6-upgrade-replica-set>`

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -32,8 +32,8 @@ What's New in 4.8
 -------------------
 
 The 4.8 driver ends support for MongoDB v3.4 and earlier. To learn
-how to upgrade your driver to v4.8, see
-:ref:`<java-server-release-change-v4.8>`.
+more about breaking changes in this driver version and how to address 
+them, see :ref:`<java-server-release-change-v4.8>`.
 
 .. _version-4.7.1:
 .. _version-4.7:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-24606

Moved Server Release Compatibility changes to the bottom since the driver breaking changes are more common. Made sure that there's a link from the driver version breaking change entry to the server compatibility changes.

Staging:

[What's new](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-24606-3.6-unsupported/whats-new/#what-s-new-in-4.8)
[v4.8 Breaking changes](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-24606-3.6-unsupported/upgrade/#version-4.8-breaking-changes)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
