### PR TITLE
[Java] Breaking change for timeout parameters for SocketSettings builder methods

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -61,6 +61,8 @@ the version after v4.0 including any listed under v4.5.
 Version 5.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _java-breaking-changes-v5.0-connectionid:
+
 - This driver version introduces the following changes to the ``ConnectionId`` class:
   
   - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
@@ -78,50 +80,50 @@ Version 5.0 Breaking Changes
     compatibility, update any source code that uses these methods and rebuild
     your binary.
 
-  - The following record annotations from the
-    ``org.bson.codecs.record.annotations`` package are replaced with
-    annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
+- The following record annotations from the
+  ``org.bson.codecs.record.annotations`` package are replaced with
+  annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
+  
+  - ``BsonId``
+  - ``BsonProperty``
+  - ``BsonRepresentation``
+
+- This driver version removes the ``Filters.eqFull()`` method, released
+  exclusively in ``Beta``, which allowed you
+  to construct an equality filter when performing a vector search.
+  You can use the ``Filters.eq()`` method when instantiating a
+  ``VectorSearchOptions`` type, as shown in the following code:
+
+  .. code-block:: java
     
-    - ``BsonId``
-    - ``BsonProperty``
-    - ``BsonRepresentation``
+    VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
 
-  - This driver version removes the ``Filters.eqFull()`` method, released
-    exclusively in ``Beta``, which allowed you
-    to construct an equality filter when performing a vector search.
-    You can use the ``Filters.eq()`` method when instantiating a
-    ``VectorSearchOptions`` type, as shown in the following code:
+- The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+  ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+  ``long`` instead of type ``int``. Because this change breaks both binary and source
+  compatibility, update any source code that uses these methods and rebuild your binary.
 
-    .. code-block:: java
-      
-      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+- You must pass a timeout duration, which is the first parameter, to the
+  following ``SocketSettings`` builder methods as a ``long`` type:
 
-  - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
-    ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
-    ``long`` instead of type ``int``. Because this change breaks both binary and source
-    compatibility, update any source code that uses these methods and rebuild your binary.
+  - ``connectTimeout()``
+  - ``readTimeout()``
 
-  - You must pass a timeout duration, which is the first parameter, to the
-    following ``SocketSettings`` builder methods as a ``long`` type:
+  In earlier versions, this parameter is of type ``int`` for both methods. To view an example
+  that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
+  <java-socketsettings-example>` in the Specify MongoClient Settings
+  guide. This change breaks binary compatibility (requires recompiling) but does not
+  require code changes.
 
-    - ``connectTimeout()``
-    - ``readTimeout()``
+- This driver version removes the ``Filters.eqFull()`` method, released
+  exclusively in ``Beta``, which allowed you
+  to construct an equality filter when performing a vector search.
+  You can use the ``Filters.eq()`` method when instantiating a
+  ``VectorSearchOptions`` type, as shown in the following code:
 
-    In earlier versions, this parameter is of type ``int`` for both methods. To view an example
-    that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
-    <java-socketsettings-example>` in the Specify MongoClient Settings
-    guide. This change breaks binary compatibility (requires recompiling) but does not
-    require code changes.
-
-  - This driver version removes the ``Filters.eqFull()`` method, released
-    exclusively in ``Beta``, which allowed you
-    to construct an equality filter when performing a vector search.
-    You can use the ``Filters.eq()`` method when instantiating a
-    ``VectorSearchOptions`` type, as shown in the following code:
-
-    .. code-block:: java
-      
-      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+  .. code-block:: java
+    
+     VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
 
 .. _java-breaking-changes-v5.0-observables:
 
@@ -139,7 +141,6 @@ Version 5.0 Breaking Changes
   ``ClusterConnectionMode``, making it more consistent by using the specified
   replica set name, regardless of how it is configured. Previously, replica set
   name was only considered if it was set by the connection string.
-<<<<<<< HEAD
 
   For example, the following two code samples both return the value
   ``ClusterConnectionMode.MULTIPLE``, while previously the second one returned
@@ -161,8 +162,6 @@ Version 5.0 Breaking Changes
         .requiredReplicaSetName("replset")
         .build()
         .getMode()
-=======
->>>>>>> 0b9ba11 (VK review)
 
   For example, the following two code samples both return the value
   ``ClusterConnectionMode.MULTIPLE``, while previously the second one returned

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -58,8 +58,8 @@ the version after v4.0 including any listed under v4.5.
 
 .. _java-breaking-changes-v5.0:
 
