### PR TITLE
Fix broken API link

### DIFF
--- a/source/fundamentals/crud/read-operations/sort.txt
+++ b/source/fundamentals/crud/read-operations/sort.txt
@@ -390,7 +390,7 @@ following API Documentation:
 - `MongoCollection <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html>`__
 
 For more information, see the
-`Sorts class </apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`__ API Documentation.
+`Sorts class <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Sorts.html>`__ API Documentation.
 See the server manual documentation for more information on the :manual:`$text </reference/operator/query/text/>`
 query operator and the
 :manual:`$meta </reference/operator/aggregation/meta/>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - No official ticket, but related to https://jira.mongodb.org/browse/DOCSP-28477
Staging 

https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/030923-api-link-fix/fundamentals/crud/read-operations/sort/#text-search

> "For more information, see the Sorts class API Documentation."

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
