### PR TITLE
DOCSP-31790 update title to alphabetize legacy product menu

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -1,5 +1,5 @@
 name = "java"
-title = "Java Sync"
+title = "Java Sync Driver"
 intersphinx = [
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/drivers/objects.inv",


### PR DESCRIPTION
Hello again @caitlindavey!

Here's the PR for renaming the Java Sync Driver title field in the snooty.toml files so that DOP can set up the legacy menu to pull from that field. Please backport to older versions if we're good to go.

This changes two elements on the page: the top level on the level nav and the breadcrumb verbiage. It was previously just 'Java Sync.'

Here's my [ build log ](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653add743ede3ec1117529cc).

Thanks for your review & merge!
Sarah

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-31790
Staging - https://preview-mongodbsarahemlin.gatsbyjs.io/java/DOCSP-31790/