-  Version 5.0 Breaking Changes
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Version 5.0 Breaking Changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   - This driver version introduces the following changes to the ``ConnectionId`` class:
     

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -78,25 +78,23 @@ Version 5.0 Breaking Changes
     compatibility, update any source code that uses these methods and rebuild
     your binary.
 
-- The following record annotations from the
-  ``org.bson.codecs.record.annotations`` package are replaced with
-  annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
-  
-  - ``BsonId``
-  - ``BsonProperty``
-  - ``BsonRepresentation``
-
-- This driver version removes the ``Filters.eqFull()`` method, released
-  exclusively in ``Beta``, which allowed you
-  to construct an equality filter when performing a vector search.
-  You can use the ``Filters.eq()`` method when instantiating a
-  ``VectorSearchOptions`` type, as shown in the following code:
-
-  .. code-block:: java
+  - The following record annotations from the
+    ``org.bson.codecs.record.annotations`` package are replaced with
+    annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
     
-    VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+    - ``BsonId``
+    - ``BsonProperty``
+    - ``BsonRepresentation``
 
-.. _java-breaking-changes-v5.0-observables:
+  - This driver version removes the ``Filters.eqFull()`` method, released
+    exclusively in ``Beta``, which allowed you
+    to construct an equality filter when performing a vector search.
+    You can use the ``Filters.eq()`` method when instantiating a
+    ``VectorSearchOptions`` type, as shown in the following code:
+
+    .. code-block:: java
+      
+      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
 
   - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
     ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
