### PR TITLE
DOCSP-32565: Fix the AWS refresh credentials example

### DIFF
--- a/source/fundamentals/auth.txt
+++ b/source/fundamentals/auth.txt
@@ -489,7 +489,7 @@ that returns new credentials as shown in the following example:
    :dedent:
    :start-after: start refreshCredentials
    :end-before: end refreshCredentials
-   :emphasize-lines: 4-5,9
+   :emphasize-lines: 4-5,8-9
 
 .. note::
 

--- a/source/includes/fundamentals/code-snippets/MongoDbAwsAuth.java
+++ b/source/includes/fundamentals/code-snippets/MongoDbAwsAuth.java
@@ -108,7 +108,7 @@ public class MongoDbAwsAuth {
             return new AwsCredential("<awsKeyId>", "<awsSecretKey>", "<awsSessionToken>");
         };
 
-        MongoCredential credential = MongoCredential.createAwsCredential("<awsKeyId>", "<awsSecretKey>".toCharArray())
+        MongoCredential credential = MongoCredential.createAwsCredential(null, null)
                 .withMechanismProperty(MongoCredential.AWS_CREDENTIAL_PROVIDER_KEY, awsFreshCredentialSupplier);
         MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder()


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-32565
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-32565-correct-refresh-example/fundamentals/auth/#std-label-mongodb-aws-auth-mechanism
Make sure MongoCredential tab is selected and review the last code example.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
