### PR TITLE
DOCSP-43565: Update Indexes page to clarify Vector Search Indexes use the plural create method

### DIFF
--- a/source/fundamentals/indexes.txt
+++ b/source/fundamentals/indexes.txt
@@ -225,7 +225,7 @@ embeddings stored in MongoDB Atlas. To learn more about Atlas Vector Search, see
 You can call the following methods on a collection to manage your Atlas
 Search and Vector Search indexes:
 
-- ``createSearchIndex()``
+- ``createSearchIndex()`` *(valid for Search indexes only)*
 - ``createSearchIndexes()``
 - ``listSearchIndexes()``
 - ``updateSearchIndex()``
@@ -244,10 +244,10 @@ each of the preceding methods.
 Create a Search Index
 +++++++++++++++++++++
 
-You can use the `createSearchIndex() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createSearchIndex(org.bson.conversions.Bson)>`__
-and the
-`createSearchIndexes() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createSearchIndexes(java.util.List)>`__
-methods to create Atlas Search and Vector Search indexes.
+You can use the `createSearchIndex()
+<{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createSearchIndex(org.bson.conversions.Bson)>`__
+method to create an Atlas Search index. You *cannot* use this method to create a
+Vector Search index at this time.
 
 The following code example shows how to create an Atlas Search index:
 
@@ -257,7 +257,10 @@ The following code example shows how to create an Atlas Search index:
    :start-after: start create-search-index
    :end-before: end create-search-index
 
-To create multiple Search or Vector Search indexes, you must create a
+You can use the
+`createSearchIndexes() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#createSearchIndexes(java.util.List)>`__
+method to create multiple Atlas Search indexes or one or more Vector Search
+indexes. You must create and pass a
 `SearchIndexModel
 <{+api+}/apidocs/mongodb-driver-core/com/mongodb/client/model/SearchIndexModel.html>`__
 instance for each index.
@@ -606,4 +609,5 @@ For prior versions of MongoDB, pass "*" as a parameter to your call to
 For more information about the methods in this section, see the following API Documentation:
 
 - `dropIndex() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#dropIndex(java.lang.String)>`__
-- `dropIndexes() <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#dropIndexes()>`__
+- `dropIndexes()
+  <{+api+}/apidocs/mongodb-driver-sync/com/mongodb/client/MongoCollection.html#dropIndexes()>`__


### PR DESCRIPTION
Engineering confirmed that the `createSearchIndex()` method does not create a `"type": "vector"` search index. You must use the plural `createSearchIndexes()` and pass a `SearchIndexModel`.

> Note: If these updates look okay, I'll make a dupe PR for the Kotlin page

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-43565>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
