### PR TITLE
[v5.5] Merge pull request #722 from mballard-mdb/DOCSP-51245-conn-noind

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,7 +7,6 @@ intersphinx = [
 ]
 
 toc_landing_pages = [
-    "/connection",
     "/connection/specify-connection-options",
     "/crud/update-documents",
     "/aggregation",

--- a/source/connection.txt
+++ b/source/connection.txt
@@ -10,6 +10,9 @@ Connection Guide
    Specify Connection Options </connection/specify-connection-options>
    Connection Troubleshooting </connection/connection-troubleshooting>
 
+.. meta::
+   :robots: noindex
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `v5.5`:
 - [Merge pull request #722 from mballard-mdb/DOCSP-51245-conn-noind](https://github.com/mongodb/docs-java/pull/722)

<!--- Backport version: 9.6.6 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)