@@ -113,20 +111,17 @@ Version 5.0 Breaking Changes
     that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
     <java-socketsettings-example>` in the Specify MongoClient Settings
     guide. This change breaks binary compatibility (requires recompiling) but does not
-  require code changes.
+    require code changes.
 
-  This change breaks binary compatibility (requires recompiling) but does not
-  require code changes.
+  - This driver version removes the ``Filters.eqFull()`` method, released
+    exclusively in ``Beta``, which allowed you
+    to construct an equality filter when performing a vector search.
+    You can use the ``Filters.eq()`` method when instantiating a
+    ``VectorSearchOptions`` type, as shown in the following code:
 
-- This driver version removes the ``Filters.eqFull()`` method, released
-  exclusively in ``Beta``, which allowed you
-  to construct an equality filter when performing a vector search.
-  You can use the ``Filters.eq()`` method when instantiating a
-  ``VectorSearchOptions`` type, as shown in the following code:
-
-  .. code-block:: java
-    
-    VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+    .. code-block:: java
+      
+      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
 
 .. _java-breaking-changes-v5.0-observables:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -77,8 +77,7 @@ Version 5.0 Breaking Changes
   - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
     ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
     ``long`` instead of type ``int``. Because this change breaks both binary and source
-    compatibility, update any source code that uses these methods and rebuild
-    your binary.
+    compatibility, update any source code that uses these methods and rebuild your binary.
 
 - The following record annotations from the
   ``org.bson.codecs.record.annotations`` package are replaced with
@@ -112,7 +111,9 @@ Version 5.0 Breaking Changes
   In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings
-  guide. This change breaks binary compatibility (requires recompiling) but does not
+  guide. 
+  
+  This change breaks binary compatibility (requires recompiling) but does not
   require code changes.
 
 - This driver version removes the ``Filters.eqFull()`` method, released

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -164,6 +164,25 @@ Version 5.0 Breaking Changes
 =======
 >>>>>>> 0b9ba11 (VK review)
 
+  For example, the following two code samples return the value ``ClusterConnectionMode.MULTIPLE``
+
+  .. code-block:: java
+
+    ClusterSettings.builder()
+        .applyConnectionString(new ConnectionString("mongodb://127.0.0.1:27017/?replicaSet=replset"))
+        .build()
+        .getMode()
+
+  .. code-block:: java
+
+    ClusterSettings.builder()
+        .hosts(Collections.singletonList(
+                new ServerAddress("127.0.0.1", 27017)
+        ))
+        .requiredReplicaSetName("replset")
+        .build()
+        .getMode()
+
 - This driver changes how ``BsonDecimal128`` values respond to method calls, by
   responding in the same way as ``Decimal128`` values. In particular,
   ``BsonDecimal128.isNumber()`` now returns ``true``, and

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -162,27 +162,6 @@ Version 5.0 Breaking Changes
         .build()
         .getMode()
 
-  For example, the following two code samples both return the value
-  ``ClusterConnectionMode.MULTIPLE``, while previously the second one returned
-  ``ClusterConnectionMode.SINGLE``.
-
-  .. code-block:: java
-
-    ClusterSettings.builder()
-        .applyConnectionString(new ConnectionString("mongodb://127.0.0.1:27017/?replicaSet=replset"))
-        .build()
-        .getMode()
-
-  .. code-block:: java
-
-    ClusterSettings.builder()
-        .hosts(Collections.singletonList(
-                new ServerAddress("127.0.0.1", 27017)
-        ))
-        .requiredReplicaSetName("replset")
-        .build()
-        .getMode()
-
 - This driver changes how ``BsonDecimal128`` values respond to method calls, by
   responding in the same way as ``Decimal128`` values. In particular,
   ``BsonDecimal128.isNumber()`` now returns ``true``, and

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -61,23 +61,23 @@ the version after v4.0 including any listed under v4.5.
 Version 5.0 Breaking Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  - This driver version introduces the following changes to the ``ConnectionId`` class:
-    
-    - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
-      parameter instead of type ``int``. Similarly, the constructor now accepts a value of
-      type ``Long`` as its third parameter instead of type ``Integer``. Because this change breaks
-      binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
+- This driver version introduces the following changes to the ``ConnectionId`` class:
+  
+  - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
+    parameter instead of type ``int``. Similarly, the constructor now accepts a value of
+    type ``Long`` as its third parameter instead of type ``Integer``. Because this change breaks
+    binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
 
-    - The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
-      type ``int``. This change breaks binary compatibility, so you must recompile any code
-      that calls the ``withServerValue()`` method.
+  - The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
+    type ``int``. This change breaks binary compatibility, so you must recompile any code
+    that calls the ``withServerValue()`` method.
 
-    - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
-      ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
-      ``long`` instead of type ``int``. Because this change breaks both binary and source
-      compatibility, update any source code that uses these methods and rebuild your binary.
+  - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+    ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+    ``long`` instead of type ``int``. Because this change breaks both binary and source
+    compatibility, update any source code that uses these methods and rebuild
+    your binary.
 
-<<<<<<< HEAD
 - The following record annotations from the
   ``org.bson.codecs.record.annotations`` package are replaced with
   annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
@@ -85,13 +85,23 @@ Version 5.0 Breaking Changes
   - ``BsonId``
   - ``BsonProperty``
   - ``BsonRepresentation``
-=======
-  - This driver version removes the following record annotations:
+
+- This driver version removes the ``Filters.eqFull()`` method, released
+  exclusively in ``Beta``, which allowed you
+  to construct an equality filter when performing a vector search.
+  You can use the ``Filters.eq()`` method when instantiating a
+  ``VectorSearchOptions`` type, as shown in the following code:
+
+  .. code-block:: java
     
-    - ``BsonId``
-    - ``BsonProperty``
-    - ``BsonRepresentation``
->>>>>>> 33ab215 (tech review)
+    VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+
+.. _java-breaking-changes-v5.0-observables:
+
+  - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+    ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+    ``long`` instead of type ``int``. Because this change breaks both binary and source
+    compatibility, update any source code that uses these methods and rebuild your binary.
 
   - You must pass a timeout duration, which is the first parameter, to the
     following ``SocketSettings`` builder methods as a ``long`` type:
@@ -99,13 +109,10 @@ Version 5.0 Breaking Changes
     - ``connectTimeout()``
     - ``readTimeout()``
 
-<<<<<<< HEAD
-  In earlier versions, this parameter is of type ``int`` for both methods. To view an example
-  that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
-  <java-socketsettings-example>` in the Specify MongoClient Settings
-  guide.
-
-  This change breaks binary compatibility (requires recompiling) but does not
+    In earlier versions, this parameter is of type ``int`` for both methods. To view an example
+    that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
+    <java-socketsettings-example>` in the Specify MongoClient Settings
+    guide. This change breaks binary compatibility (requires recompiling) but does not
   require code changes.
 
 - This driver version removes the ``Filters.eqFull()`` method, released
@@ -117,26 +124,9 @@ Version 5.0 Breaking Changes
   .. code-block:: java
     
     VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
-=======
-    In earlier versions, this parameter is of type ``int`` for both methods. To view an example
-    that shows how to instantiate a ``SocketSettings`` instance by using
-    these methods, see the :ref:`SocketSettings Example
-    <java-socketsettings-example>` in the Specify MongoClient Settings
-    guide.
 
-  - This driver version removes the ``Filters.eqFull()`` method, which allowed you
-    to construct an equality filter when performing a vector search.
-    You can use the ``Filters.eq()`` method when instantiating a
-    ``VectorSearchOptions`` type, as shown in the following code:
+.. _java-breaking-changes-v5.0-observables:
 
-    .. code-block:: java
-      
-      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
->>>>>>> 33ab215 (tech review)
-
-  .. _java-breaking-changes-v5.0-observables:
-
-<<<<<<< HEAD
 - This driver version removes the
   ``org.mongodb.scala.ObservableImplicits.ToSingleObservableVoid`` implicit
   class. This means the ``org.reactivestreams.Publisher[Void]`` type no longer
@@ -146,17 +136,6 @@ Version 5.0 Breaking Changes
   
   .. After the 5.0 Scala API docs are released, this line will be uncommented. 
     For more information, see the `Observable trait documentation <https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongo-scala-driver/org/mongodb/scala/Observable.html>`__.
-=======
-  - This driver version removes the
-    ``org.mongodb.scala.ObservableImplicits.ToSingleObservableVoid`` implicit
-    class. This means the ``org.reactivestreams.Publisher[Void]`` type no longer
-    converts automatically to ``org.mongodb.scala.SingleObservable[Void]``. The also
-    API exposes ``org.mongodb.scala.Observable[Unit]`` instead of
-    ``org.mongodb.scala.Observable[Void]``. 
-    
-    .. After the 5.0 Scala API docs are released, this line will be uncommented. 
-      For more information, see the `Observable trait documentation <https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongo-scala-driver/org/mongodb/scala/Observable.html>`__.
->>>>>>> 33ab215 (tech review)
 
 - This driver changes how ``ClusterSettings`` computes
   ``ClusterConnectionMode``, making it more consistent by using the specified

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -139,6 +139,7 @@ Version 5.0 Breaking Changes
   ``ClusterConnectionMode``, making it more consistent by using the specified
   replica set name, regardless of how it is configured. Previously, replica set
   name was only considered if it was set by the connection string.
+<<<<<<< HEAD
 
   For example, the following two code samples both return the value
   ``ClusterConnectionMode.MULTIPLE``, while previously the second one returned
@@ -160,6 +161,8 @@ Version 5.0 Breaking Changes
         .requiredReplicaSetName("replset")
         .build()
         .getMode()
+=======
+>>>>>>> 0b9ba11 (VK review)
 
 - This driver changes how ``BsonDecimal128`` values respond to method calls, by
   responding in the same way as ``Decimal128`` values. In particular,

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -58,25 +58,26 @@ the version after v4.0 including any listed under v4.5.
 
 .. _java-breaking-changes-v5.0:
 
-Version 5.0 Breaking Changes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  Version 5.0 Breaking Changes
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- This driver version introduces the following changes to the ``ConnectionId`` class:
-  
-  - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
-    parameter instead of type ``int``. Similarly, the constructor now accepts a value of
-    type ``Long`` as its third parameter instead of type ``Integer``. Because this change breaks
-    binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
+  - This driver version introduces the following changes to the ``ConnectionId`` class:
+    
+    - The ``ConnectionId`` constructor now accepts a value of type ``long`` as its second
+      parameter instead of type ``int``. Similarly, the constructor now accepts a value of
+      type ``Long`` as its third parameter instead of type ``Integer``. Because this change breaks
+      binary compatibility, recompile any existing code that calls the ``ConnectionId`` constructor.
 
-  - The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
-    type ``int``. This change breaks binary compatibility, so you must recompile any code
-    that calls the ``withServerValue()`` method.
+    - The ``withServerValue()`` method now accepts a parameter of type ``long`` rather than
+      type ``int``. This change breaks binary compatibility, so you must recompile any code
+      that calls the ``withServerValue()`` method.
 
-  - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
-    ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
-    ``long`` instead of type ``int``. Because this change breaks both binary and source
-    compatibility, update any source code that uses these methods and rebuild your binary.
+    - The ``getServerValue()`` method now returns a value of type ``Long`` instead of type
+      ``Integer``. Similarly, the ``getLocalValue()`` method returns a value of type
+      ``long`` instead of type ``int``. Because this change breaks both binary and source
+      compatibility, update any source code that uses these methods and rebuild your binary.
 
+<<<<<<< HEAD
 - The following record annotations from the
   ``org.bson.codecs.record.annotations`` package are replaced with
   annotations of the same name from the ``org.bson.codecs.pojo.annotations`` package:
@@ -84,13 +85,21 @@ Version 5.0 Breaking Changes
   - ``BsonId``
   - ``BsonProperty``
   - ``BsonRepresentation``
+=======
+  - This driver version removes the following record annotations:
+    
+    - ``BsonId``
+    - ``BsonProperty``
+    - ``BsonRepresentation``
+>>>>>>> 33ab215 (tech review)
 
-- You must pass a timeout duration, which is the first parameter, to the
-  following ``SocketSettings`` builder methods as a ``long`` type:
+  - You must pass a timeout duration, which is the first parameter, to the
+    following ``SocketSettings`` builder methods as a ``long`` type:
 
-  - ``connectTimeout()``
-  - ``readTimeout()``
+    - ``connectTimeout()``
+    - ``readTimeout()``
 
+<<<<<<< HEAD
   In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings
@@ -108,9 +117,26 @@ Version 5.0 Breaking Changes
   .. code-block:: java
     
     VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+=======
+    In earlier versions, this parameter is of type ``int`` for both methods. To view an example
+    that shows how to instantiate a ``SocketSettings`` instance by using
+    these methods, see the :ref:`SocketSettings Example
+    <java-socketsettings-example>` in the Specify MongoClient Settings
+    guide.
 
-.. _java-breaking-changes-v5.0-observables:
+  - This driver version removes the ``Filters.eqFull()`` method, which allowed you
+    to construct an equality filter when performing a vector search.
+    You can use the ``Filters.eq()`` method when instantiating a
+    ``VectorSearchOptions`` type, as shown in the following code:
 
+    .. code-block:: java
+      
+      VectorSearchOptions opts = vectorSearchOptions().filter(eq("x", 8));
+>>>>>>> 33ab215 (tech review)
+
+  .. _java-breaking-changes-v5.0-observables:
+
+<<<<<<< HEAD
 - This driver version removes the
   ``org.mongodb.scala.ObservableImplicits.ToSingleObservableVoid`` implicit
   class. This means the ``org.reactivestreams.Publisher[Void]`` type no longer
@@ -120,6 +146,17 @@ Version 5.0 Breaking Changes
   
   .. After the 5.0 Scala API docs are released, this line will be uncommented. 
     For more information, see the `Observable trait documentation <https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongo-scala-driver/org/mongodb/scala/Observable.html>`__.
+=======
+  - This driver version removes the
+    ``org.mongodb.scala.ObservableImplicits.ToSingleObservableVoid`` implicit
+    class. This means the ``org.reactivestreams.Publisher[Void]`` type no longer
+    converts automatically to ``org.mongodb.scala.SingleObservable[Void]``. The also
+    API exposes ``org.mongodb.scala.Observable[Unit]`` instead of
+    ``org.mongodb.scala.Observable[Void]``. 
+    
+    .. After the 5.0 Scala API docs are released, this line will be uncommented. 
+      For more information, see the `Observable trait documentation <https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongo-scala-driver/org/mongodb/scala/Observable.html>`__.
+>>>>>>> 33ab215 (tech review)
 
 - This driver changes how ``ClusterSettings`` computes
   ``ClusterConnectionMode``, making it more consistent by using the specified

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -115,6 +115,9 @@ Version 5.0 Breaking Changes
     guide. This change breaks binary compatibility (requires recompiling) but does not
   require code changes.
 
+  This change breaks binary compatibility (requires recompiling) but does not
+  require code changes.
+
 - This driver version removes the ``Filters.eqFull()`` method, released
   exclusively in ``Beta``, which allowed you
   to construct an equality filter when performing a vector search.

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -164,7 +164,9 @@ Version 5.0 Breaking Changes
 =======
 >>>>>>> 0b9ba11 (VK review)
 
-  For example, the following two code samples return the value ``ClusterConnectionMode.MULTIPLE``
+  For example, the following two code samples both return the value
+  ``ClusterConnectionMode.MULTIPLE``, while previously the second one returned
+  ``ClusterConnectionMode.SINGLE``.
 
   .. code-block:: java
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -111,8 +111,8 @@ Version 5.0 Breaking Changes
   In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings
-  guide. 
-  
+  guide.
+
   This change breaks binary compatibility (requires recompiling) but does not
   require code changes.
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -111,7 +111,7 @@ Version 5.0 Breaking Changes
   In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings
-  guide. This change breaks binary compatibility (requires recompiling) but does not
+  guide. This change breaks binary compatibility and requires recompiling, but does not
   require code changes.
 
 - This driver version removes the ``Filters.eqFull()`` method, released

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -111,9 +111,7 @@ Version 5.0 Breaking Changes
   In earlier versions, this parameter is of type ``int`` for both methods. To view an example
   that shows how to call ``SocketSettings`` methods, see the :ref:`SocketSettings Example
   <java-socketsettings-example>` in the Specify MongoClient Settings
-  guide.
-
-  This change breaks binary compatibility (requires recompiling) but does not
+  guide. This change breaks binary compatibility (requires recompiling) but does not
   require code changes.
 
 - This driver version removes the ``Filters.eqFull()`` method, released

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,16 +48,14 @@ What's New in 5.0
 
 The 5.0 driver release introduces the following features:
 
-- Consistent computation of the ``ClusterConnectionMode`` type after
-  instantiating a ``ClusterSettings``. The connection mode defaults to
-  ``SINGLE`` if you specify one host and do not specify a replica set
-  name, or it defaults to ``MULTIPLE`` if you specify more than one
-  host.
+- ``ClusterSettings`` computes ``ClusterConnectionMode`` more consistently using
+  the specified replica set name, regardless of how it is configured.
+  Previously, replica set name was only considered if it was set by the
+  connection string.
 
-- ``BsonDecimal128`` values respond to method calls in the same way as Java
-  ``Decimal128`` values. In particular, the error responses for the
-  ``isNumber()`` and ``asNumber()`` methods match the Java responses for
-  equivalent ``Decimal128`` values.
+- ``BsonDecimal128`` values respond to method calls in the same way as
+  ``Decimal128`` values. In particular, ``BsonDecimal128.isNumber`` now returns
+  ``true``, and ``BsonDecimal128.asNumber`` returns the equivalent ``BsonNumber``.
 
 - The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
   includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,15 +48,6 @@ What's New in 5.0
 
 The 5.0 driver release introduces the following features:
 
-- ``ClusterSettings`` computes ``ClusterConnectionMode`` more consistently using
-  the specified replica set name, regardless of how it is configured.
-  Previously, replica set name was only considered if it was set by the
-  connection string.
-
-- ``BsonDecimal128`` values respond to method calls in the same way as
-  ``Decimal128`` values. In particular, ``BsonDecimal128.isNumber`` now returns
-  ``true``, and ``BsonDecimal128.asNumber`` returns the equivalent ``BsonNumber``.
-
 - The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
   includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
   the time returned includes the duration of the

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -64,6 +64,19 @@ The 5.0 driver release introduces the following features:
   This relates to a :ref:`breaking change about Observables in this version
   <java-breaking-changes-v5.0-observables>`.
 
+  - The first parameter, time durations, of the following ``SocketSettings``
+    builder methods is of ``long`` type:
+
+  - ``connectTimeout()``
+  - ``readTimeout()``
+
+  In earlier versions, this parameter is of type ``int`` for both methods. To
+  view an example that shows how to instantiate a ``SocketSettings`` instance by
+  using these methods, see the :ref:`SocketSettings Example
+  <java-socketsettings-example>` in the Specify MongoClient Settings guide. This
+  correlates with a :ref:`binary breaking change
+  <java-breaking-changes-v5.0-socketsettings>`.
+
   - Changes to the ``ConnectionId`` class. To learn more, see the
     :ref:`Version 5.0 Breaking Changes <java-breaking-changes-v5.0>`.
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -37,8 +37,8 @@ Learn what's new in:
 
 .. _version-5.0:
 
-  What's New in 5.0
-  -----------------
+What's New in 5.0
+-----------------
 
   .. warning:: Breaking Changes in v5.0
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -40,40 +40,40 @@ Learn what's new in:
 What's New in 5.0
 -----------------
 
-  .. warning:: Breaking Changes in v5.0
+.. warning:: Breaking Changes in v5.0
 
   This driver version introduces breaking changes. For a list of these changes, see 
   the :ref:`Version 5.0 Breaking Changes section <java-breaking-changes-v5.0>` in the 
   Upgrade guide.
 
-  The 5.0 driver release introduces the following features:
+The 5.0 driver release introduces the following features:
 
-  - Consistent computation of the ``ClusterConnectionMode`` type after
-    instantiating a ``ClusterSettings``. The connection mode defaults to
-    ``SINGLE`` if you specify one host and do not specify a replica set
-    name, or it defaults to ``MULTIPLE`` if you specify more than one
-    host.
+- Consistent computation of the ``ClusterConnectionMode`` type after
+  instantiating a ``ClusterSettings``. The connection mode defaults to
+  ``SINGLE`` if you specify one host and do not specify a replica set
+  name, or it defaults to ``MULTIPLE`` if you specify more than one
+  host.
 
-  - ``BsonDecimal128`` values respond to method calls in the same way as Java
-    ``Decimal128`` values. In particular, the error responses for the
-    ``isNumber()`` and ``asNumber()`` methods match the Java responses for
-    equivalent ``Decimal128`` values.
+- ``BsonDecimal128`` values respond to method calls in the same way as Java
+  ``Decimal128`` values. In particular, the error responses for the
+  ``isNumber()`` and ``asNumber()`` methods match the Java responses for
+  equivalent ``Decimal128`` values.
 
-  - The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
-    includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
-    the time returned includes the duration of the
-    ``com.mongodb.event.ConnectionPoolListener.connectionCreated()`` method.
-    
-    The ``getElapsedTime()`` methods on
-    ``com.mongodb.event.ConnectionCheckedOutFailedEvent`` and
-    ``com.mongodb.event.ConnectionCheckedOutEvent`` include the time taken to
-    deliver the ``com.mongodb.event.ConnectionCheckOutStartedEvent``. That is, the
-    time returned includes the duration of the
-    ``com.mongodb.eventConnectionPoolListener.connectionCheckOutStarted()`` method.
+- The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
+  includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
+  the time returned includes the duration of the
+  ``com.mongodb.event.ConnectionPoolListener.connectionCreated()`` method.
+  
+  The ``getElapsedTime()`` methods on
+  ``com.mongodb.event.ConnectionCheckedOutFailedEvent`` and
+  ``com.mongodb.event.ConnectionCheckedOutEvent`` include the time taken to
+  deliver the ``com.mongodb.event.ConnectionCheckOutStartedEvent``. That is, the
+  time returned includes the duration of the
+  ``com.mongodb.eventConnectionPoolListener.connectionCheckOutStarted()`` method.
 
-  - The ``org.mongodb.scala.Observable.completeWithUnit()`` method is deprecated.
-    This relates to a :ref:`breaking change about Observables in this version
-    <java-breaking-changes-v5.0-observables>`.
+- The ``org.mongodb.scala.Observable.completeWithUnit()`` method is deprecated.
+  This relates to a :ref:`breaking change about Observables in this version
+  <java-breaking-changes-v5.0-observables>`.
 
   - Changes to the ``ConnectionId`` class. To learn more, see the
     :ref:`Version 5.0 Breaking Changes <java-breaking-changes-v5.0>`.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -67,7 +67,7 @@ The 5.0 driver release introduces the following features:
   This relates to a :ref:`breaking change about Observables in this version
   <java-breaking-changes-v5.0-observables>`.
 
-- The first parameter, time durations, of the following ``SocketSettings``
+- The timeout parameters of the following ``SocketSettings``
   builder methods is of ``long`` type:
 
   - ``connectTimeout()``

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -48,6 +48,9 @@ What's New in 5.0
 
 The 5.0 driver release introduces the following features:
 
+- Changes to the ``ConnectionId`` class. To learn more, see the
+  :ref:`breaking change description <java-breaking-changes-v5.0-connectionid>`.
+
 - The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
   includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
   the time returned includes the duration of the
@@ -64,7 +67,7 @@ The 5.0 driver release introduces the following features:
   This relates to a :ref:`breaking change about Observables in this version
   <java-breaking-changes-v5.0-observables>`.
 
-  - The first parameter, time durations, of the following ``SocketSettings``
+- The first parameter, time durations, of the following ``SocketSettings``
     builder methods is of ``long`` type:
 
   - ``connectTimeout()``
@@ -76,9 +79,6 @@ The 5.0 driver release introduces the following features:
   <java-socketsettings-example>` in the Specify MongoClient Settings guide. This
   correlates with a :ref:`binary breaking change
   <java-breaking-changes-v5.0-socketsettings>`.
