### PR TITLE
DOCSP-33234: add vectorSearch builder

### DIFF
--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -981,9 +981,9 @@ Atlas Vector Search
 .. important::
 
    To learn what versions of MongoDB Atlas support this feature, see
-   (TODO: link atlas-vector-search/vector-search-stage/#limitations after those docs are published)
+   :atlas:`/atlas-vector-search/vector-search-stage/#limitations`.
 
-Use the ``vectorSearch()`` method to create a ``$vectorSearch`` (TODO: link to Server manual once updated)
+Use the ``vectorSearch()`` method to create a :atlas:`$vectorSearch </atlas-vector-search/vector-search-stage/>`
 pipeline stage that specifies a **semantic search**. A semantic search is
 a type of search which locates information that is similar in meaning.
 
@@ -1010,4 +1010,4 @@ preceding aggregation pipeline:
    :dedent:
 
 Learn more about this helper from the
-`vectorSearch() <{+api+}/...>`__ (TODO: link to API docs) API documentation.
+`vectorSearch() <{+api+}//apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#vectorSearch(com.mongodb.client.model.search.FieldSearchPath,java.lang.Iterable,java.lang.String,long,long)>`__ API documentation.

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -1010,4 +1010,4 @@ preceding aggregation pipeline:
    :dedent:
 
 Learn more about this helper from the
-`vectorSearch() API <{+api+}/...>`__ (TODO: link to API docs) API documentation.
+`vectorSearch() <{+api+}/...>`__ (TODO: link to API docs) API documentation.

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -119,11 +119,11 @@ pipeline stage that returns literal documents from input values.
 
 .. important::
 
-   If you use a ``$documents`` stage in an aggregation pipeline, it must be the first 
+   If you use a ``$documents`` stage in an aggregation pipeline, it must be the first
    stage in the pipeline.
 
-The following example creates a pipeline stage that creates 
-sample documents with a ``title`` field: 
+The following example creates a pipeline stage that creates
+sample documents with a ``title`` field:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
    :start-after: // begin documents
@@ -133,8 +133,8 @@ sample documents with a ``title`` field:
 
 .. important::
 
-   If you use the ``documents()`` method to provide the input to an aggregation pipeline, 
-   you must call the ``aggregate()`` method on a database instead of on a 
+   If you use the ``documents()`` method to provide the input to an aggregation pipeline,
+   you must call the ``aggregate()`` method on a database instead of on a
    collection.
 
 
@@ -975,3 +975,39 @@ aggregation stage:
 Learn more about this helper from the
 `searchMeta() API documentation <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/Aggregates.html#searchMeta(com.mongodb.client.model.search.SearchCollector)>`__.
 
+Atlas Vector Search
+-------------------
+
+.. important::
+
+   To learn what versions of MongoDB Atlas support this feature, see
+   (TODO: link atlas-vector-search/vector-search-stage/#limitations after those docs are published)
+
+Use the ``vectorSearch()`` method to create a ``$vectorSearch`` (TODO: link to Server manual once updated)
+pipeline stage that specifies a **semantic search**. A semantic search is
+a type of search which locates information that is similar in meaning.
+
+To use this feature, you must set up a vector search index and index your
+vector embeddings.  To learn how set these up in MongoDB Atlas, see
+:atlas:`How to Index Vector Embeddings for Vector Search </atlas-search/field-types/knn-vector/>`.
+
+The following example shows how to build an aggregation  pipeline that uses the
+``vectorSearch()`` and ``project()`` methods to compute a vector search score:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
+   :start-after: // begin vectorSearch
+   :end-before: // end vectorSearch
+   :language: java
+   :dedent:
+
+The following example shows how you can print the score from the result of the
+preceding aggregation pipeline:
+
+.. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java
+   :start-after: // begin vectorSearch-output
+   :end-before: // end vectorSearch-output
+   :language: java
+   :dedent:
+
+Learn more about this helper from the
+`vectorSearch() API <{+api+}/...>`__ (TODO: link to API docs) API documentation.

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -988,10 +988,10 @@ pipeline stage that specifies a **semantic search**. A semantic search is
 a type of search which locates information that is similar in meaning.
 
 To use this feature, you must set up a vector search index and index your
-vector embeddings.  To learn how set these up in MongoDB Atlas, see
+vector embeddings. To learn how set these up in MongoDB Atlas, see
 :atlas:`How to Index Vector Embeddings for Vector Search </atlas-search/field-types/knn-vector/>`.
 
-The following example shows how to build an aggregation  pipeline that uses the
+The following example shows how to build an aggregation pipeline that uses the
 ``vectorSearch()`` and ``project()`` methods to compute a vector search score:
 
 .. literalinclude:: /includes/fundamentals/code-snippets/builders/AggBuilders.java

--- a/source/fundamentals/builders/aggregates.txt
+++ b/source/fundamentals/builders/aggregates.txt
@@ -981,7 +981,8 @@ Atlas Vector Search
 .. important::
 
    To learn what versions of MongoDB Atlas support this feature, see
-   :atlas:`/atlas-vector-search/vector-search-stage/#limitations`.
+   :atlas:`Limitations </atlas-vector-search/vector-search-stage/#limitations>`
+   in the MongoDB Atlas documentation.
 
 Use the ``vectorSearch()`` method to create a :atlas:`$vectorSearch </atlas-vector-search/vector-search-stage/>`
 pipeline stage that specifies a **semantic search**. A semantic search is


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

Note: as mentioned on the ticket, do not merge this until after the feature is released with MongoDB 6.0.11 and 7.0.2.

Note: all the TODOs should be resolved after the API docs are published and before merging.

JIRA - https://jira.mongodb.org/browse/DOCSP-33234
Staging:
- [List of static imports updated](https://preview-mongodbcchomongodb.gatsbyjs.io/java/DOCSP-33234-vector-search/fundamentals/builders/aggregates/#overview)
 - [vectorSearch section](https://preview-mongodbcchomongodb.gatsbyjs.io/java/DOCSP-33234-vector-search/fundamentals/builders/aggregates/#atlas-vector-search)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
