### PR TITLE
DOCSP-35011: ConnectionId class changes

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -57,21 +57,21 @@ the version after v4.0 including any listed under v4.5.
 Version 5.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Several changes were made to the ``ConnectionId`` class.
+- This driver version introduces the following changes to the ``ConnectionId`` class:
   
-  The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
-  parameter instead of type ``int``. Similarly, the constructor now accepts a value of
-  type ``Long`` as its third parameter instead of type ``Integer``. Since this change breaks
-  binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
+  - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
+    parameter instead of type ``int``. Similarly, the constructor now accepts a value of
+    type ``Long`` as its third parameter instead of type ``Integer``. Because this change breaks
+    binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
 
-  The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
-  type ``int``. This change also breaks binary compatibility, so you must recompile any code
-  that calls the ``withServerValue()`` method.
+  - The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
+    type ``int``. This change breaks binary compatibility, so you must recompile any code
+    that calls the ``withServerValue()`` method.
 
-  The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
-  ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
-  ``long`` instead of type ``int``. Since this change breaks both binary and source
-  compatibility, update any source code that uses these methods and rebuild your binary.
+  - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+    ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+    ``long`` instead of type ``int``. Because this change breaks both binary and source
+    compatibility, update any source code that uses these methods and rebuild your binary.
 
 .. _java-breaking-changes-v4.8:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -52,6 +52,27 @@ changes between the current and upgrade versions. For example, if you
 are upgrading the driver from v4.0 to v4.5, address all breaking changes from
 the version after v4.0 including any listed under v4.5.
 
+.. _java-breaking-changes-v5.0:
+
+Version 5.0 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Several changes were made to the ``ConnectionId`` class.
+  
+  The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
+  parameter instead of type ``int``. Similarly, the constructor now accepts a value of
+  type ``Long`` as its third parameter instead of type ``Integer``. Since this change breaks
+  binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
+
+  The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
+  type ``int``. This change also breaks binary compatibility, so you must recompile any code
+  that calls the ``withServerValue()`` method.
+
+  The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+  ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+  ``long`` instead of type ``int``. Since this change breaks both binary and source
+  compatibility, update any source code that uses these methods and rebuild your binary.
+
 .. _java-breaking-changes-v4.8:
 
 Version 4.8 Breaking Changes

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -37,6 +37,16 @@ Learn what's new in:
 .. In addition to the deprecations mentioned in specific driver versions on this
    page, anticipated breaking changes include the following:
 
+.. _version-5.0:
+
+What's New in 5.0
+-----------------
+
+.. warning:: Breaking Changes in v5.0
+
+   The v5.0 driver contains breaking changes. To learn more about these changes,
+   see :ref:`<java-breaking-changes-v5.0>`.
+
 .. _version-4.11:
 
 What's New in 4.11

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -54,16 +54,6 @@ The 5.0 driver release introduces the following features:
   name, or it defaults to ``MULTIPLE`` if you specify more than one
   host.
 
-.. _version-5.0:
-
-What's New in 5.0
------------------
-
-.. warning:: Breaking Changes in v5.0
-
-   The v5.0 driver contains breaking changes. To learn more about these changes,
-   see :ref:`<java-breaking-changes-v5.0>`.
-
 .. _version-4.11:
 
 What's New in 4.11


### PR DESCRIPTION
This is a Java 5.0 ticket.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35011>
Staging:
https://preview-mongodbnorareidy.gatsbyjs.io/java/DOCSP-35011-connectionid-return-types/whats-new/
https://preview-mongodbnorareidy.gatsbyjs.io/java/DOCSP-35011-connectionid-return-types/upgrade/#std-label-java-breaking-changes-v5.0

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