-
-  - Changes to the ``ConnectionId`` class. To learn more, see the
-    :ref:`Version 5.0 Breaking Changes <java-breaking-changes-v5.0>`.
 
 .. _version-4.11:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -68,7 +68,7 @@ The 5.0 driver release introduces the following features:
   <java-breaking-changes-v5.0-observables>`.
 
 - The first parameter, time durations, of the following ``SocketSettings``
-    builder methods is of ``long`` type:
+  builder methods is of ``long`` type:
 
   - ``connectTimeout()``
   - ``readTimeout()``

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -37,35 +37,46 @@ Learn what's new in:
 
 .. _version-5.0:
 
-What's New in 5.0
------------------
+  What's New in 5.0
+  -----------------
 
-.. warning:: Breaking Changes in v5.0
+  .. warning:: Breaking Changes in v5.0
 
   This driver version introduces breaking changes. For a list of these changes, see 
   the :ref:`Version 5.0 Breaking Changes section <java-breaking-changes-v5.0>` in the 
   Upgrade guide.
 
-The 5.0 driver release introduces the following features:
+  The 5.0 driver release introduces the following features:
 
-- The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
-  includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
-  the time returned includes the duration of the
-  ``com.mongodb.event.ConnectionPoolListener.connectionCreated()`` method.
-  
-  The ``getElapsedTime()`` methods on
-  ``com.mongodb.event.ConnectionCheckedOutFailedEvent`` and
-  ``com.mongodb.event.ConnectionCheckedOutEvent`` include the time taken to
-  deliver the ``com.mongodb.event.ConnectionCheckOutStartedEvent``. That is, the
-  time returned includes the duration of the
-  ``com.mongodb.eventConnectionPoolListener.connectionCheckOutStarted()`` method.
+  - Consistent computation of the ``ClusterConnectionMode`` type after
+    instantiating a ``ClusterSettings``. The connection mode defaults to
+    ``SINGLE`` if you specify one host and do not specify a replica set
+    name, or it defaults to ``MULTIPLE`` if you specify more than one
+    host.
 
-- The ``org.mongodb.scala.Observable.completeWithUnit()`` method is deprecated.
-  This relates to a :ref:`breaking change about Observables in this version
-  <java-breaking-changes-v5.0-observables>`.
+  - ``BsonDecimal128`` values respond to method calls in the same way as Java
+    ``Decimal128`` values. In particular, the error responses for the
+    ``isNumber()`` and ``asNumber()`` methods match the Java responses for
+    equivalent ``Decimal128`` values.
 
-- Changes to the ``ConnectionId`` class. To learn more, see the
-  :ref:`Version 5.0 Breaking Changes <java-breaking-changes-v5.0>`.
+  - The ``getElapsedTime()`` method on ``com.mongodb.event.ConnectionReadyEvent``
+    includes the time taken to deliver the ``ConnectionCreatedEvent``. That is,
+    the time returned includes the duration of the
+    ``com.mongodb.event.ConnectionPoolListener.connectionCreated()`` method.
+    
+    The ``getElapsedTime()`` methods on
+    ``com.mongodb.event.ConnectionCheckedOutFailedEvent`` and
+    ``com.mongodb.event.ConnectionCheckedOutEvent`` include the time taken to
+    deliver the ``com.mongodb.event.ConnectionCheckOutStartedEvent``. That is, the
+    time returned includes the duration of the
+    ``com.mongodb.eventConnectionPoolListener.connectionCheckOutStarted()`` method.
+
+  - The ``org.mongodb.scala.Observable.completeWithUnit()`` method is deprecated.
+    This relates to a :ref:`breaking change about Observables in this version
+    <java-breaking-changes-v5.0-observables>`.
+
+  - Changes to the ``ConnectionId`` class. To learn more, see the
+    :ref:`Version 5.0 Breaking Changes <java-breaking-changes-v5.0>`.
 
 .. _version-4.11:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35763>
Staging
 - [What's New](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-35763/whats-new/)
 - [Breaking Changes](https://docs-mongodbcom-staging.corp.mongodb.com/java/docsworker-xlarge/DOCSP-35763/upgrade/#version-5.0-breaking-changes)

This includes a few weird changes that are artifacts from a rebase.

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
