### PR TITLE
091423: fix malformed connection uri on MongoClientSettings page

### DIFF
--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -187,7 +187,7 @@ This example demonstrates specifying a ``ConnectionString``:
       :emphasize-lines: 2,4
 
       MongoClient mongoClient = MongoClients.create(
-         MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb+srv:/<username>:<password>@<hostname>:<port>?connectTimeoutMS(2000)"))
+         MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb+srv://<username>:<password>@<hostname>:<port>/?connectTimeoutMS=2000"))
             .applyToSocketSettings(builder ->
             builder.connectTimeout(5, SECONDS))
             .build());

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -181,7 +181,7 @@ This example demonstrates specifying a ``ConnectionString``:
       :emphasize-lines: 2,4
 
       MongoClient mongoClient = MongoClients.create(
-         MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb+srv://<username>:<password>@<hostname>:<port>/?connectTimeoutMS=2000"))
+         MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb+srv://<username>:<password>@<hostname>:<port>/<auth db>?connectTimeoutMS=2000"))
             .applyToSocketSettings(builder ->
             builder.connectTimeout(5, SECONDS))
             .build());

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -121,13 +121,13 @@ connection behavior:
        | **Default**: ``primary``
 
    * - ``retryReads()``
-     - | Whether the driver should :manual:`retry reads </core/retryable-reads/>`
+     - | Whether the driver performs :manual:`retry reads </core/retryable-reads/>`
          if a network error occurs.
        |
        | **Default**: ``true``
 
    * - ``retryWrites()``
-     - | Whether the driver should :manual:`retry writes </core/retryable-writes/>`
+     - | Whether the driver performs :manual:`retry writes </core/retryable-writes/>`
          if a network error occurs.
        |
        | **Default**: ``true``
@@ -162,12 +162,6 @@ This example demonstrates specifying a ``ConnectionString``:
    :language: java
    :emphasize-lines: 3
    :dedent:
-
-.. tip::
-
-   Each setting has an ``applyConnectionString()`` method. They are
-   rarely needed within the settings, so you should use this method as shown
-   in :ref:`the preceding example <connection-string-example>`.
 
 .. note:: Chain Order
 


### PR DESCRIPTION
# Pull Request Info

- Fixed the format of the connection string in the Chain Order example
- Removed the tip that provided redundant information.
- Vale fixes

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - none
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/091423-fix-malformed-connection-uri/fundamentals/connection/mongoclientsettings/#example

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
