### PR TITLE
Add missing meta descriptions

### DIFF
--- a/source/integrations.txt
+++ b/source/integrations.txt
@@ -10,6 +10,7 @@ Third-Party Integrations
 
 .. meta::
    :keywords: java sync, third party, tools, frameworks
+   :description: Explore how to integrate the Java driver with frameworks like Spring Data, Quarkus, and Micronaut for developing applications.
 
 .. contents:: On this page
    :local:

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -10,6 +10,7 @@ Issues & Help
 
 .. meta::
    :keywords: java sync, troubleshooting, feedback
+   :description: Find support for the Java driver through community forums, report bugs or feature requests via Jira, and contribute to the driver with pull requests.
 
 .. contents:: On this page
    :local:

--- a/source/issues-and-help.txt
+++ b/source/issues-and-help.txt
@@ -10,7 +10,7 @@ Issues & Help
 
 .. meta::
    :keywords: java sync, troubleshooting, feedback
-   :description: Find support for the Java driver through community forums, report bugs or feature requests via Jira, and contribute to the driver with pull requests.
+   :description: Find support for the Java Sync driver through community forums, report bugs or feature requests via Jira, and learn how to contribute to the driver.
 
 .. contents:: On this page
    :local:


### PR DESCRIPTION
Adds missing meta descriptions generated by the Education AI Team\n\nSOURCE: https://docs.google.com/spreadsheets/d/1fdrjF4Ms9fMl96zLiLGsYD_V38rTfPLuKs5VQk4vz6E/edit?gid=1166644539