### PR TITLE
DOCSP-21335 - 4.5.1 Release Note

### DIFF
--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -20,6 +20,7 @@ Learn what's new in:
 * :ref:`Version 4.7.1 <version-4.7.1>`
 * :ref:`Version 4.7.0 <version-4.7.0>`
 * :ref:`Version 4.6 <version-4.6>`
+* :ref:`Version 4.5.1 <version-4.5.1>`
 * :ref:`Version 4.5 <version-4.5>`
 * :ref:`Version 4.4 <version-4.4>`
 * :ref:`Version 4.3 <version-4.3>`
@@ -63,7 +64,7 @@ What's New in 4.8
 
 .. warning:: Breaking Changes in v4.8
 
-   The v4.8 driver contains breaking changes. See :ref:`<java-breaking-changes-v4.8>` 
+   The v4.8 driver contains breaking changes. See :ref:`<java-breaking-changes-v4.8>`
    and :ref:`<java-server-release-change-v4.8>` for more information.
 
 .. important:: Deprecation Notice
@@ -206,6 +207,16 @@ New features of the 4.6 Java driver release include:
   for more information.
 
 .. _version-4.5:
+.. _version-4.5.1:
+
+What's New in 4.5.1
+-------------------
+
+If the DNS server returns an NXDomain error,
+indicating a non-existent domain, the 4.5.1
+driver no longer throws an exception.
+
+.. _version-4.5.0:
 
 What's New in 4.5
 -----------------


### PR DESCRIPTION
Added as release note only (see comments to Jira ticket). 
Modeled on 4.7.1 update on the same page.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-21335
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/docsp-21335-nxdomain-error/whats-new/#std-label-version-4.5.1

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Did you run a spell-check?
- [X] Did you run a grammar-check?
- [X] Are all the links working?
