### PR TITLE
DOCSP-40537 Optional delimiting slash in connection string

### DIFF
--- a/source/fundamentals/connection/connect.txt
+++ b/source/fundamentals/connection/connect.txt
@@ -178,7 +178,7 @@ class. Select the tab that corresponds to your preferred class.
 
       .. code-block:: java
 
-         ConnectionString connectionString = new ConnectionString("mongodb://host1:27017,host2:27017,host3:27017/");
+         ConnectionString connectionString = new ConnectionString("mongodb://host1:27017,host2:27017,host3:27017");
          MongoClient mongoClient = MongoClients.create(connectionString);
 
    .. tab:: MongoClientSettings

--- a/source/fundamentals/connection/connect.txt
+++ b/source/fundamentals/connection/connect.txt
@@ -4,6 +4,13 @@
 Connect to MongoDB
 ==================
 
+.. facet::
+   :name: genre
+   :values: reference
+ 
+.. meta::
+   :keywords: connection string, URI, Atlas, code example
+
 In this guide, you can learn how to connect to a 
 `MongoDB Atlas deployment <https://www.mongodb.com/docs/atlas>`__, 
 a MongoDB instance, or a replica set using the {+driver-short+}.

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -19,6 +19,7 @@ What's New
 
 Learn what's new in:
 
+* :ref:`Version 5.2 <version-5.2>`
 * :ref:`Version 5.1 <version-5.1>`
 * :ref:`Version 5.0 <version-5.0>`
 * :ref:`Version 4.11 <version-4.11>`
@@ -35,6 +36,25 @@ Learn what's new in:
 * :ref:`Version 4.2 <version-4.2>`
 * :ref:`Version 4.1 <version-4.1>`
 * :ref:`Version 4.0 <version-4.0>`
+
+.. _version-5.2:
+
+What's New in 5.2
+-----------------
+
+New features of the 5.2 driver release include:
+
+- A forward-slash (``/``) between the hosts and client options in a
+  connection URI is optional. The driver parses the following connection URI
+  examples in the same way:
+
+  .. code-block:: java
+     
+     // Connection URI with delimiting forward-slash
+     String uri = "mongodb://example.com/?w=majority";
+
+     // Connection URI without delimiting forward-slash
+     String uri = "mongodb://example.com?w=majority";
 
 .. _version-5.1:
 

--- a/source/whats-new.txt
+++ b/source/whats-new.txt
@@ -44,7 +44,7 @@ What's New in 5.2
 
 New features of the 5.2 driver release include:
 
-- A forward-slash (``/``) between the hosts and client options in a
+- A forward-slash (``/``) character between the host names and client options in a
   connection URI is optional. The driver parses the following connection URI
   examples in the same way:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-40537
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/java/DOCSP-40537-connection-optional-slash/whats-new/#std-label-version-5.2

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
