### PR TITLE
[v5.4] Merge pull request #718 from mballard-mdb/DOCSP-50728-duplicate-metadata-bulk

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -14,62 +14,116 @@ raw: ${prefix}/master -> ${base}/upcoming/
 
 # TOC evolution redirects
 
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/ -> ${base}/${version}/crud/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/ -> ${base}/${version}/crud/query-documents/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/retrieve/ -> ${base}/${version}/crud/query-documents/find/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/cursor/ -> ${base}/${version}/crud/query-documents/cursor/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/change-streams/ -> ${base}/${version}/logging-monitoring/change-streams/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/sort/ -> ${base}/${version}/crud/query-documents/sort/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/skip/ -> ${base}/${version}/crud/query-documents/skip/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/limit/ -> ${base}/${version}/crud/query-documents/limit/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/project/ -> ${base}/${version}/crud/query-documents/project/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/geo/ -> ${base}/${version}/crud/query-documents/geo/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/read-operations/text/ -> ${base}/${version}/crud/query-documents/text/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/ -> ${base}/${version}/crud/insert/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/insert/ -> ${base}/${version}/crud/insert/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/delete/ -> ${base}/${version}/crud/update-documents/delete/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/modify/ -> ${base}/${version}/crud/update-documents/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/embedded-arrays/ -> ${base}/${version}/crud/update-documents/embedded-arrays/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/upsert/ -> ${base}/${version}/crud/update-documents/upsert/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/write-operations/bulk/ -> ${base}/${version}/crud/bulk/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/query-document/ -> ${base}/${version}/crud/query-documents/specify-query/
-[v5.0-master]: ${prefix}/${version}/fundamentals/crud/compound-operations/ -> ${base}/${version}/crud/compound-operations/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/ -> ${base}/${version}/data-formats/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-bson/ -> ${base}/${version}/data-formats/document-data-format-bson/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-extended-json/ -> ${base}/${version}/data-formats/document-data-format-extended-json/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/documents/ -> ${base}/${version}/data-formats/documents/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-pojo/ -> ${base}/${version}/data-formats/document-data-format-pojo/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-record/ -> ${base}/${version}/data-formats/document-data-format-record/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/pojo-customization/ -> ${base}/${version}/data-formats/pojo-customization/
-[v5.0-master]: ${prefix}/${version}/fundamentals/data-formats/codecs/ -> ${base}/${version}/data-formats/codecs/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/ -> ${base}/${version}/connection/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/connect/ -> ${base}/${version}/connection/mongoclient
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/connection-options/ -> ${base}/${version}/connection/connection-options/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/mongoclientsettings/ -> ${base}/${version}/connection/mongoclientsettings/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/network-compression/ -> ${base}/${version}/connection/network-compression/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/socks/ -> ${base}/${version}/connection/socks/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/tls/ -> ${base}/${version}/security/tls/
-[v5.0-master]: ${prefix}/${version}/fundamentals/connection/jndi/ -> ${base}/${version}/connection/jndi/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/ -> ${base}/${version}/builders/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/aggregates/ -> ${base}/${version}/builders/aggregates/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/filters/ -> ${base}/${version}/builders/filters/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/indexes/ -> ${base}/${version}/builders/indexes/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/projections/ -> ${base}/${version}/builders/projections/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/sort/ -> ${base}/${version}/builders/sort/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/updates/ -> ${base}/${version}/builders/updates/
-[v5.0-master]: ${prefix}/${version}/fundamentals/builders/vector-search -> ${base}/${version}/atlas-vector-search/
-[v5.0-master]: ${prefix}/${version}/fundamentals/aggregation/ -> ${base}/${version}/aggregation/
-[v5.0-master]: ${prefix}/${version}/fundamentals/aggregation-expression-operations/ -> ${base}/${version}/aggregation/aggregation-expression-operations/
-[v5.0-master]: ${prefix}/${version}/fundamentals/collations/ -> ${base}/${version}/crud/collations/
-[v5.0-master]: ${prefix}/${version}/fundamentals/stable-api/ -> ${base}/${version}/connection/stable-api/
-[v5.0-master]: ${prefix}/${version}/connection-troubleshooting/ -> ${base}/${version}/connection/connection-troubleshooting/
-[v5.0-master]: ${prefix}/${version}/fundamentals/gridfs/ -> ${base}/${version}/crud/gridfs/
-[v5.0-master]: ${prefix}/${version}/fundamentals/transactions/ -> ${base}/${version}/crud/transactions/
-[v5.0-master]: ${prefix}/${version}/fundamentals/time-series/ -> ${base}/${version}/data-formats/time-series/
-[v5.0-master]: ${prefix}/${version}/quick-start/ -> ${base}/${version}/getting-started/
-[v5.0-master]: ${prefix}/${version}/fundamentals/databases-collections/ -> ${base}/${version}/getting-started/databases-collections/
-[v5.0-master]: ${prefix}/${version}/integrations/ -> ${base}/${version}/getting-started/integrations/
-[v5.0-master]: ${prefix}/${version}/quick-reference/ -> ${base}/${version}/getting-started/quick-reference/
-[v5.0-master]: ${prefix}/${version}/fundamentals/enterprise-auth/ -> ${base}/${version}/security/enterprise-auth/
-[v5.0-master]: ${prefix}/${version}/connection/socks/ -> ${base}/${version}/security/socks/
-[v5.0-*]: ${prefix}/${version}/whats-new/ -> ${base}/${version}/reference/release-notes/ 
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/ -> ${base}/${version}/get-started/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/ -> ${base}/${version}/crud/specify-query/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/retrieve/ -> ${base}/${version}/crud/query-documents/find/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/cursor/ -> ${base}/${version}/crud/query-documents/cursor/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/change-streams/ -> ${base}/${version}/logging-monitoring/change-streams/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/sort/ -> ${base}/${version}/crud/query-documents/sort/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/skip/ -> ${base}/${version}/crud/query-documents/skip/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/limit/ -> ${base}/${version}/crud/query-documents/limit/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/project/ -> ${base}/${version}/crud/query-documents/project/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/geo/ -> ${base}/${version}/crud/query-documents/geo/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/read-operations/text/ -> ${base}/${version}/crud/query-documents/text/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/insert/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/delete/ -> ${base}/${version}/crud/delete/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/modify/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/embedded-arrays/ -> ${base}/${version}/crud/update-documents/embedded-arrays/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/upsert/ -> ${base}/${version}/crud/update-documents/upsert/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/write-operations/bulk/ -> ${base}/${version}/crud/bulk/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/query-document/ -> ${base}/${version}/crud/query-documents/specify-query/
+[v5.0-*]: ${prefix}/${version}/fundamentals/crud/compound-operations/ -> ${base}/${version}/crud/compound-operations/
+
+[v5.0-*]: ${prefix}/${version}/crud/ -> ${base}/${version}/get-started/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/ -> ${base}/${version}/crud/specify-query/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/retrieve/ -> ${base}/${version}/crud/query-documents/find/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/cursor/ -> ${base}/${version}/crud/query-documents/cursor/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/change-streams/ -> ${base}/${version}/logging-monitoring/change-streams/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/sort/ -> ${base}/${version}/crud/query-documents/sort/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/skip/ -> ${base}/${version}/crud/query-documents/skip/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/limit/ -> ${base}/${version}/crud/query-documents/limit/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/project/ -> ${base}/${version}/crud/query-documents/project/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/geo/ -> ${base}/${version}/crud/query-documents/geo/
+[v5.0-*]: ${prefix}/${version}/crud/read-operations/text/ -> ${base}/${version}/crud/query-documents/text/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/insert/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/delete/ -> ${base}/${version}/crud/delete/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/modify/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/embedded-arrays/ -> ${base}/${version}/crud/update-documents/embedded-arrays/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/upsert/ -> ${base}/${version}/crud/update-documents/upsert/
+[v5.0-*]: ${prefix}/${version}/crud/write-operations/bulk/ -> ${base}/${version}/crud/bulk/
+[v5.0-*]: ${prefix}/${version}/crud/query-document/ -> ${base}/${version}/crud/query-documents/specify-query/
+[v5.0-*]: ${prefix}/${version}/crud/compound-operations/ -> ${base}/${version}/crud/compound-operations/
+
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/ -> ${base}/${version}/data-formats/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-bson/ -> ${base}/${version}/data-formats/document-data-format-bson/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-extended-json/ -> ${base}/${version}/data-formats/document-data-format-extended-json/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/documents/ -> ${base}/${version}/data-formats/documents/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-pojo/ -> ${base}/${version}/data-formats/document-data-format-pojo/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/document-data-format-record/ -> ${base}/${version}/data-formats/document-data-format-record/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/pojo-customization/ -> ${base}/${version}/data-formats/pojo-customization/
+[v5.0-*]: ${prefix}/${version}/fundamentals/data-formats/codecs/ -> ${base}/${version}/data-formats/codecs/
+
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/ -> ${base}/${version}/connection/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/connect/ -> ${base}/${version}/connection/mongoclient
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/connection-options/ -> ${base}/${version}/connection/connection-options/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/mongoclientsettings/ -> ${base}/${version}/connection/mongoclientsettings/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/network-compression/ -> ${base}/${version}/connection/network-compression/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/socks/ -> ${base}/${version}/connection/socks/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/tls/ -> ${base}/${version}/security/tls/
+[v5.0-*]: ${prefix}/${version}/fundamentals/connection/jndi/ -> ${base}/${version}/connection/jndi/
+
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/ -> ${base}/${version}/builders/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/aggregates/ -> ${base}/${version}/builders/aggregates/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/filters/ -> ${base}/${version}/builders/filters/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/indexes/ -> ${base}/${version}/builders/indexes/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/projections/ -> ${base}/${version}/builders/projections/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/sort/ -> ${base}/${version}/builders/sort/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/updates/ -> ${base}/${version}/builders/updates/
+[v5.0-*]: ${prefix}/${version}/fundamentals/builders/vector-search -> ${base}/${version}/atlas-vector-search/
+
+[v5.0-*]: ${prefix}/${version}/fundamentals/aggregation/ -> ${base}/${version}/aggregation/
+[v5.0-*]: ${prefix}/${version}/fundamentals/aggregation-expression-operations/ -> ${base}/${version}/aggregation/aggregation-expression-operations/
+[v5.0-*]: ${prefix}/${version}/fundamentals/collations/ -> ${base}/${version}/crud/collations/
+[v5.0-*]: ${prefix}/${version}/fundamentals/stable-api/ -> ${base}/${version}/connection/stable-api/
+[v5.0-*]: ${prefix}/${version}/connection-troubleshooting/ -> ${base}/${version}/connection/connection-troubleshooting/
+[v5.0-*]: ${prefix}/${version}/fundamentals/gridfs/ -> ${base}/${version}/crud/gridfs/
+[v5.0-*]: ${prefix}/${version}/fundamentals/transactions/ -> ${base}/${version}/crud/transactions/
+[v5.0-*]: ${prefix}/${version}/fundamentals/time-series/ -> ${base}/${version}/data-formats/time-series/
+
+[v5.0-*]: ${prefix}/${version}/fundamentals/auth/ -> ${base}/${version}/security/auth/
+[v5.0-*]: ${prefix}/${version}/fundamentals/enterprise-auth/ -> ${base}/${version}/security/auth/
+[v5.0-*]: ${prefix}/${version}/connection/socks/ -> ${base}/${version}/security/socks/
+
+[v5.0-*]: ${prefix}/${version}/whats-new/ -> ${base}/${version}/reference/release-notes/
+[v5.0-*]: ${prefix}/${version}/compatibility/ -> ${base}/${version}/reference/compatibility/
+[v5.0-*]: ${prefix}/${version}/upgrade/ -> ${base}/${version}/reference/upgrade/
+[v5.0-*]: ${prefix}/${version}/legacy/ -> ${base}/${version}/reference/legacy/
+
+# Get Started Pages Redirects (TOC reorg)
+
+[v5.0-*]: ${prefix}/${version}/quick-start/ -> ${base}/${version}/get-started/
+[v5.0-v5.3]: ${prefix}/${version}/quick-reference/ -> ${base}/${version}/get-started/quick-reference/
+[v5.0-*]: ${prefix}/${version}/fundamentals/databases-collections/ -> ${base}/${version}/databases-collections/
+
+[v5.0-*]: ${prefix}/${version}/getting-started/ -> ${base}/${version}/get-started/
+[v5.0-v5.3]: ${prefix}/${version}/getting-started/quick-reference/ -> ${base}/${version}/get-started/quick-reference/
+
+# Usage Example Redirects (TOC reorg)
+
+[v5.0-*]: ${prefix}/${version}/usage-examples/ -> ${base}/${version}/crud/
+[v5.0-*]: ${prefix}/${version}/usage-examples/findOne/ -> ${base}/${version}/crud/query-documents/find/
+[v5.0-*]: ${prefix}/${version}/usage-examples/find/ -> ${base}/${version}/crud/query-documents/find/
+[v5.0-*]: ${prefix}/${version}/usage-examples/insertOne/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/usage-examples/insertMany/ -> ${base}/${version}/crud/insert/
+[v5.0-*]: ${prefix}/${version}/usage-examples/updateOne/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/usage-examples/updateMany/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/usage-examples/replaceOne/ -> ${base}/${version}/crud/update-documents/
+[v5.0-*]: ${prefix}/${version}/usage-examples/deleteOne/ -> ${base}/${version}/crud/delete/
+[v5.0-*]: ${prefix}/${version}/usage-examples/deleteMany/ -> ${base}/${version}/crud/delete/
+[v5.0-*]: ${prefix}/${version}/usage-examples/bulkWrite/ -> ${base}/${version}/crud/bulk/
+[v5.0-*]: ${prefix}/${version}/usage-examples/watch/ -> ${base}/${version}/logging-monitoring/change-streams/
+[v5.0-*]: ${prefix}/${version}/usage-examples/count/ -> ${base}/${version}/crud/query-documents/count/
+[v5.0-*]: ${prefix}/${version}/usage-examples/distinct/ -> ${base}/${version}/crud/query-documents/distinct/
+[v5.0-*]: ${prefix}/${version}/usage-examples/command/ -> ${base}/${version}/command/


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.4`:
 - [Merge pull request #718 from mballard-mdb/DOCSP-50728-duplicate-metadata-bulk](https://github.com/mongodb/docs-java/pull/718)

<!--- Backport version: 10.0.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)