### PR TITLE
[v5.5] Merge pull request #721 from mballard-mdb/DOCSP-51250-rem-ref-page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,6 +7,7 @@ intersphinx = [
 ]
 
 toc_landing_pages = [
+    "/connection",
     "/connection/specify-connection-options",
     "/crud/update-documents",
     "/aggregation",

--- a/snooty.toml
+++ b/snooty.toml
@@ -14,7 +14,6 @@ toc_landing_pages = [
     "/builders",
     "/builders/aggregates",
     "/data-formats",
-    "/reference",
     "/logging-monitoring",
     "/api-documentation",
     "/security",

--- a/snooty.toml
+++ b/snooty.toml
@@ -7,7 +7,6 @@ intersphinx = [
 ]
 
 toc_landing_pages = [
-    "/connection",
     "/connection/specify-connection-options",
     "/crud/update-documents",
     "/aggregation",

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -4,6 +4,7 @@ Reference
 
 .. meta::
    :description: Find reference material related to the {+driver-long+}.
+   :robots: noindex
 
 .. toctree::
    :titlesonly:


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.5`:
 - [Merge pull request #721 from mballard-mdb/DOCSP-51250-rem-ref-page](https://github.com/mongodb/docs-java/pull/721)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)