### PR TITLE
DOCSP-34994: socketsettings parameter types fix

### DIFF
--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -183,7 +183,7 @@ This example demonstrates specifying a ``ConnectionString``:
       MongoClient mongoClient = MongoClients.create(
          MongoClientSettings.builder().applyConnectionString(new ConnectionString("mongodb+srv://<username>:<password>@<hostname>:<port>/<auth db>?connectTimeoutMS=2000"))
             .applyToSocketSettings(builder ->
-            builder.connectTimeout(5, SECONDS))
+            builder.connectTimeout(5L, SECONDS))
             .build());
 
    Since the driver reads the socket settings options last, the driver

--- a/source/fundamentals/connection/mongoclientsettings.txt
+++ b/source/fundamentals/connection/mongoclientsettings.txt
@@ -5,12 +5,18 @@
 Specify MongoClient Settings
 ============================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: java sync, customize, connection, code example
+
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 1
    :class: singlecol
-
 
 Overview
 --------
@@ -524,6 +530,8 @@ to modify the driver's behavior:
      - | Sets the socket's buffer size when sending.
        |
        | **Default**: The operating system default
+
+.. _java-socketsettings-example:
 
 Example
 ~~~~~~~

--- a/source/includes/fundamentals/code-snippets/mcs.java
+++ b/source/includes/fundamentals/code-snippets/mcs.java
@@ -91,8 +91,8 @@ public class MCSettings {
             MongoClient mongoClient = MongoClients.create(
                 MongoClientSettings.builder().applyConnectionString(new ConnectionString("<your connection string>"))
                 .applyToSocketSettings(builder ->
-                    builder.connectTimeout(10, SECONDS)
-                    .readTimeout(15, SECONDS))
+                    builder.connectTimeout(10L, SECONDS)
+                    .readTimeout(15L, SECONDS))
                 .build());
             //end SocketSettings
             mongoClient.listDatabaseNames().forEach(n -> System.out.println(n));

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -67,6 +67,10 @@ Version 5.0 Breaking Changes
   - ``connectTimeout()``
   - ``readTimeout()``
 
+  To view an example that shows how to instantiate a ``SocketSettings``
+  instance by using these methods, see the `SocketSettings Example
+  <java-socketsettings-example>` in the Specify MongoClient Settings guide.
+
 .. _java-breaking-changes-v4.8:
 
 Version 4.8 Breaking Changes

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -67,16 +67,17 @@ Version 5.0 Breaking Changes
   - ``BsonProperty``
   - ``BsonRepresentation``
 
-- The first parameter, which describes the timeout duration, passed to each of
-  the following ``SocketSettings`` builder methods is updated from type
-  ``int`` to ``long``:
+- You must pass a timeout duration, which is the first parameter, to the
+  following ``SocketSettings`` builder methods as a ``long`` type:
 
   - ``connectTimeout()``
   - ``readTimeout()``
 
-  To view an example that shows how to instantiate a ``SocketSettings``
-  instance by using these methods, see the :ref:`SocketSettings Example
-  <java-socketsettings-example>` in the Specify MongoClient Settings guide.
+  Previously, this parameter was of type ``int``. To view an example
+  that shows how to instantiate a ``SocketSettings`` instance by using
+  these methods, see the :ref:`SocketSettings Example
+  <java-socketsettings-example>` in the Specify MongoClient Settings
+  guide.
 
 .. _java-breaking-changes-v4.8:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -67,8 +67,9 @@ Version 5.0 Breaking Changes
   - ``BsonProperty``
   - ``BsonRepresentation``
 
-- The first parameter for each of the following ``SocketSettings`` builder
-  methods is updated from type ``int`` to ``long``:
+- The first parameter, which describes the timeout duration, passed to each of
+  the following ``SocketSettings`` builder methods is updated from type
+  ``int`` to ``long``:
 
   - ``connectTimeout()``
   - ``readTimeout()``

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -4,12 +4,18 @@
 Upgrade Driver Versions
 =======================
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: java sync, backwards compatibility, update
+
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 1
    :class: singlecol
-
 
 Overview
 --------

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -73,7 +73,7 @@ Version 5.0 Breaking Changes
   - ``connectTimeout()``
   - ``readTimeout()``
 
-  Previously, this parameter was of type ``int``. To view an example
+  In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to instantiate a ``SocketSettings`` instance by using
   these methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -74,7 +74,7 @@ Version 5.0 Breaking Changes
   - ``readTimeout()``
 
   To view an example that shows how to instantiate a ``SocketSettings``
-  instance by using these methods, see the `SocketSettings Example
+  instance by using these methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings guide.
 
 .. _java-breaking-changes-v4.8:

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -4,8 +4,6 @@
 Upgrade Driver Versions
 =======================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -51,6 +49,23 @@ introduced them. When upgrading driver versions, address all the breaking
 changes between the current and upgrade versions. For example, if you
 are upgrading the driver from v4.0 to v4.5, address all breaking changes from
 the version after v4.0 including any listed under v4.5.
+
+.. _java-breaking-changes-v5.0:
+
+Version 5.0 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The driver removes the following record annotations:
+  
+  - ``BsonId``
+  - ``BsonProperty``
+  - ``BsonRepresentation``
+
+- The first parameter for each of the following ``SocketSettings`` builder
+  methods is updated from type ``int`` to ``long``:
+
+  - ``connectTimeout()``
+  - ``readTimeout()``
 
 .. _java-breaking-changes-v4.8:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -28,20 +28,18 @@ Learn what's new in:
 * :ref:`Version 4.1 <version-4.1>`
 * :ref:`Version 4.0 <version-4.0>`
 
-.. _upcoming-breaking-changes:
 
-.. Upcoming Breaking Changes
-   -------------------------
-
-.. Relocate these items into the source/upgrade.txt page once they become breaking changes
-
-.. In addition to the deprecations mentioned in specific driver versions on this
-   page, anticipated breaking changes include the following:
 
 .. _version-5.0:
 
 What's New in 5.0
 -----------------
+
+.. warning:: Breaking Changes in v5.0
+
+   This driver version introduces breaking changes. For a list of these changes, see 
+   the :ref:`Version 5.0 Breaking Changes section <java-breaking-changes-v5.0>` in the 
+   Upgrade guide.
 
 The 5.0 driver release introduces the following features:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -4,6 +4,13 @@
 What's New
 ==========
 
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta::
+   :keywords: java sync, backwards compatibility, update, version
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -27,8 +34,6 @@ Learn what's new in:
 * :ref:`Version 4.2 <version-4.2>`
 * :ref:`Version 4.1 <version-4.1>`
 * :ref:`Version 4.0 <version-4.0>`
-
-
 
 .. _version-5.0:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-34994>

**this PR also includes content for the removal described in [DOCSP-34104](https://jira.mongodb.org/browse/DOCSP-34104)**

Staging:
- [whats new](https://preview-mongodbrustagir.gatsbyjs.io/java/DOCSP-34994-clustersettings-types-fix/whats-new/)
- [upgrade guide](https://preview-mongodbrustagir.gatsbyjs.io/java/DOCSP-34994-clustersettings-types-fix/upgrade/)
- [example](https://preview-mongodbrustagir.gatsbyjs.io/java/DOCSP-34994-clustersettings-types-fix/fundamentals/connection/mongoclientsettings/#example-5)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
