### PR TITLE
DOCSP-33300: Fix aggregation operator links to the manual

### DIFF
--- a/source/fundamentals/aggregation-expression-operations.txt
+++ b/source/fundamentals/aggregation-expression-operations.txt
@@ -311,13 +311,13 @@ using the methods described in this section.
      - :manual:`$filter </reference/operator/aggregation/filter/>`
 
    * - `first() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/mql/MqlArray.html#first()>`__
-     - :manual:`$first </reference/operator/aggregation/first/#array-operator/>`
+     - :manual:`$first </reference/operator/aggregation/first/>`
 
    * - `joinStrings() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/mql/MqlArray.html#joinStrings(java.util.function.Function)>`__
      - :manual:`$concat </reference/operator/aggregation/concat/>`
 
    * - `last() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/mql/MqlArray.html#last()>`__
-     - :manual:`$last </reference/operator/aggregation/last/#array-operator/>`
+     - :manual:`$last </reference/operator/aggregation/last/>`
 
    * - `map() <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/mql/MqlArray.html#map(java.util.function.Function)>`__
      - :manual:`$map </reference/operator/aggregation/map/>`


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

The "$first" and "$last" links in the linked staging site should take you to the correct locations in the Server manual

Note: there are several Vale errors, but skipping for now since this is a quick link fix rather than a content one.

JIRA - https://jira.mongodb.org/browse/DOCSP-33300
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/java/DOCSP-33300-fix-agg-links/fundamentals/aggregation-expression-operations/


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
