### PR TITLE
[v5.5] Merge pull request #718 from mballard-mdb/DOCSP-50728-duplicate-metadata-bulk

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -12,8 +12,8 @@ raw: ${prefix}/master -> ${base}/upcoming/
 
 # TOC evolution redirects
 
-[v5.0-*]: ${prefix}/${version}/fundamentals/crud/ -> ${base}/${version}/crud/
-[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/ -> ${base}/${version}/crud/query-documents/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/ -> ${base}/${version}/get-started/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/ -> ${base}/${version}/crud/specify-query/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/retrieve/ -> ${base}/${version}/crud/query-documents/find/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/cursor/ -> ${base}/${version}/crud/query-documents/cursor/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/change-streams/ -> ${base}/${version}/logging-monitoring/change-streams/
@@ -25,13 +25,34 @@ raw: ${prefix}/master -> ${base}/upcoming/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/text/ -> ${base}/${version}/crud/query-documents/text/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/ -> ${base}/${version}/crud/insert/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/insert/ -> ${base}/${version}/crud/insert/
-[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/delete/ -> ${base}/${version}/crud/update-documents/delete/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/delete/ -> ${base}/${version}/crud/delete/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/modify/ -> ${base}/${version}/crud/update-documents/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/embedded-arrays/ -> ${base}/${version}/crud/update-documents/embedded-arrays/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/upsert/ -> ${base}/${version}/crud/update-documents/upsert/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/bulk/ -> ${base}/${version}/crud/bulk/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/query-document/ -> ${base}/${version}/crud/query-documents/specify-query/
 [v5.0-*]: ${prefix}/${version}/fundamentals/crud/compound-operations/ -> ${base}/${version}/crud/compound-operations/
+
+[v5.0-*]: ${prefix}/${version}/crud/ -> ${base}/${version}/get-started/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/ -> ${base}/${version}/crud/specify-query/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/retrieve/ -> ${base}/${version}/crud/query-documents/find/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/cursor/ -> ${base}/${version}/crud/query-documents/cursor/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/change-streams/ -> ${base}/${version}/logging-monitoring/change-streams/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/sort/ -> ${base}/${version}/crud/query-documents/sort/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/skip/ -> ${base}/${version}/crud/query-documents/skip/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/limit/ -> ${base}/${version}/crud/query-documents/limit/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/project/ -> ${base}/${version}/crud/query-documents/project/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/geo/ -> ${base}/${version}/crud/query-documents/geo/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/text/ -> ${base}/${version}/crud/query-documents/text/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/insert/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/delete/ -> ${base}/${version}/crud/delete/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/modify/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/embedded-arrays/ -> ${base}/${version}/crud/update-documents/embedded-arrays/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/upsert/ -> ${base}/${version}/crud/update-documents/upsert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/bulk/ -> ${base}/${version}/crud/bulk/
+[v5.0-*]: ${prefix}/${version}/crud/query-document/ -> ${base}/${version}/crud/query-documents/specify-query/
+[v5.0-*]: ${prefix}/${version}/crud/compound-operations/ -> ${base}/${version}/crud/compound-operations/
 
 [v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/ -> ${base}/${version}/data-formats/
 [v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-bson/ -> ${base}/${version}/data-formats/document-data-format-bson/


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.5`:
 - [Merge pull request #718 from mballard-mdb/DOCSP-50728-duplicate-metadata-bulk](https://github.com/mongodb/docs-java/pull/718)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)