### PR TITLE
DOCSP-29939 Codec example fix

### DIFF
--- a/source/fundamentals/data-formats/codecs.txt
+++ b/source/fundamentals/data-formats/codecs.txt
@@ -176,7 +176,7 @@ from the prior example using the following code:
 .. code-block:: java
    :copyable: true
 
-   Codec<String> powerStatusCodec = codecRegistry.get(String.class);
+   Codec<PowerStatus> powerStatusCodec = codecRegistry.get(PowerStatus.class);
    Codec<Integer> integerCodec = codecRegistry.get(Integer.class);
 
 If you attempt to retrieve a ``Codec`` instance for a class that is not


### PR DESCRIPTION
# Pull Request Info

After investigating this ticket with the Java engineer, the decision was to leave the codec example as-is, but fix a bug on the page

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-29939
Staging - https://deploy-preview-605--docs-java.netlify.app/fundamentals/data-formats/codecs/#codecregistry

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
