### PR TITLE
DOCSP-49143 - Remove duplicate H1s

### DIFF
--- a/source/security/encrypt-fields.txt
+++ b/source/security/encrypt-fields.txt
@@ -26,22 +26,3 @@
                :tabid: gradle-dependency
          
                .. include:: /includes/fundamentals/code-snippets/crypt-gradle-versioned.rst
-
-Connection Settings
--------------------
-
-You can apply encryption settings when creating a ``MongoClient`` instance by
-passing an `AutoEncryptionSettings
-<{+core-api+}/AutoEncryptionSettings.html>`__
-object to the `autoEncryptionSettings()
-<{+core-api+}/MongoClientSettings.Builder.html#autoEncryptionSettings(com.mongodb.AutoEncryptionSettings)>`__
-method.
-
-.. TODO: Add example
-
-.. note:: 
-
-   If you omit ``keyVaultClient`` or set ``bypassAutomaticEncryption`` to false
-   in your ``AutoEncryptionSettings``, the driver creates a separate, internal
-   ``MongoClient``. The internal ``MongoClient`` configuration differs from the
-   parent ``MongoClient`` by setting the ``minPoolSize`` to  0 and omitting the ``AutoEncryptionSettings``. 


### PR DESCRIPTION
Moved QE Connection Settings to Server docs ([PR](https://github.com/10gen/docs-mongodb-internal/pull/11665))

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-java/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-49143>

### Staging Links
<!-- start insert-links -->
<li><a href=https://deploy-preview-673--docs-java.netlify.app/security/encrypt-fields>security/encrypt-fields</a></li>
<!-- end insert-links -->

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
- [x] Are the page titles greater than 20 characters long and [SEO relevant](https://docs.google.com/spreadsheets/d/1Wkt0-5z04KmcMNscN5bjUKnzwWAtMq9VESp-Lz6r2o8/edit?usp=sharing)?
