### PR TITLE
DOCSP-32129: fix ServerAddress placeholder for port parameter

### DIFF
--- a/source/includes/fundamentals/code-snippets/MongoDbAwsAuth.java
+++ b/source/includes/fundamentals/code-snippets/MongoDbAwsAuth.java
@@ -47,7 +47,7 @@ public class MongoDbAwsAuth {
         MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()
                 .applyToClusterSettings(builder ->
-                builder.hosts(Arrays.asList(new ServerAddress("<atlasUri>"))))
+                builder.hosts(Arrays.asList(new ServerAddress("<hostname>"))))
                 .credential(credential)
                 .build());
         // end mongoCredential
@@ -60,7 +60,7 @@ public class MongoDbAwsAuth {
         MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()
                 .applyToClusterSettings(builder ->
-                builder.hosts(Arrays.asList(new ServerAddress("<atlasUri>"))))
+                builder.hosts(Arrays.asList(new ServerAddress("<hostname>"))))
                 .credential(credential)
                 .build());
         // end mechOnlyMongoCredential
@@ -86,7 +86,7 @@ public class MongoDbAwsAuth {
         MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()
                 .applyToClusterSettings(builder ->
-                builder.hosts(Arrays.asList(new ServerAddress("<atlasUri>"))))
+                builder.hosts(Arrays.asList(new ServerAddress("<hostname>"))))
                 .credential(credential)
                 .build());
         // end mongoCredentialSessionTokenCredential

--- a/source/includes/fundamentals/code-snippets/auth-credentials-default.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-default.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .credential(credential)
            .build());
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-gssapi.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-gssapi.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .credential(credential)
            .build());
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-ldap.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-ldap.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .credential(credential)
            .build());
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-sha1.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-sha1.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .credential(credential)
            .build());
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-sha256.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-sha256.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+                   builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .credential(credential)
            .build());
 

--- a/source/includes/fundamentals/code-snippets/auth-credentials-x509.rst
+++ b/source/includes/fundamentals/code-snippets/auth-credentials-x509.rst
@@ -5,7 +5,7 @@
    MongoClient mongoClient = MongoClients.create(
        MongoClientSettings.builder()
            .applyToClusterSettings(builder ->
-               builder.hosts(Arrays.asList(new ServerAddress("<hostname>", "<port>"))))
+               builder.hosts(Arrays.asList(new ServerAddress("<hostname>", <port>))))
            .applyToSslSettings(builder ->
                builder.enabled(true);
                )


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)


JIRA - https://jira.mongodb.org/browse/DOCSP-32129

Note: in some instances, the "atlasUri" placeholder was replaced by "hostname" since an Atlas URI likely contains more information than just the hostname, and would therefore error according to the [API documentation](https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-core/com/mongodb/ServerAddress.html#%3Cinit%3E(java.lang.String)).


Staging:

[Authentication Mechanisms](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-32129-fix-serveraddress-port-placeholder/fundamentals/auth/) - select MongoCredential tab to see the relevant code snippets.

[Enterprise Authentication Mechanisms](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-32129-fix-serveraddress-port-placeholder/fundamentals/enterprise-auth/) - select MongoCredential tab to see the relevant code snippets.




## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
