### PR TITLE
[v5.5] DOCSP-50736 update title Java Codec

### DIFF
--- a/source/data-formats/codecs.txt
+++ b/source/data-formats/codecs.txt
@@ -1,8 +1,8 @@
 .. _fundamentals-codecs:
 
-======
-Codecs
-======
+============================
+Encode Data with Type Codecs
+============================
 
 .. facet::
    :name: genre


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.5`:
 - [DOCSP-50736 update title Java Codec](https://github.com/mongodb/docs-java/pull/716)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)