### PR TITLE
011124: fix redirect for connection troubleshooting up to v4.8

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -10,3 +10,4 @@ raw: ${prefix}/master -> ${base}/upcoming/
 [*-master]: ${prefix}/${version}/fundamentals/csfle/ -> ${base}/${version}/fundamentals/encrypt-fields/
 [*-master]: ${prefix}/${version}/fundamentals/crud/write-operations/change-a-document/ -> ${base}/${version}/fundamentals/crud/write-operations/modify/
 [*-v4.10]: ${prefix}/${version}/fundamentals/connection/socks/ -> ${base}/${version}/
+[*-v4.8]: ${prefix}/${version}/connection-troubleshooting/ -> ${base}/${version}/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

I noticed the Connection Troubleshooting page only exists for v4.9 and newer.

JIRA - None
Staging - None

New redirects generated by mut-redirects:
```
Redirect 301 /docs/drivers/java/sync/v4.3/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.3/
Redirect 301 /docs/drivers/java/sync/v4.4/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.4/
Redirect 301 /docs/drivers/java/sync/v4.5/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.5/
Redirect 301 /docs/drivers/java/sync/v4.6/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.6/
Redirect 301 /docs/drivers/java/sync/v4.7/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.7/
Redirect 301 /docs/drivers/java/sync/v4.8/connection-troubleshooting/ https://www.mongodb.com/docs/drivers/java/sync/v4.8/
````


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
