### PR TITLE
[v4.7] DOCSP-27932: add AWS Lambda connection guide link (#317)

### DIFF
--- a/source/fundamentals/connection.txt
+++ b/source/fundamentals/connection.txt
@@ -4,8 +4,6 @@
 Connection Guide
 ================
 
-.. default-domain:: mongodb
-
 .. toctree::
 
    /fundamentals/connection/connect
@@ -14,6 +12,7 @@ Connection Guide
    /fundamentals/connection/network-compression
    /fundamentals/connection/tls
    /fundamentals/connection/jndi
+   Connect to MongoDB Atlas from AWS Lambda <https://www.mongodb.com/docs/atlas/manage-connections-aws-lambda/>
 
 .. contents:: On this page
    :local:
@@ -34,6 +33,7 @@ sections:
 - :ref:`Enable Network Compression <network-compression>`
 - :ref:`Enable TLS/SSL on a Connection <tls-ssl>`
 - :ref:`Connect to MongoDB Using a JNDI Datasource <jndi>`
+- :atlas:`Connect to MongoDB Atlas from AWS Lambda </manage-connections-aws-lambda/>`
 
 For information about authenticating with a MongoDB instance,
 see :ref:`<authentication-mechanisms>` and :ref:`<enterprise-authentication-mechanisms>`.


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v4.7`:
 - [DOCSP-27932: add AWS Lambda connection guide link (#317)](https://github.com/mongodb/docs-java/pull/317)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)