### PR TITLE
DOCSP-35304: remove eqFull method

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -98,8 +98,7 @@ Version 5.0 Breaking Changes
 - The driver removes the ``Filters.eqFull()`` method, which allowed you
   to construct an equality filter when performing a vector search.
   You can use the ``Filters.eq()`` method when instantiating a
-  ``VectorSearchOptions`` type as you would when creating any other
-  equality filter, as shown in the following code:
+  ``VectorSearchOptions`` type, as shown in the following code:
 
   .. code-block:: java
      

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -79,6 +79,16 @@ Version 5.0 Breaking Changes
   <java-socketsettings-example>` in the Specify MongoClient Settings
   guide.
 
+- The driver removes the ``Filters.eqFull()`` method, which allowed you
+  to construct an equality filter when performing a vector search.
+  You can use the ``Filters.eq()`` method when instantiating a
+  ``VectorSearchOptions`` type as you would when creating any other
+  equality filter, as shown in the following code:
+
+  .. code-block:: java
+     
+     VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+
 .. _java-breaking-changes-v4.8:
 
 Version 4.8 Breaking Changes

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -77,7 +77,7 @@ Version 5.0 Breaking Changes
     ``long`` instead of type ``int``. Because this change breaks both binary and source
     compatibility, update any source code that uses these methods and rebuild your binary.
 
-- The driver removes the following record annotations:
+- This driver version removes the following record annotations:
   
   - ``BsonId``
   - ``BsonProperty``
@@ -95,7 +95,7 @@ Version 5.0 Breaking Changes
   <java-socketsettings-example>` in the Specify MongoClient Settings
   guide.
 
-- The driver removes the ``Filters.eqFull()`` method, which allowed you
+- This driver version removes the ``Filters.eqFull()`` method, which allowed you
   to construct an equality filter when performing a vector search.
   You can use the ``Filters.eq()`` method when instantiating a
   ``VectorSearchOptions`` type, as shown in the following code:


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35304>
Staging - https://preview-mongodbrustagir.gatsbyjs.io/java/DOCSP-35304-remove-fulleq/upgrade/#version-5.0-breaking-changes

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
