### PR TITLE
DOCSP-33943: mention dns seedlist default tls setting

### DIFF
--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -44,7 +44,7 @@ using a method in the ``MongoClientSettings.Builder`` class.
    set the ``tls`` or ``ssl`` parameter value to ``false`` it in your
    connection string or ``MongoClientSettings`` instance.
 
-   To learn more about the connection behavior when you use a DNS seedlist,
+   To learn more about connection behavior when you use a DNS seedlist,
    see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`
    section in the Server manual.
 

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -37,6 +37,17 @@ You can enable TLS/SSL for the connection to your MongoDB instance
 in two different ways: through a parameter in your connection string, or
 using a method in the ``MongoClientSettings.Builder`` class.
 
+.. note::
+
+   If you connect by using the DNS seedlist protocol, indicated by the ``+srv``
+   connection string modifier, the driver enables TLS/SSL. To disable it,
+   set the ``tls`` or ``ssl`` parameter value to ``false`` it in your
+   connection string or ``MongoClientSettings`` instance.
+
+   To learn more about the connection behavior when you use a DNS seedlist,
+   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>
+   section in the Server manual.
+
 .. tabs::
 
    .. tab:: ConnectionString

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -39,10 +39,10 @@ using a method in the ``MongoClientSettings.Builder`` class.
 
 .. note::
 
-   If you connect by using the DNS seedlist protocol, indicated by the ``+srv``
-   connection string modifier, the driver enables TLS/SSL. To disable it,
-   set the ``tls`` or ``ssl`` parameter value to ``false`` it in your
-   connection string or ``MongoClientSettings`` instance.
+   If you connect by using the DNS seedlist protocol, indicated by the
+   ``mongodb+srv`` prefix in your connection string, the driver enables
+   TLS/SSL. To disable it, set the ``tls`` or ``ssl`` parameter value to
+   ``false`` in your connection string or ``MongoClientSettings`` instance.
 
    To learn more about connection behavior when you use a DNS seedlist,
    see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`

--- a/source/fundamentals/connection/tls.txt
+++ b/source/fundamentals/connection/tls.txt
@@ -45,7 +45,7 @@ using a method in the ``MongoClientSettings.Builder`` class.
    connection string or ``MongoClientSettings`` instance.
 
    To learn more about the connection behavior when you use a DNS seedlist,
-   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>
+   see the :manual:`SRV Connection Format </reference/connection-string/#std-label-connections-dns-seedlist>`
    section in the Server manual.
 
 .. tabs::


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-33943
Staging - [Enable TLS/SSL](https://preview-mongodbcchomongodb.gatsbyjs.io/java/DOCSP-33943-tls-when-using-seedlist/fundamentals/connection/tls/#enable-tls-ssl)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
